### PR TITLE
Fix missing column index when using ArrowDataset.from_pandas with preserve_index

### DIFF
--- a/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
@@ -154,18 +154,19 @@ class ArrowDataset(ArrowBaseDataset):
   def from_pandas(cls, df, columns=None, preserve_index=True):
     """Create an ArrowDataset from a given Pandas DataFrame. Output types
     and shapes are inferred from the Arrow schema after DataFrame conversion.
+    If preserve_index is True, the DataFrame index will be the last column.
     This method requires pyarrow to be installed.
 
     Args:
       df: a Pandas DataFrame
       columns: Optional column indices to use, if None all are used
-      preserve_index: Flag to include the DataFrame index as a column
+      preserve_index: Flag to include the DataFrame index as the last column
     """
     import pyarrow as pa
     if columns is not None:
-      df = df[columns]
+      df = df.iloc[:, list(columns)]
     batch = pa.RecordBatch.from_pandas(df, preserve_index=preserve_index)
-    columns = tuple(range(len(df.columns)))
+    columns = tuple(range(batch.num_columns))
     output_types, output_shapes = arrow_schema_to_tensor_types(batch.schema)
     return cls(batch, columns, output_types, output_shapes)
 


### PR DESCRIPTION
This change fixes an error caused when ArrowDataset.from_pandas `preserve_index` flag is True. Instead of making column indices based on the DataFrame, they are now made based on the pyarrow.RecordBatch, which includes the index column. Also, the DataFrame columns are now properly selected using `iloc`.  Added regression tests with `preserve_index=True`.

Fixes #75 