### PR TITLE
[WIP] Add --test_output=errors to bazel command to show erros from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,28 +20,28 @@ matrix:
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: python
       python:
         - 3.4
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: python
       python:
         - 3.5
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: python
       python:
         - 3.6
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
     - language: r
       r:
         - 3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,28 +20,28 @@ matrix:
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: python
       python:
         - 3.4
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: python
       python:
         - 3.5
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: python
       python:
         - 3.6
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: r
       r:
         - 3.2


### PR DESCRIPTION
This fix adds --test_output=errors to bazel to show errors from Travis CI

This fix also enables Ignite tests in Travis CI

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>