### PR TITLE
Change the TIFFDataset to read from the TF FileSytem interface.

### DIFF
--- a/tensorflow_io/image/kernels/tiff_dataset_ops.cc
+++ b/tensorflow_io/image/kernels/tiff_dataset_ops.cc
@@ -23,6 +23,216 @@ namespace tensorflow {
 namespace data {
 namespace {
 
+extern "C" {
+  static tmsize_t tiffclient_read(thandle_t handle, void* buf, tmsize_t tsize);
+  static tmsize_t tiffclient_write(thandle_t handle, void* buf, tmsize_t tsize);
+  static toff_t tiffclient_seek(thandle_t handle, toff_t toffset, int whence);
+  static int tiffclient_close(thandle_t handle);
+  static toff_t tiffclient_size(thandle_t handle);
+  static int tiffclient_map(thandle_t handle, void** base, toff_t* tsize);
+  static void tiffclient_unmap(thandle_t handle, void* base, toff_t tsize);
+}
+
+
+// Base object for wrapping TIFFClientOpen file operation callbacks
+
+class TiffFileBase {
+  std::unique_ptr<TIFF, decltype(&TIFFClose)> tif_;
+
+ public:
+  TIFF* Tiff() { return tif_.get(); }
+
+  TiffFileBase() :  tif_(nullptr, TIFFClose) {}
+  virtual ~TiffFileBase() {}
+
+ protected:
+  Status ClientOpen(const char *name, const char* mode) {
+    auto tif = TIFFClientOpen(name, mode, this,
+                          tiffclient_read,
+                          tiffclient_write,
+                          tiffclient_seek,
+                          tiffclient_close,
+                          tiffclient_size,
+                          tiffclient_map,
+                          tiffclient_unmap);
+
+    if (tif == NULL) {
+      return errors::InvalidArgument("unable to open file:", name);
+    }
+
+    tif_.reset(tif);
+    return Status::OK();
+  }
+
+
+  void ClientClose() {tif_.reset(); }
+
+ protected:
+  virtual size_t  TiffClientRead(void*, size_t) { return 0;}
+  virtual size_t  TiffClientWrite(void*, size_t) { return 0; }
+  virtual off_t   TiffClientSeek(off_t offset, int whence) = 0;
+  virtual int     TiffClientClose() { return 0;}
+  virtual off_t   TiffClientSize() = 0;
+  virtual int     TiffClientMap(void** base, off_t* size) { return 0;}
+  virtual void    TiffClientUnmap(void* base, off_t size) {}
+
+  friend tmsize_t tiffclient_read(thandle_t handle, void* buf, tmsize_t tsize);
+  friend tmsize_t tiffclient_write(thandle_t handle, void* buf, tmsize_t tsize);
+  friend toff_t tiffclient_seek(thandle_t handle, toff_t toffset, int whence);
+  friend int tiffclient_close(thandle_t handle);
+  friend toff_t tiffclient_size(thandle_t handle);
+  friend int tiffclient_map(thandle_t handle, void** base, toff_t* tsize);
+  friend void tiffclient_unmap(thandle_t handle, void* base, toff_t tsize);
+};
+
+
+
+extern "C"  {
+
+static tmsize_t
+tiffclient_read(thandle_t handle, void* buf, tmsize_t tsize) {
+  TiffFileBase *bobj = reinterpret_cast<TiffFileBase *>(handle);
+  size_t size = static_cast<size_t>(tsize);
+  if (static_cast<tmsize_t>(size) != tsize)
+    return static_cast<tmsize_t>(-1);
+  size_t result = bobj->TiffClientRead(buf, size);
+  return static_cast<tmsize_t>(result);
+}
+
+static tmsize_t
+tiffclient_write(thandle_t handle, void* buf, tmsize_t tsize) {
+  TiffFileBase *bobj = reinterpret_cast<TiffFileBase *>(handle);
+  size_t size = static_cast<size_t>(tsize);
+  if (static_cast<tmsize_t>(size) != tsize)
+    return static_cast<tmsize_t>(-1);
+  size_t result =  bobj->TiffClientWrite(buf, size);
+  return static_cast<tmsize_t>(result);
+}
+
+static toff_t
+tiffclient_seek(thandle_t handle, toff_t toffset, int whence) {
+  TiffFileBase *bobj = reinterpret_cast<TiffFileBase *>(handle);
+  off_t offset = static_cast<off_t>(toffset);
+  off_t result = bobj->TiffClientSeek(offset, whence);
+  return static_cast<toff_t>(result);
+}
+
+static int
+tiffclient_close(thandle_t handle) {
+  TiffFileBase *bobj = reinterpret_cast<TiffFileBase *>(handle);
+  return bobj->TiffClientClose();
+}
+
+static toff_t
+tiffclient_size(thandle_t handle) {
+  TiffFileBase *bobj = reinterpret_cast<TiffFileBase *>(handle);
+  off_t result = bobj->TiffClientSize();
+  return static_cast<toff_t>(result);
+}
+
+static int
+tiffclient_map(thandle_t handle, void** base, toff_t* tsize) {
+  TiffFileBase *bobj = reinterpret_cast<TiffFileBase *>(handle);
+  off_t size;
+  int result = bobj->TiffClientMap(base, &size);
+  *tsize = static_cast<toff_t>(size);
+  return result;
+}
+
+static void
+tiffclient_unmap(thandle_t handle, void* base, toff_t tsize) {
+  TiffFileBase *bobj = reinterpret_cast<TiffFileBase *>(handle);
+  off_t size = static_cast<off_t>(tsize);
+  return bobj->TiffClientUnmap(base, size);
+}
+
+}  //  extern "C"
+
+// Use RandomAccessFile for tiff file system operation callbacks
+class TiffRandomFile : public TiffFileBase {
+ public:
+  TiffRandomFile() {}
+  ~TiffRandomFile() override  {
+    Close();
+  }
+
+  Status Open(Env *env, const string& filename) {
+    // Open Random access file
+    std::unique_ptr<RandomAccessFile> file;
+    TF_RETURN_IF_ERROR(env->NewRandomAccessFile(filename, &file));
+    // Read Size and hope we get same file as above
+    uint64 size = 0;
+    TF_RETURN_IF_ERROR(env->GetFileSize(filename, &size));
+    // Open Tiff
+    fileSize_ = static_cast<off_t>(size);
+    offset_ = 0;
+    file_ = std::move(file);
+    Status s = ClientOpen(filename.c_str(), "rm");
+    if (!s.ok()) {
+      file_.reset();
+    }
+    return s;
+  }
+
+  bool IsOpen() {
+    return static_cast<bool>(file_);
+  }
+
+  void Close() {
+    ClientClose();
+    file_.reset();
+  }
+
+ private:
+  size_t  TiffClientRead(void*, size_t) override;
+  off_t   TiffClientSeek(off_t offset, int whence) override;
+  int     TiffClientClose() override;
+  off_t   TiffClientSize() override;
+
+  std::unique_ptr<RandomAccessFile> file_;
+  off_t fileSize_;
+  off_t offset_;
+};
+
+size_t TiffRandomFile::TiffClientRead(void* data, size_t n) {
+  StringPiece result;
+  Status s;
+  s = file_.get()->Read(offset_, n, &result, reinterpret_cast<char *>(data));
+  if (result.data() != data) {
+    memmove(data, result.data(), result.size());
+  }
+  if (s.ok() || errors::IsOutOfRange(s)) {
+    offset_ += result.size();
+  }
+  return  result.size();
+}
+
+off_t TiffRandomFile::TiffClientSeek(off_t offset, int whence) {
+  switch (whence) {
+    case SEEK_SET:
+      offset_ = offset;
+      break;
+    case SEEK_CUR:
+      offset_ += offset;
+      break;
+    case SEEK_END:
+      offset_ = fileSize_ + offset;
+      break;
+    default:
+      break;
+  }
+  return offset_;
+}
+
+off_t TiffRandomFile::TiffClientSize() {
+  return fileSize_;
+}
+
+int TiffRandomFile::TiffClientClose() {
+  return 0;
+}
+
+
 class TIFFDatasetOp : public DatasetOpKernel {
  public:
   using DatasetOpKernel::DatasetOpKernel;
@@ -87,7 +297,7 @@ class TIFFDatasetOp : public DatasetOpKernel {
     class Iterator : public DatasetIterator<Dataset> {
      public:
       explicit Iterator(const Params& params)
-          : DatasetIterator<Dataset>(params), file_(nullptr, TIFFClose) {}
+          : DatasetIterator<Dataset>(params) {}
 
       Status GetNextInternal(IteratorContext* ctx,
                              std::vector<Tensor>* out_tensors,
@@ -95,29 +305,29 @@ class TIFFDatasetOp : public DatasetOpKernel {
         mutex_lock l(mu_);
         do {
           // We are currently processing a file, so try to read the next record.
-          if (file_) {
+          if (file_.IsOpen()) {
             unsigned int width, height;
-	    // get the size of the tiff
-	    TIFFGetField(file_.get(), TIFFTAG_IMAGEWIDTH, &width);
-	    TIFFGetField(file_.get(), TIFFTAG_IMAGELENGTH, &height);
-	    // get the total number of pixels
-	    unsigned int npixels = width*height;
-	    uint32* raster = (uint32*)_TIFFmalloc(npixels * sizeof(uint32));
-	    if (!TIFFReadRGBAImageOriented(file_.get(), width, height, raster, 	ORIENTATION_TOPLEFT, 0)) {
+            // get the size of the tiff
+            TIFFGetField(file_.Tiff(), TIFFTAG_IMAGEWIDTH, &width);
+            TIFFGetField(file_.Tiff(), TIFFTAG_IMAGELENGTH, &height);
+            // get the total number of pixels
+            unsigned int npixels = width*height;
+            uint32* raster = (uint32*)_TIFFmalloc(npixels * sizeof(uint32));
+            if (!TIFFReadRGBAImageOriented(file_.Tiff(), width, height, raster, ORIENTATION_TOPLEFT, 0)) {
               _TIFFfree(raster);
               return errors::InvalidArgument("unable to read file: ", dataset()->filenames_[current_file_index_]);
-	    }
-	    // RGBA
-	    static const int channel = 4;
-	    Tensor value_tensor(ctx->allocator({}), DT_UINT8, {height, width, channel});
-	    int num_bytes = npixels * sizeof(uint32);
+            }
+           // RGBA
+            static const int channel = 4;
+            Tensor value_tensor(ctx->allocator({}), DT_UINT8, {height, width, channel});
+            int num_bytes = npixels * sizeof(uint32);
             std::memcpy(reinterpret_cast<char*>(value_tensor.flat<uint8_t>().data()), raster, num_bytes * sizeof(uint8_t));
             out_tensors->emplace_back(std::move(value_tensor));
-	    _TIFFfree(raster);
-            if (!TIFFReadDirectory(file_.get())) {
+            _TIFFfree(raster);
+            if (!TIFFReadDirectory(file_.Tiff())) {
               ResetStreamsLocked();
               ++current_file_index_;
-	    }
+            }
             *end_of_sequence = false;
             return Status::OK();
           }
@@ -155,22 +365,18 @@ class TIFFDatasetOp : public DatasetOpKernel {
 
         // Actually move on to next file.
         const string& filename = dataset()->filenames_[current_file_index_];
-	TIFF* f = TIFFOpen(filename.c_str(), "r");
-	if (f == NULL) {
-          return errors::InvalidArgument("unable to open file:", filename);
-	}
-	file_.reset(f);
-	return Status::OK();
+        Status s = file_.Open(env, filename);
+        return s;
       }
 
       // Resets all TIFF streams.
       void ResetStreamsLocked() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-        file_.reset();
+        file_.Close();
       }
 
       mutex mu_;
       size_t current_file_index_ GUARDED_BY(mu_) = 0;
-      std::unique_ptr<TIFF, decltype(&TIFFClose)> file_ GUARDED_BY(mu_);
+      TiffRandomFile file_ GUARDED_BY(mu_);
     };
 
     const std::vector<string> filenames_;

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -109,6 +109,7 @@ class ImageDatasetTest(test.TestCase):
         images.append(image_v)
 
     filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_image", "small.tiff")
+    filename = "file://" + filename
 
     num_repeats = 2
 


### PR DESCRIPTION
The Libtiff can be used with callbacks to abstract the file
system operations. This change redirects the operations to
a RandomAccessFile.

The same method can be used to redirect tiff file reading to
a string for future tiff OPs or whole file readaheads.