### PR TITLE
Add an integration test case for VideoDataset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,25 +55,25 @@ matrix:
         - docker pull tensorflow/tensorflow:custom-op
         - docker pull ubuntu:16.04
         - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e BAZEL_VERSION=$BAZEL_VERSION --rm -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op bash -x /working_dir/.travis/python.release.sh 2.7
-        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:16.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python-pip && pip install artifacts/tensorflow_io-*-cp27-*.whl"
+        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:16.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python-pip ffmpeg && pip install artifacts/tensorflow_io-*-cp27-*.whl && pip install pytest && (cd tests && python -m pytest .)"
     - name: "Ubuntu 16.04 Python 3.5 Build Tests"
       script:
         - docker pull tensorflow/tensorflow:custom-op
         - docker pull ubuntu:16.04
         - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e BAZEL_VERSION=$BAZEL_VERSION --rm -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op bash -x /working_dir/.travis/python.release.sh 3.5
-        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:16.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python3-pip && pip3 install artifacts/tensorflow_io-*-cp35-*.whl"
+        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:16.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python3-pip ffmpeg && pip3 install artifacts/tensorflow_io-*-cp35-*.whl && pip3 install pytest && (cd tests && python3 -m pytest .)"
     - name: "Ubuntu 18.04 Python 2.7 Build Tests"
       script:
         - docker pull tensorflow/tensorflow:custom-op
         - docker pull ubuntu:18.04
         - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e BAZEL_VERSION=$BAZEL_VERSION --rm -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op bash -x /working_dir/.travis/python.release.sh 2.7
-        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:18.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python-pip && pip install artifacts/tensorflow_io-*-cp27-*.whl"
+        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:18.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python-pip ffmpeg && pip install artifacts/tensorflow_io-*-cp27-*.whl && pip install pytest && (cd tests && python -m pytest .)"
     - name: "Ubuntu 18.04 Python 3.6 Build Tests"
       script:
         - docker pull tensorflow/tensorflow:custom-op
         - docker pull ubuntu:18.04
         - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e BAZEL_VERSION=$BAZEL_VERSION --rm -v ${PWD}:/working_dir -w /working_dir  tensorflow/tensorflow:custom-op bash -x /working_dir/.travis/python.release.sh 3.6
-        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:18.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python3-pip && pip3 install artifacts/tensorflow_io-*-cp36-*.whl"
+        - docker run -i -t -v $HOME/.cache/pip:/root/.cache/pip -e --rm -v $PWD:/workspace -w /workspace --net=host ubuntu:18.04 bash -x -c "apt-get -y -qqq update && apt-get -y -qqq install python3-pip ffmpeg && pip3 install artifacts/tensorflow_io-*-cp36-*.whl && pip3 install pytest && (cd tests && python3 -m pytest .)"
     - name: "Ubuntu 16.04 R 3.5 (Python 2.7) Build Tests"
       script:
         - docker pull tensorflow/tensorflow:custom-op

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,56 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import pytest
+
+import tensorflow as tf
+from tensorflow.keras.applications.resnet50 import ResNet50
+from tensorflow.keras.applications.resnet50 import preprocess_input, decode_predictions
+from tensorflow_io.video import VideoDataset
+
+video_path = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "tensorflow_io/video/python/kernel_tests/testdata/small.mp4"))
+
+@pytest.mark.skip(reason="expect tensorflow > 1.12.0")
+def test_video_predict():
+  model = ResNet50(weights='imagenet')
+  x = VideoDataset(video_path).batch(1).map(lambda x: preprocess_input(tf.image.resize_images(x, (224, 224))))
+  y = model.predict(x)
+  p = decode_predictions(y, top=3)
+  assert len(p) == 166
+
+def test_video_dataset():
+  num_repeats = 2
+
+  dataset = VideoDataset([video_path]).repeat(num_repeats)
+  iterator = dataset.make_initializable_iterator()
+  init_op = iterator.initializer
+  get_next = iterator.get_next()
+
+  with tf.Session() as sess:
+    sess.run(init_op)
+    for _ in range(num_repeats):
+      for _ in range(166):
+        v = sess.run(get_next)
+        assert v.shape == (320, 560, 3)
+    with pytest.raises(tf.errors.OutOfRangeError):
+      sess.run(get_next)


### PR DESCRIPTION
In our build test we haven't had a test case yet
(only tested that `pip install tensorflow_io-*-*-*.whl` works),
this PR add an integration test case for VideoDataset.

This PR is part of #57.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>