### PR TITLE
Fix PyTest warning due to class TestData

### DIFF
--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -39,7 +39,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.python.platform import test
 
 
-TestData = namedtuple("TestData", ["data", "output_types", "output_shapes"])
+TruthData = namedtuple("TruthData", ["data", "output_types", "output_shapes"])
 
 
 class ArrowDatasetTest(test.TestCase):
@@ -95,7 +95,7 @@ class ArrowDatasetTest(test.TestCase):
     cls.list_shapes = tuple(
         [tensor_shape.TensorShape([None]) for _ in cls.list_dtypes])
 
-  def run_test_case(self, dataset, case_data):
+  def run_test_case(self, dataset, truth_data):
     iterator = dataset.make_one_shot_iterator()
     next_element = iterator.get_next()
 
@@ -103,20 +103,20 @@ class ArrowDatasetTest(test.TestCase):
       return dtype in [dtypes.float16, dtypes.float32, dtypes.float64]
 
     with self.test_session() as sess:
-      for row in range(len(case_data.data[0])):
+      for row in range(len(truth_data.data[0])):
         value = sess.run(next_element)
         for i, col in enumerate(dataset.columns):
-          if case_data.output_shapes[col].ndims == 0:
-            if is_float(case_data.output_types[col]):
-              self.assertAlmostEqual(value[i], case_data.data[col][row], 4)
+          if truth_data.output_shapes[col].ndims == 0:
+            if is_float(truth_data.output_types[col]):
+              self.assertAlmostEqual(value[i], truth_data.data[col][row], 4)
             else:
-              self.assertEqual(value[i], case_data.data[col][row])
-          elif case_data.output_shapes[col].ndims == 1:
-            if is_float(case_data.output_types[col]):
+              self.assertEqual(value[i], truth_data.data[col][row])
+          elif truth_data.output_shapes[col].ndims == 1:
+            if is_float(truth_data.output_types[col]):
               for j, v in enumerate(value[i]):
-                self.assertAlmostEqual(v, case_data.data[col][row][j], 4)
+                self.assertAlmostEqual(v, truth_data.data[col][row][j], 4)
             else:
-              self.assertListEqual(value[i].tolist(), case_data.data[col][row])
+              self.assertListEqual(value[i].tolist(), truth_data.data[col][row])
 
   def get_arrow_type(self, dt, is_list):
     if dt == dtypes.bool:
@@ -149,46 +149,46 @@ class ArrowDatasetTest(test.TestCase):
       arrow_type = pa.list_(arrow_type)
     return arrow_type
  
-  def make_record_batch(self, test_data):
-    arrays = [pa.array(test_data.data[col],
-                  type=self.get_arrow_type(test_data.output_types[col],
-                  test_data.output_shapes[col].ndims == 1))
-              for col in range(len(test_data.output_types))]
+  def make_record_batch(self, truth_data):
+    arrays = [pa.array(truth_data.data[col],
+                  type=self.get_arrow_type(truth_data.output_types[col],
+                  truth_data.output_shapes[col].ndims == 1))
+              for col in range(len(truth_data.output_types))]
     names = ["%s_[%s]" % (i, a.type) for i, a in enumerate(arrays)]
     return pa.RecordBatch.from_arrays(arrays, names)
 
   @unittest.skipIf(not _have_pyarrow, _pyarrow_requirement_message)
   def testArrowDataset(self):
 
-    test_data = TestData(
+    truth_data = TruthData(
         self.scalar_data + self.list_data,
         self.scalar_dtypes + self.list_dtypes,
         self.scalar_shapes + self.list_shapes)
 
-    batch = self.make_record_batch(test_data)
+    batch = self.make_record_batch(truth_data)
 
     # test all columns selected
     dataset = arrow_dataset_ops.ArrowDataset(
         batch,
-        list(range(len(test_data.output_types))),
-        test_data.output_types,
-        test_data.output_shapes)
-    self.run_test_case(dataset, test_data)
+        list(range(len(truth_data.output_types))),
+        truth_data.output_types,
+        truth_data.output_shapes)
+    self.run_test_case(dataset, truth_data)
 
     # test column selection
