### PR TITLE
Added new ops since 0.1.0 release and link for Ignite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ TensorFlow I/O is a collection of file systems and file formats that are not
 available in TensorFlow's built-in support.
 
 At the moment TensorFlow I/O supports 5 data sources:
-- `tensorflow_io.ignite`: Data source for Apache Ignite and Ignite File System (IGFS).
+- `tensorflow_io.ignite`: Data source for Apache Ignite and Ignite File System (IGFS). Overview and usage guide [here](tensorflow_io/ignite/README.md).
 - `tensorflow_io.kafka`: Apache Kafka stream-processing support.
 - `tensorflow_io.kinesis`: Amazon Kinesis data streams support.
 - `tensorflow_io.hadoop`: Hadoop SequenceFile format support.
 - `tensorflow_io.arrow`: Apache Arrow data format support. Usage guide [here](tensorflow_io/arrow/README.md).
+- `tensorflow_io.image`: WebP image format support.
+- `tensorflow_io.libsvm`: LIBSVM file format support.
+- `tensorflow_io.video`: Video file support with FFmpeg.
 
 ## Installation
 


### PR DESCRIPTION
This change adds new ops supported since the 0.1.0 release of TensorFlow-IO, and adds a link to the Apache Ignite README.