### PR TITLE
Enhancement with Travis CI configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,28 +20,28 @@ matrix:
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.test.sh
+        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: python
       python:
         - 3.4
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.test.sh
+        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: python
       python:
         - 3.5
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.test.sh
+        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: python
       python:
         - 3.6
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.test.sh
+        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: r
       before_install:
         - cd R-package

--- a/.travis/python.configure.sh
+++ b/.travis/python.configure.sh
@@ -1,7 +1,11 @@
+# Show gcc and python version in Travis CI
+gcc -v
+python --version
+# Install bazel
 URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh"
 wget -O install.sh "${URL}"
 chmod +x install.sh
 ./install.sh --user
 rm -f install.sh
+# Configure TensorFlow
 ./configure.sh
-

--- a/.travis/python.test.sh
+++ b/.travis/python.test.sh
@@ -1,6 +1,0 @@
-gcc -v
-python --version
-bazel test -s --verbose_failures //tensorflow_io/hadoop:hadoop_py_test
-bazel test -s --verbose_failures //tensorflow_io/kafka:kafka_py_test
-bazel test -s --verbose_failures //tensorflow_io/ignite:ignite_py_test
-bazel test -s --verbose_failures //tensorflow_io/ignite:igfs_py_test

--- a/tensorflow_io/kinesis/BUILD
+++ b/tensorflow_io/kinesis/BUILD
@@ -29,6 +29,19 @@ py_library(
     srcs_version = "PY2AND3",
 )
 
+# Stub test to make sure kinesis ops is loaded.
+py_test(
+    name = "kinesis_stub_test",
+    srcs = [
+        "python/kernel_tests/kinesis_stub_test.py"
+    ],
+    main = "python/kernel_tests/kinesis_stub_test.py",
+    deps = [
+        ":kinesis_ops_py",
+    ],
+    srcs_version = "PY2AND3",
+)
+
 py_test(
     name = "kinesis_py_test",
     srcs = [
@@ -39,6 +52,7 @@ py_test(
         ":kinesis_ops_py",
     ],
     srcs_version = "PY2AND3",
+    tags = ["manual"],
 )
 
 py_library(

--- a/tensorflow_io/kinesis/python/kernel_tests/kinesis_stub_test.py
+++ b/tensorflow_io/kinesis/python/kernel_tests/kinesis_stub_test.py
@@ -1,0 +1,50 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for KinesisDataset.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.platform import test
+
+from tensorflow_io.kinesis.python.ops import kinesis_dataset_ops
+from tensorflow.python.data.ops import iterator_ops
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
+from tensorflow.python.ops import array_ops
+
+
+class KinesisDatasetStubTest(test.TestCase):
+  """Tests for KinesisDataset."""
+
+  def test_kinesis_dataset_stub(self):
+    """Stub Tests for KinesisDataset, no session"""
+    stream = array_ops.placeholder(dtypes.string, shape=[])
+    num_epochs = array_ops.placeholder(dtypes.int64, shape=[])
+    batch_size = array_ops.placeholder(dtypes.int64, shape=[])
+
+    repeat_dataset = kinesis_dataset_ops.KinesisDataset(
+        stream, read_indefinitely=False).repeat(num_epochs)
+    batch_dataset = repeat_dataset.batch(batch_size)
+
+    iterator = iterator_ops.Iterator.from_structure(batch_dataset.output_types)
+    init_op = iterator.make_initializer(repeat_dataset)
+    get_next = iterator.get_next()
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
This fix updates Travis CI configurations by
removing redudant .travis/python.test.sh and calling
for bazel directly. A stub kinesis has been created
so that kinesis ops could be built on Travis CI
(testing against kinesis could be done manually)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>