-    columns = (1, 3, len(test_data.output_types) - 1)
+    columns = (1, 3, len(truth_data.output_types) - 1)
     dataset = arrow_dataset_ops.ArrowDataset(
         batch,
         columns,
-        tuple([test_data.output_types[c] for c in columns]),
-        tuple([test_data.output_shapes[c] for c in columns]))
-    self.run_test_case(dataset, test_data)
+        tuple([truth_data.output_types[c] for c in columns]),
+        tuple([truth_data.output_shapes[c] for c in columns]))
+    self.run_test_case(dataset, truth_data)
 
     # test construction from pd.DataFrame
     df = batch.to_pandas()
     dataset = arrow_dataset_ops.ArrowDataset.from_pandas(
         df, preserve_index=False)
-    self.run_test_case(dataset, test_data)
+    self.run_test_case(dataset, truth_data)
 
   @unittest.skipIf(not _have_pyarrow, _pyarrow_requirement_message)
   def testFromPandasPreserveIndex(self):
@@ -197,41 +197,41 @@ class ArrowDatasetTest(test.TestCase):
         [0.2, 0.4, 0.8],
     ]
 
-    test_data = TestData(
+    truth_data = TruthData(
         data,
         (dtypes.float32, dtypes.float32),
         (tensor_shape.TensorShape([]), tensor_shape.TensorShape([])))
 
-    batch = self.make_record_batch(test_data)
+    batch = self.make_record_batch(truth_data)
     df = batch.to_pandas()
     dataset = arrow_dataset_ops.ArrowDataset.from_pandas(
         df, preserve_index=True)
 
     # Add index column to test data to check results
-    test_data_with_index = TestData(
-        test_data.data + [range(len(test_data.data[0]))],
-        test_data.output_types + (dtypes.int64,),
-        test_data.output_shapes + (tensor_shape.TensorShape([]),))
-    self.run_test_case(dataset, test_data_with_index)
+    truth_data_with_index = TruthData(
+        truth_data.data + [range(len(truth_data.data[0]))],
+        truth_data.output_types + (dtypes.int64,),
+        truth_data.output_shapes + (tensor_shape.TensorShape([]),))
+    self.run_test_case(dataset, truth_data_with_index)
 
     # Test preserve_index again, selecting second column only
-    # NOTE: need to select TestData because `df` gets selected also
-    test_data_selected_with_index = TestData(
-        test_data_with_index.data[1:],
-        test_data_with_index.output_types[1:],
-        test_data_with_index.output_shapes[1:])
+    # NOTE: need to select TruthData because `df` gets selected also
+    truth_data_selected_with_index = TruthData(
+        truth_data_with_index.data[1:],
+        truth_data_with_index.output_types[1:],
+        truth_data_with_index.output_shapes[1:])
     dataset = arrow_dataset_ops.ArrowDataset.from_pandas(
         df, columns=(1,), preserve_index=True)
-    self.run_test_case(dataset, test_data_selected_with_index)
+    self.run_test_case(dataset, truth_data_selected_with_index)
 
   @unittest.skipIf(not _have_pyarrow, _pyarrow_requirement_message)
   def testArrowFeatherDataset(self):
 
     # Feather files currently do not support columns of list types
-    test_data = TestData(self.scalar_data, self.scalar_dtypes,
+    truth_data = TruthData(self.scalar_data, self.scalar_dtypes,
         self.scalar_shapes)
 
-    batch = self.make_record_batch(test_data)
+    batch = self.make_record_batch(truth_data)
     df = batch.to_pandas()
 
     # Create a tempfile that is deleted after tests run
@@ -241,39 +241,39 @@ class ArrowDatasetTest(test.TestCase):
     # test single file
     dataset = arrow_dataset_ops.ArrowFeatherDataset(
         f.name,
-        list(range(len(test_data.output_types))),
-        test_data.output_types,
-        test_data.output_shapes)
-    self.run_test_case(dataset, test_data)
+        list(range(len(truth_data.output_types))),
+        truth_data.output_types,
+        truth_data.output_shapes)
+    self.run_test_case(dataset, truth_data)
 
     # test multiple files
     dataset = arrow_dataset_ops.ArrowFeatherDataset(
         [f.name, f.name],
-        list(range(len(test_data.output_types))),
-        test_data.output_types,
-        test_data.output_shapes)
-    test_data_doubled = TestData(
-        [d * 2 for d in test_data.data],
-        test_data.output_types,
-        test_data.output_shapes)
-    self.run_test_case(dataset, test_data_doubled)
+        list(range(len(truth_data.output_types))),
+        truth_data.output_types,
+        truth_data.output_shapes)
+    truth_data_doubled = TruthData(
+        [d * 2 for d in truth_data.data],
+        truth_data.output_types,
+        truth_data.output_shapes)
+    self.run_test_case(dataset, truth_data_doubled)
 
     # test construction from schema
     dataset = arrow_dataset_ops.ArrowFeatherDataset.from_schema(
         f.name, batch.schema)
