### PR TITLE
[WIP] Use buildpack-deps as the base image to speed up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ git:
 services:
 - docker
 
+cache:
+  directories:
+  - .cache/pip
+
 addons:
   apt:
     update: true
@@ -19,14 +23,20 @@ install:
 - twine --version
 
 before_script:
+- sudo chown -R root:root .cache/pip
 - bash -x -e tests/test_ignite/start_ignite.sh
 - bash -x -e tests/test_kafka/kafka_test.sh start kafka
 - bash -x -e tests/test_kinesis/kinesis_test.sh start kinesis
+
+
+after_cache:
+- sudo chown -R $(id -un):$(id -gn) .cache/pip
 
 stages:
 - build
 - preview
 - install
+- release
 
 jobs:
   include:
@@ -36,40 +46,56 @@ jobs:
     - |
       set -e
       export TENSORFLOW_INSTALL="tensorflow==1.13.0rc2"
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:16.04 bash -x -e /v/.travis/build.test.sh
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:16.04 bash -x -e /v/.travis/build.test.sh
   - stage: build
     name: "Ubuntu 18.04 Build"
     script:
     - |
       set -e
       export TENSORFLOW_INSTALL="tensorflow==1.13.0rc2"
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:18.04 bash -x -e /v/.travis/build.test.sh
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:18.04 bash -x -e /v/.travis/build.test.sh
   - stage: preview
     name: "TensorFlow 2.0 Build"
     script:
     - |
       set -e
       export TENSORFLOW_INSTALL="tf-nightly-2.0-preview"
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:14.04 bash -x -e /v/.travis/python.release.sh --preview ${TRAVIS_BUILD_NUMBER}
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:14.04 bash -x -e /v/.travis/python.release.sh --preview ${TRAVIS_BUILD_NUMBER}
       ls -la wheelhouse/*.whl
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:18.04 bash -x -e /v/.travis/install.test.sh
-      ls wheelhouse/*.whl
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:18.04 bash -x -e /v/.travis/install.test.sh
+      ls -la wheelhouse/*.whl
       if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
         twine upload wheelhouse/*-cp27-*.whl
         twine upload wheelhouse/*-cp36-*.whl
       fi
   - stage: install
-    name: "Python, R, Nightly"
+    name: "Python/R Install on Ubuntu 16.04"
     script:
     - |
       set -e
       export TENSORFLOW_INSTALL="tensorflow==1.13.0rc2"
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:14.04 bash -x -e /v/.travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:14.04 bash -x -e /v/.travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
       ls -la wheelhouse/*.whl
       # Note token is for rate limit only. When regenerate should not grant any access.
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -e GITHUB_PAT=9eecea9200150af1ec29f70bb067575eb2e56fc7 -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:16.04 bash -x -e /v/.travis/install.test.sh
-      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -e GITHUB_PAT=9eecea9200150af1ec29f70bb067575eb2e56fc7 -i -t --rm -v $PWD:/v -w /v  --net=host ubuntu:18.04 bash -x -e /v/.travis/install.test.sh
-      ls wheelhouse/*.whl
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -e GITHUB_PAT=9eecea9200150af1ec29f70bb067575eb2e56fc7 -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:16.04 bash -x -e /v/.travis/install.test.sh
+  - stage: install
+    name: "Python/R Install on Ubuntu 18.04"
+    script:
+    - |
+      set -e
+      export TENSORFLOW_INSTALL="tensorflow==1.13.0rc2"
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:14.04 bash -x -e /v/.travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+      ls -la wheelhouse/*.whl
+      # Note token is for rate limit only. When regenerate should not grant any access.
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -e GITHUB_PAT=9eecea9200150af1ec29f70bb067575eb2e56fc7 -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:18.04 bash -x -e /v/.travis/install.test.sh
+  - stage: release
+    name: "Nightly Release"
+    script:
+    - |
+      set -e
+      export TENSORFLOW_INSTALL="tensorflow==1.13.0rc2"
+      docker run -e TENSORFLOW_INSTALL=${TENSORFLOW_INSTALL} -i -t --rm -v $PWD/.cache/pip/:/root/.cache/pip -v $PWD:/v -w /v  --net=host buildpack-deps:14.04 bash -x -e /v/.travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+      ls -la wheelhouse/*.whl
       if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
         twine upload wheelhouse/*.whl
       fi

--- a/.travis/build.test.sh
+++ b/.travis/build.test.sh
@@ -20,20 +20,21 @@ export BAZEL_VERSION=0.20.0 BAZEL_OS=linux
 # Path to shared libraries for running pytest
 export TFIO_DATAPATH="bazel-bin"
 
-# Install needed repo
-DEBIAN_FRONTEND=noninteractive apt-get -y -qq update
-DEBIAN_FRONTEND=noninteractive apt-get -y -qq install \
-    python-pip python3-pip \
-    unzip curl \
-    ffmpeg > /dev/null
-
+# Install bazel, display log only if error
 curl -sOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
 chmod +x bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-
-# Install bazel, display log only if error
 ./bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh 2>&1 > bazel-install.log || (cat bazel-install.log && false)
-rm -rf bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-rm -rf bazel-install.log
+rm -rf bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh bazel-install.log
+
+# Install needed repo
+DEBIAN_FRONTEND=noninteractive apt-get -y -qq update
+DEBIAN_FRONTEND=noninteractive apt-get -y -qq install python python3 ffmpeg > /dev/null
+
+# Install the latest version of pip (needed for google-cloud-pubsub)
+curl -sOL https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py
+python get-pip.py
+rm -rf get-pip.py
 
 if [[ ! -z ${TENSORFLOW_INSTALL} ]]; then
   python3 -m pip install -q ${TENSORFLOW_INSTALL}
@@ -49,8 +50,8 @@ bazel build \
   --test_output=errors -- \
   //tensorflow_io/...
 
-python3 -m pip install -q pytest boto3 pyarrow==0.11.1 pandas==0.19.2
-python -m pip install -q pytest boto3 pyarrow==0.11.1 pandas==0.19.2
+python3 -m pip install -q pytest google-cloud-pubsub boto3 pyarrow==0.11.1 pandas==0.19.2
+python -m pip install -q pytest google-cloud-pubsub boto3 pyarrow==0.11.1 pandas==0.19.2
 
 python3 -m pytest tests
 python -m pytest tests

--- a/.travis/install.test.sh
+++ b/.travis/install.test.sh
@@ -17,7 +17,13 @@ set -e -x
 
 # Install needed repo
 DEBIAN_FRONTEND=noninteractive apt-get -y -qq update
-DEBIAN_FRONTEND=noninteractive apt-get -y -qq install python-pip python3-pip ffmpeg > /dev/null
+DEBIAN_FRONTEND=noninteractive apt-get -y -qq install python python3 ffmpeg > /dev/null
+
+# Install the latest version of pip (needed for google-cloud-pubsub)
+curl -sOL https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py
+python get-pip.py
+rm -rf get-pip.py
 
 CPYTHON_VERSION=$(python3 -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
 if [[ ! -z ${TENSORFLOW_INSTALL} ]]; then
@@ -26,7 +32,7 @@ if [[ ! -z ${TENSORFLOW_INSTALL} ]]; then
 else
   python3 -m pip install wheelhouse/*-cp${CPYTHON_VERSION}-*.whl
 fi
-python3 -m pip install -q pytest boto3 pyarrow==0.11.1 pandas==0.19.2
+python3 -m pip install -q pytest google-cloud-pubsub boto3 pyarrow==0.11.1 pandas==0.19.2
 (cd tests && python3 -m pytest --import-mode=append .)
 
 CPYTHON_VERSION=$(python -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
@@ -36,16 +42,14 @@ if [[ ! -z ${TENSORFLOW_INSTALL} ]]; then
 else
   python -m pip install wheelhouse/*-cp${CPYTHON_VERSION}-*.whl
 fi
-python -m pip install -q pytest boto3 pyarrow==0.11.1 pandas==0.19.2
+python -m pip install -q pytest google-cloud-pubsub boto3 pyarrow==0.11.1 pandas==0.19.2
 (cd tests && python -m pytest --import-mode=append .)
 
 if [[ ${TENSORFLOW_INSTALL} == "tf-nightly-2.0-preview" ]]; then
   exit 0
 fi
 
-DEBIAN_FRONTEND=noninteractive apt-get -y -qq install \
-    build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev \
-    software-properties-common apt-transport-https > /dev/null
+DEBIAN_FRONTEND=noninteractive apt-get -y -qq install software-properties-common apt-transport-https > /dev/null
 DEBIAN_FRONTEND=noninteractive apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 DEBIAN_FRONTEND=noninteractive add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran35/"
 DEBIAN_FRONTEND=noninteractive apt-get -y -qq update


### PR DESCRIPTION
The official buildpack-deps has build tools installed already,
and are based on different os Ubuntu:14.04/16.04/18.04
so speed up should be possible.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>