### PR TITLE
Enable Apache Ignite tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,28 +20,28 @@ matrix:
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: python
       python:
         - 3.4
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: python
       python:
         - 3.5
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: python
       python:
         - 3.6
       before_install:
         - bash -x ${TRAVIS_BUILD_DIR}/.travis/python.configure.sh
       script:
-        - bazel test -s --verbose_failures -- //tensorflow_io/... -//tensorflow_io/ignite:ignite_py_test
+        - bazel test -s --verbose_failures --test_output=errors -- //tensorflow_io/...
     - language: r
       r:
         - 3.2

--- a/tensorflow_io/ignite/python/tests/bin/start-igfs.sh
+++ b/tensorflow_io/ignite/python/tests/bin/start-igfs.sh
@@ -15,6 +15,6 @@
 # ==============================================================================
 
 nohup apache-ignite-fabric/bin/ignite.sh /data/config/ignite-config-igfs.xml &
-sleep 5 # Wait Apache Ignite to be started
+sleep 10 # Wait Apache Ignite to be started
 
 tail -f nohup.out

--- a/tensorflow_io/ignite/python/tests/bin/start-plain.sh
+++ b/tensorflow_io/ignite/python/tests/bin/start-plain.sh
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 nohup apache-ignite-fabric/bin/ignite.sh /data/config/ignite-config-plain.xml & 
-sleep 5 # Wait Apache Ignite to be started
+sleep 10 # Wait Apache Ignite to be started
 
 ./apache-ignite-fabric/bin/sqlline.sh \
 -u "jdbc:ignite:thin://127.0.0.1/" \

--- a/tensorflow_io/ignite/python/tests/start_ignite.sh
+++ b/tensorflow_io/ignite/python/tests/start_ignite.sh
@@ -24,3 +24,6 @@ docker run -itd --name ignite-plain -p 42300:10800 \
 # Start Apache Ignite with IGFS.
 docker run -itd --name ignite-igfs -p 10500:10500 \
 -v ${SCRIPT_PATH}:/data apacheignite/ignite:${IGNITE_VERSION} /data/bin/start-igfs.sh
+
+# Wait Apache Ignite to be started
+sleep 10


### PR DESCRIPTION
This PR created to fix exceptions in Apache Ignite tests and enable them (see https://github.com/tensorflow/io/pull/35).