### PR TITLE
Update docs for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,37 @@
 TensorFlow I/O is a collection of file systems and file formats that are not
 available in TensorFlow's built-in support.
 
+## Installation
+
+The `tensorflow-io` package could be installed with pip directly:
+```
+$ pip install tensorflow-io
+```
+
+The related module such as Kafka could be imported with python:
+```
+$  python
+Python 2.7.6 (default, Nov 13 2018, 12:45:42)
+[GCC 4.8.4] on linux2
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import tensorflow as tf
+>>> import tensorflow_io.kafka as kafka
+>>>
+>>> dataset = kafka.KafkaDataset(["test:0:0:4"], group="test", eof=True)
+>>> iterator = dataset.make_initializable_iterator()
+>>> init_op = iterator.initializer
+>>> get_next = iterator.get_next()
+>>>
+>>> with tf.Session() as sess:
+...   print(sess.run(init_op))
+...   for i in range(5):
+...     print(sess.run(get_next))
+>>>
+```
+
+Note that python has to run outside of repo directory itself, otherwise python may not
+be able to find the correct path to the module.
+
 ## Developing
 
 The TensorFlow I/O package (`tensorflow-io`) could be built from source:
@@ -17,26 +48,6 @@ $ bazel-bin/build_pip_pkg artifacts
 ```
 
 A package file `artifacts/tensorflow_io-*.whl` will be generated after a build is successful.
-
-## Installation
-
-Once a package file `artifacts/tensorflow_io-*.whl` is ready, installation could be done through:
-```
-$ pip install working_dir/artifacts/tensorflow_io-*.whl
-```
-
-The related module could be imported with python:
-```
-$  python
-Python 2.7.6 (default, Nov 13 2018, 12:45:42)
-[GCC 4.8.4] on linux2
-Type "help", "copyright", "credits" or "license" for more information.
->>> from tensorflow_io.kafka import KafkaDataset
->>>
-```
-
-Note that python has to run outside of repo directory itself, otherwise python may not
-be able to find the correct path to the module.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 TensorFlow I/O is a collection of file systems and file formats that are not
 available in TensorFlow's built-in support.
 
+At the moment TensorFlow I/O supports 4 data sources:
+- `tensorflow_io.ignite`: Data source for Apache Ignite and Ignite File System (IGFS).
+- `tensorflow_io.kafka`: Apache Kafka stream-processing support.
+- `tensorflow_io.kinesis`: Amazon Kinesis data streams support.
+- `tensorflow_io.hadoop`: Hadoop SequenceFile format support.
+
 ## Installation
 
 The `tensorflow-io` package could be installed with pip directly:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+# Release 0.1.0
+
+Initial release of TensorFlow I/O.
+
+## Major Features
+* `tensorflow_io.ignite`: Data source for Apache Ignite and File System (IGFS).
+* `tensorflow_io.kafka`: Apache Kafka stream-processing support.
+* `tensorflow_io.kinesis`: Amazon Kinesis data streams support.
+* `tensorflow_io.hadoop`: Hadoop SequenceFile format support.
+
+## Thanks to our Contributors
+
+This release contains contributions from many people:
+
+Anjali Sridhar, Anton Dmitriev, Artem Malykh, Brennan Saeta, Derek Murray,
+Gunhan Gulsoy, Jacques Pienaar, Jianwei Xie, Jiri Simsa, knight, Loo Rong Jie,
+Martin Wicke, Michael Case, Sergei Lebedev, Sourabh Bajaj, Yifei Feng,
+Yong Tang, Yuan (Terry) Tang, Yun Peng
+
+We are also grateful to all who filed issues or helped resolve them, asked and
+answered questions, and were part of inspiring discussions.


### PR DESCRIPTION
This fix updates docs for installation through pip (pypi.org).

The example code has also been updated.

This will make us ready to release 0.1.0.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>