### PR TITLE
Add write_kafka ops for streaming output

### DIFF
--- a/tensorflow_io/kafka/ops/dataset_ops.cc
+++ b/tensorflow_io/kafka/ops/dataset_ops.cc
@@ -41,4 +41,18 @@ timeout: The timeout value for the Kafka Consumer to wait
   (in millisecond).
 )doc");
 
+REGISTER_OP("WriteKafka")
+    .Input("message: string")
+    .Input("topic: string")
+    .Input("servers: string")
+    .Output("content: string")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &unused));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
+      c->set_output(0, c->Scalar());
+      return Status::OK();
+    });
+
 }  // namespace tensorflow

--- a/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
@@ -76,3 +76,19 @@ class KafkaDataset(data.Dataset):
   @property
   def output_types(self):
     return dtypes.string
+
+def write_kafka(message,
+                topic,
+                servers="localhost",
+                name=None):
+  """
+  Args:
+      message: A `Tensor` of type `string`. 0-D.
+      topic: A `tf.string` tensor containing one subscription,
+        in the format of topic:partition.
+      servers: A list of bootstrap servers.
+      name: A name for the operation (optional).
+  Returns:
+      A `Tensor` of type `string`. 0-D.
+  """
+  return kafka_ops.write_kafka(message=message, topic=topic, servers=servers, name=name)


### PR DESCRIPTION
This PR adds a very early implementation of write_kafka ops
so that we could do a streaming output.

The basic idea of write_kafka is to implement in C++ WriteKafkaOp
which takes a message as input, write the message to a Kafka server,
and returns the original message. The return of original message
is on purpose so that write_kafka is not a terminal op.
This helps to do further processing.

So far most of the tensorflow-io ops are input, while the output
has been mentioned in discussions. This implementation could be
a start for future implementation of output ops.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
