### PR TITLE
Add interleave support into IgniteDataset

### DIFF
--- a/tensorflow_io/ignite/python/ops/ignite_dataset_ops.py
+++ b/tensorflow_io/ignite/python/ops/ignite_dataset_ops.py
@@ -710,6 +710,8 @@ class IgniteDataset(dataset_ops.DatasetSource):
                cache_name,
                host="localhost",
                port=10800,
+               schema_host=None,
+               schema_port=None,
                local=False,
                part=-1,
                page_size=100,
@@ -724,6 +726,8 @@ class IgniteDataset(dataset_ops.DatasetSource):
       cache_name: Cache name to be used as datasource.
       host: Apache Ignite Thin Client host to be connected.
       port: Apache Ignite Thin Client port to be connected.
+      schema_host: Host to be connected to retrieve cache schema.
+      schema_port: Port to be connected to retrieve cache schema.
       local: Local flag that defines to query only local data.
       part: Number of partitions to be queried.
       page_size: Apache Ignite Thin Client page size.
@@ -739,8 +743,13 @@ class IgniteDataset(dataset_ops.DatasetSource):
     """
     super(IgniteDataset, self).__init__()
 
-    with IgniteClient(host, port, username, password, certfile, keyfile,
-                      cert_password) as client:
+    if not schema_host:
+        schema_host = host
+    if not schema_port:
+        schema_port = port
+
+    with IgniteClient(schema_host, schema_port, username, password, certfile,
+                      keyfile, cert_password) as client:
       client.handshake()
       self.cache_type = client.get_cache_type(cache_name)
 

--- a/tensorflow_io/ignite/python/tests/ignite_dataset_test.py
+++ b/tensorflow_io/ignite/python/tests/ignite_dataset_test.py
@@ -22,6 +22,7 @@ import os
 from tensorflow.python.platform import test
 
 from tensorflow_io.ignite import IgniteDataset
+from tensorflow.data import Dataset
 from tensorflow.python.client import session
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
@@ -45,6 +46,18 @@ class IgniteDatasetTest(test.TestCase):
     """
     self._clear_env()
     ds = IgniteDataset(cache_name="SQL_PUBLIC_TEST_CACHE", port=42300)
+    self._check_dataset(ds)
+
+  def test_ignite_dataset_with_plain_client_with_interleave(self):
+    """Test Ignite Dataset with plain client with interleave.
+
+    """
+    self._clear_env()
+    ds = Dataset.from_tensor_slices(["localhost"]).interleave(
+        lambda host: IgniteDataset(cache_name="SQL_PUBLIC_TEST_CACHE",
+                                   schema_host="localhost", host=host,
+                                   port=42300), cycle_length=4, block_length=16
+    )
     self._check_dataset(ds)
 
   def _clear_env(self):


### PR DESCRIPTION
Currently `IgniteDataset` makes a call to data source during construction (in python) to retrieve a data schema. When we use `Dataset.interleave` it doesn't work well because `host` and `port` objects are tensors during the construction, not `string`/`int` values. This fact is also reflected in Apache JIRA in [this issue](https://issues.apache.org/jira/browse/IGNITE-10996).

To eliminate this problem I propose to use separate `host`/`port` objects to be used to retrieve schema and to retrieve data itself. Please have a look at the changed tests in this PR for details.