### PR TITLE
Remove unused template rule in aws.BUILD

### DIFF
--- a/third_party/aws.BUILD
+++ b/third_party/aws.BUILD
@@ -64,12 +64,3 @@ genrule(
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
     ],
 )
-
-#template_rule(
-#    name = "SDKConfig_h",
-#    src = "aws-cpp-sdk-core/include/aws/core/SDKConfig.h.in",
-#    out = "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
-#    substitutions = {
-#        "cmakedefine": "define",
-#    },
-#)


### PR DESCRIPTION
This fix removes unused template rule in aws.BUILD

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>