### PR TITLE
Fix Ignite build so that .py files included into artifact

### DIFF
--- a/tensorflow_io/ignite/BUILD
+++ b/tensorflow_io/ignite/BUILD
@@ -98,7 +98,11 @@ py_test(
 
 py_library(
     name = "ignite_py",
-    srcs = ["__init__.py"],
+    srcs = [
+        "__init__.py",
+        "python/__init__.py",
+        "python/ops/__init__.py",
+    ],
     deps = [
         ":dataset_ops_py",
         ":igfs_ops_py",


### PR DESCRIPTION
Currently when I try to use Ignite the following exception is thrown:

`ModuleNotFoundError: No module named 'tensorflow_io.ignite.python.ops.ignite_dataset_ops'`

The reason is that a file `ignite_dataset_ops` is not included into the result artifact. Changes in this PR fixes this issue.