### PR TITLE
Improve error message when _load_library fails

### DIFF
--- a/tensorflow_io/__init__.py
+++ b/tensorflow_io/__init__.py
@@ -44,11 +44,13 @@ def _load_library(filename, lib="op"):
       else lambda f: tensorflow.compat.v1.load_file_system_library(f) == None
 
   # Try to load all paths for file, fail if none succeed
+  errs = []
   for f in filenames:
     try:
       l = load_fn(f)
       if l is not None:
         return l
     except errors.NotFoundError as e:
-      pass
-  raise NotImplementedError("unable to open file: ", filename)
+      errs.append(str(e))
+  raise NotImplementedError("unable to open file: " +
+      "{}, from paths: {}\ncaused by: {}".format(filename, filenames, errs))


### PR DESCRIPTION
When _load_library fails due to a problem loading the shared library, the error message can be misleading because it seems like it can not find the file. This change includes the cause of the load failure and the complete paths searched.