### PR TITLE
Add GITHUB_PAT to pass a token, to have a higher limit to pull from R repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ jobs:
       export TENSORFLOW_INSTALL="tensorflow==1.13.0rc2"
       docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:14.04 bash -x -e /v/.travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
       ls -la wheelhouse/*.whl
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:16.04 bash -x -e /v/.travis/install.test.sh
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:18.04 bash -x -e /v/.travis/install.test.sh
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -e GITHUB_PAT=${GITHUB_PAT} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:16.04 bash -x -e /v/.travis/install.test.sh
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -e GITHUB_PAT=${GITHUB_PAT} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:18.04 bash -x -e /v/.travis/install.test.sh
       if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
         ls wheelhouse/*.whl
         twine upload wheelhouse/*.whl


### PR DESCRIPTION
Travis CI set a limit to pull unless a GITHUB_PAT is passed. With
GITHUB_PAT we should have 5000/hour (vs. 60/hour).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>