### PR TITLE
Change project name to tensorflow-io-nightly in case of nightly build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ project = 'tensorflow-io'
 if '--nightly' in sys.argv:
   nightly_idx = sys.argv.index('--nightly')
   version = version + ".dev" + sys.argv[nightly_idx + 1]
-  project = 'tensorflow-io'
+  project = 'tensorflow-io-nightly'
   sys.argv.remove('--nightly')
   sys.argv.pop(nightly_idx)
 


### PR DESCRIPTION
We purposely change the nightly build to name it as tensorflow-io-nightly, so that it will not interference with the release build in case some error happens. (Also make sure tensorflow-io's PyPI.org is clean).

The name change was lost in the last PR. Now this PR bring it back.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>