### PR TITLE
Add PyPI and CRAN status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # TensorFlow I/O
 
-[![Travis-CI Build Status](https://travis-ci.org/tensorflow/io.svg?branch=master)](https://travis-ci.org/tensorflow/io) 
+[![Travis-CI Build Status](https://travis-ci.org/tensorflow/io.svg?branch=master)](https://travis-ci.org/tensorflow/io)
+[![PyPI Status Badge](https://badge.fury.io/py/tensorflow-io.svg)](https://pypi.org/project/tensorflow-io/)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/tfio)](https://cran.r-project.org/package=tfio)
 
 TensorFlow I/O is a collection of file systems and file formats that are not
 available in TensorFlow's built-in support.


### PR DESCRIPTION
Note that the CRAN status badge will soon be changed from "not published" to "0.1.0" when the first package release gets accepted to CRAN.