### PR TITLE
Add decode_webp op support

### DIFF
--- a/tensorflow_io/image/ops/dataset_ops.cc
+++ b/tensorflow_io/image/ops/dataset_ops.cc
@@ -37,4 +37,16 @@ REGISTER_OP("TIFFDataset")
        return Status::OK();
      });
 
+REGISTER_OP("DecodeWebP")
+    .Input("contents: string")
+    .Output("image: uint8")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &unused));
+      c->set_output(0, c->MakeShape({
+          shape_inference::InferenceContext::kUnknownDim,
+          shape_inference::InferenceContext::kUnknownDim, 4}));
+      return Status::OK();
+    });
+
 }  // namespace tensorflow

--- a/tensorflow_io/image/python/ops/image_dataset_ops.py
+++ b/tensorflow_io/image/python/ops/image_dataset_ops.py
@@ -43,7 +43,7 @@ class WebPDataset(dataset_ops.DatasetSource):
         filenames, dtype=dtypes.string, name="filenames")
 
   def _as_variant_tensor(self):
-    return image_ops.web_p_dataset( self._filenames)
+    return image_ops.web_p_dataset(self._filenames)
 
   @property
   def output_classes(self):
@@ -83,3 +83,16 @@ class TIFFDataset(dataset_ops.DatasetSource):
   @property
   def output_types(self):
     return dtypes.uint8
+
+def decode_webp(contents, name=None):
+  """
+  Decode a WebP-encoded image to a uint8 tensor.
+
+  Args:
+    contents: A `Tensor` of type `string`. 0-D.  The WebP-encoded image.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `uint8` and shape of `[height, width, 4]` (RGBA).
+  """
+  return image_ops.decode_web_p(contents, name=name)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -32,6 +32,31 @@ from tensorflow.python.platform import resource_loader
 
 class ImageDatasetTest(test.TestCase):
 
+  def test_decode_webp(self):
+    """Test case for decode_webp.
+    """
+    width = 400
+    height = 301
+    channel = 4
+    png_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_image", "sample.png")
+    with open(png_file, 'rb') as f:
+      png_contents = f.read()
+    filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_image", "sample.webp")
+    with open(filename, 'rb') as f:
+      webp_contents = f.read()
+
+    with self.cached_session():
+      png_op = image_ops.decode_png(png_contents, channels=channel)
+      png = png_op.eval()
+      self.assertEqual(png.shape, (height, width, channel))
+
+      webp_p = image_dataset_ops.decode_webp(webp_contents)
+      webp_v = webp_p.eval()
+      self.assertEqual(webp_v.shape, (height, width, channel))
+
+      self.assertAllEqual(webp_v, png)
+
+
   def test_webp_file_dataset(self):
     """Test case for WebPDataset.
     """


### PR DESCRIPTION
This is based on the comment from tensorflow issue tensorflow/tensorflow#18250  where it is desirable to implement a `decode_webp` in sig-io first.

The implementation is pretty much straightforward as WebPDataset has already been in place.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