-    self.run_test_case(dataset, test_data)
+    self.run_test_case(dataset, truth_data)
 
     os.unlink(f.name)
 
   @unittest.skipIf(not _have_pyarrow, _pyarrow_requirement_message)
   def testArrowSocketDataset(self):
 
-    test_data = TestData(
+    truth_data = TruthData(
         self.scalar_data + self.list_data,
         self.scalar_dtypes + self.list_dtypes,
         self.scalar_shapes + self.list_shapes)
 
-    batch = self.make_record_batch(test_data)
+    batch = self.make_record_batch(truth_data)
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(('127.0.0.1', 0))
@@ -299,11 +299,11 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_dataset_ops.ArrowStreamDataset.from_schema(
         host, batch.schema)
-    test_data_mult = TestData(
-        [d * num_batches for d in test_data.data],
-        test_data.output_types,
-        test_data.output_shapes)
-    self.run_test_case(dataset, test_data_mult)
+    truth_data_mult = TruthData(
+        [d * num_batches for d in truth_data.data],
+        truth_data.output_types,
+        truth_data.output_shapes)
+    self.run_test_case(dataset, truth_data_mult)
 
     server.join()
 
@@ -314,33 +314,33 @@ class ArrowDatasetTest(test.TestCase):
     # ArrowNotImplementedError:
     #   Not implemented type for list in DataFrameBlock: bool
     # see https://issues.apache.org/jira/browse/ARROW-4370
-    test_data = TestData(
+    truth_data = TruthData(
         [[[False, False], [False, True], [True, False], [True, True]]],
         (dtypes.bool,),
         (tensor_shape.TensorShape([None]),))
 
-    batch = self.make_record_batch(test_data)
+    batch = self.make_record_batch(truth_data)
 
     dataset = arrow_dataset_ops.ArrowDataset(
         batch,
         (0,),
-        test_data.output_types,
-        test_data.output_shapes)
-    self.run_test_case(dataset, test_data)
+        truth_data.output_types,
+        truth_data.output_shapes)
+    self.run_test_case(dataset, truth_data)
 
   @unittest.skipIf(not _have_pyarrow, _pyarrow_requirement_message)
   def testIncorrectColumnType(self):
-    test_data = TestData(self.scalar_data, self.scalar_dtypes,
-            self.scalar_shapes)
-    batch = self.make_record_batch(test_data)
+    truth_data = TruthData(self.scalar_data, self.scalar_dtypes,
+        self.scalar_shapes)
+    batch = self.make_record_batch(truth_data)
 
     dataset = arrow_dataset_ops.ArrowDataset(
         batch,
-        list(range(len(test_data.output_types))),
-        tuple([dtypes.int32 for _ in test_data.output_types]),
-        test_data.output_shapes)
+        list(range(len(truth_data.output_types))),
+        tuple([dtypes.int32 for _ in truth_data.output_types]),
+        truth_data.output_shapes)
     with self.assertRaisesRegexp(errors.OpError, 'Arrow type mismatch'):
-      self.run_test_case(dataset, test_data)
+      self.run_test_case(dataset, truth_data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change renames class `TestData` in `test_arrow.py` to prevent the below warning from PyTest during test discovery because the name starts with "Test".

`/working_dir/tests/test_arrow.py:0: PytestWarning: cannot collect test class 'TestData' because it has a __new__ constructor`