### PR TITLE
Add Dockerfile for Python Development

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    curl \
+    nano \
+    unzip \
+    ffmpeg
+
+ARG BAZEL_VERSION=0.20.0
+ARG BAZEL_OS=linux
+
+RUN curl -sL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh -o bazel-install.sh && \
+    bash -x bazel-install.sh && \
+    rm bazel-install.sh
+
+ARG CONDA_OS=Linux
+
+# Miniconda - Python 3.6, 64-bit, x86, latest
+RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
+    bash -x mconda-install.sh -b -p miniconda && \
+    rm mconda-install.sh
+
+ENV PATH="/miniconda/bin:$PATH"
+
+ARG CONDA_ADD_PACKAGES=""
+
+RUN conda create -y -q -n tfio-dev python=3.6 ${CONDA_ADD_PACKAGES}
+
+ARG ARROW_VERSION=0.11.1
+
+RUN echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "source activate tfio-dev" >> ~/.bashrc
+
+ARG PIP_ADD_PACKAGES=""
+
+RUN /bin/bash -c "source activate tfio-dev && python -m pip install \
+    pytest \
+    boto3 \
+    pyarrow==${ARROW_VERSION} \
+    pandas \
+    ${PIP_ADD_PACKAGES} \
+    "
+
+ENV TFIO_DATAPATH=bazel-bin


### PR DESCRIPTION
This adds a docker file to be used for Python development. It includes required OS packages, Bazel installation, and setups up a conda environment `tfio-dev` with required pip packages. It also sets the environment variable `TFIO_DATAPATH` used for loading shared libraries needed to run PyTests.

The Docker image can be built with the command from `tensorflow/io` directory:
`docker build -f dev/Dockerfile -t tfio-dev .`

To run the container:
`docker run -it --rm -v $PWD:/v -w /v tfio-dev`

In the container, do the following:

To setup and install TensorFlow, if not installed already
`./configure.sh`

To build TensorFlow I/O C++ 
`bazel build -s --verbose_failures --spawn_strategy standalone //tensorflow_io/...`

To run tests
`pytest tests`

To build a distributable Python package
`python setup.py bdist_wheel`

Fixes #103 
