### PR TITLE
Add boolean data type support to Arrow Datasets

### DIFF
--- a/tensorflow_io/arrow/python/kernel_tests/arrow_test.py
+++ b/tensorflow_io/arrow/python/kernel_tests/arrow_test.py
@@ -48,6 +48,7 @@ class ArrowDatasetTest(test.TestCase):
   def setUpClass(cls):
 
     cls.scalar_data = [
+        [True, False, True, True],
         [1, 2, -3, 4],
         [1, 2, -3, 4],
         [1, 2, -3, 4],
@@ -60,6 +61,7 @@ class ArrowDatasetTest(test.TestCase):
         [1.1, 2.2, 3.3, 4.4],
     ]
     cls.scalar_dtypes = (
+        dtypes.bool,
         dtypes.int8,
         dtypes.int16,
         dtypes.int32,
@@ -304,6 +306,27 @@ class ArrowDatasetTest(test.TestCase):
     self.run_test_case(dataset, test_data_mult)
 
     server.join()
+
+  @unittest.skipIf(not _have_pyarrow, _pyarrow_requirement_message)
+  def testBoolArrayType(self):
+
+    # NOTE: need to test this seperately because to_pandas fails with
+    # ArrowNotImplementedError:
+    #   Not implemented type for list in DataFrameBlock: bool
+    # see https://issues.apache.org/jira/browse/ARROW-4370
+    test_data = TestData(
+        [[[False, False], [False, True], [True, False], [True, True]]],
+        (dtypes.bool,),
+        (tensor_shape.TensorShape([None]),))
+
+    batch = self.make_record_batch(test_data)
+
+    dataset = arrow_dataset_ops.ArrowDataset(
+        batch,
+        (0,),
+        test_data.output_types,
+        test_data.output_shapes)
+    self.run_test_case(dataset, test_data)
 
 
 if __name__ == "__main__":

--- a/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
@@ -38,7 +38,9 @@ def arrow_to_tensor_type(pa_t):
   """
   import pyarrow as pa
   shape_dims = []  # initialize shape as scalar
-  if pa.types.is_int8(pa_t):
+  if pa.types.is_boolean(pa_t):
+    tf_t = dtypes.bool
+  elif pa.types.is_int8(pa_t):
     tf_t = dtypes.int8
   elif pa.types.is_int16(pa_t):
     tf_t = dtypes.int16


### PR DESCRIPTION
This change adds boolean data type support to Arrow based Datasets, both for scalar and vector tensors.  Additionally, checking Arrow batch column type matches the expected tensor output type has been moved from checking at each iteration, to only once per batch stream. Checking once per stream is all that is required since a set schema applies to all batches within that stream.

Fixes #78 