### PR TITLE
Update to build tensorflow-io pypi.org packages

### DIFF
--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -59,7 +59,7 @@ function main() {
   
   python setup.py bdist_wheel
 
-  cp dist/*.whl "${DEST}"
+  auditwheel repair -w "${DEST}" dist/*.whl
   popd
   rm -rf ${TMPDIR}
   echo $(date) : "=== Output wheel file is in: ${DEST}"

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -36,6 +36,11 @@ function main() {
     exit 1
   fi
 
+  if [[ "$(auditwheel --version || true)" != *"installed"* ]]; then
+    echo "No auditwheel installed"
+    exit 1
+  fi
+
   # Create the directory, then do dirname on a non-existent file inside it to
   # give us an absolute paths with tilde characters resolved to the destination
   # directory.

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+set -e
+set -x
+
+# Release:
+# docker run -it -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op bash -x /working_dir/release.sh <2.7|3.4|3.5|3.6>
+
+PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
+
+if [[ -z "${1}" ]]; then
+  echo "usage:" $0 "<2.7|3.4|3.5|3.6>"
+  exit 1
+fi
+
+PYTHON_VERSION=$1 
+
+if [[ "3.5" == "${PYTHON_VERSION}" ]] || [ "3.6" == "${PYTHON_VERSION}" ]; then
+  # fkrull/deadsnakes is for Python3.5
+  add-apt-repository -y ppa:fkrull/deadsnakes
+  apt-get update
+
+  apt-get install -y --no-install-recommends python${PYTHON_VERSION} libpython${PYTHON_VERSION}-dev
+  wget -q https://bootstrap.pypa.io/get-pip.py
+  python${PYTHON_VERSION} get-pip.py
+  rm -f get-pip.py
+  pip${PYTHON_VERSION} install --upgrade pip
+fi
+
+rm -f /usr/bin/python /usr/bin/pip
+ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python
+ln -s /usr/bin/pip${PYTHON_VERSION} /usr/bin/pip
+
+./configure.sh
+
+bazel build build_pip_pkg
+
+bazel-bin/build_pip_pkg artifacts
+
+exit 0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import find_packages
 from setuptools import setup
 from setuptools.dist import Distribution
 
-__version__ = '0.0.1'
+__version__ = '0.1.0'
 REQUIRED_PACKAGES = [
     'tensorflow >= 1.12.0',
 ]


### PR DESCRIPTION
This fix made several updates so that we could build tensorflow-io pypi.org packages:
- Use auditwheel to repair whl files so that they are compatible with pypi.org
- Update version string to 0.1.0
- Add release.sh to build 2.7, 3.4, 3.5, 3.6 packages. Commands to run:
```
docker run -it -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op \
    bash -x /working_dir/release.sh 2.7
docker run -it -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op \
    bash -x /working_dir/release.sh 3.4
docker run -it -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op \
    bash -x /working_dir/release.sh 3.5
docker run -it -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op \
    bash -x /working_dir/release.sh 3.6
```

I think we will be ready to cut a initial 0.1.0 version release after this PR.