### PR TITLE
Export symbols properly

### DIFF
--- a/tensorflow_io/arrow/__init__.py
+++ b/tensorflow_io/arrow/__init__.py
@@ -15,6 +15,8 @@
 """Arrow Dataset.
 
 @@ArrowDataset
+@@ArrowFeatherDataset
+@@ArrowStreamDataset
 """
 
 from __future__ import absolute_import

--- a/tensorflow_io/image/__init__.py
+++ b/tensorflow_io/image/__init__.py
@@ -16,6 +16,7 @@
 
 @@WebPDataset
 @@TIFFDataset
+@@decode_webp
 """
 
 from __future__ import absolute_import
@@ -24,12 +25,14 @@ from __future__ import print_function
 
 from tensorflow_io.image.python.ops.image_dataset_ops import WebPDataset
 from tensorflow_io.image.python.ops.image_dataset_ops import TIFFDataset
+from tensorflow_io.image.python.ops.image_dataset_ops import decode_webp
 
 from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = [
     "WebPDataset",
     "TIFFDataset",
+    "decode_webp",
 ]
 
 remove_undocumented(__name__)

--- a/tensorflow_io/kafka/__init__.py
+++ b/tensorflow_io/kafka/__init__.py
@@ -15,6 +15,7 @@
 """Kafka Dataset.
 
 @@KafkaDataset
+@@write_kafka
 """
 
 from __future__ import absolute_import
@@ -22,11 +23,13 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_io.kafka.python.ops.kafka_dataset_ops import KafkaDataset
+from tensorflow_io.kafka.python.ops.kafka_dataset_ops import write_kafka
 
 from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = [
     "KafkaDataset",
+    "write_kafka",
 ]
 
 remove_undocumented(__name__)

--- a/tensorflow_io/libsvm/__init__.py
+++ b/tensorflow_io/libsvm/__init__.py
@@ -15,6 +15,7 @@
 """LibSVM Dataset.
 
 @@make_libsvm_dataset
+@@decode_libsvm
 """
 
 from __future__ import absolute_import
@@ -22,11 +23,13 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_io.libsvm.python.ops.libsvm_dataset_ops import make_libsvm_dataset
+from tensorflow_io.libsvm.python.ops.libsvm_dataset_ops import decode_libsvm
 
 from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = [
     "make_libsvm_dataset",
+    "decode_libsvm",
 ]
 
 remove_undocumented(__name__)

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -39,7 +39,7 @@ from tensorflow import dtypes
 from tensorflow import errors
 from tensorflow.compat.v1 import data
 
-from tensorflow_io.arrow.python.ops import arrow_dataset_ops
+import tensorflow_io.arrow as arrow_io
 
 from tensorflow import test
 
@@ -172,7 +172,7 @@ class ArrowDatasetTest(test.TestCase):
     batch = self.make_record_batch(truth_data)
 
     # test all columns selected
-    dataset = arrow_dataset_ops.ArrowDataset(
+    dataset = arrow_io.ArrowDataset(
         batch,
         list(range(len(truth_data.output_types))),
         truth_data.output_types,
@@ -181,7 +181,7 @@ class ArrowDatasetTest(test.TestCase):
 
     # test column selection
     columns = (1, 3, len(truth_data.output_types) - 1)
-    dataset = arrow_dataset_ops.ArrowDataset(
+    dataset = arrow_io.ArrowDataset(
         batch,
         columns,
         tuple([truth_data.output_types[c] for c in columns]),
@@ -190,7 +190,7 @@ class ArrowDatasetTest(test.TestCase):
 
     # test construction from pd.DataFrame
     df = batch.to_pandas()
-    dataset = arrow_dataset_ops.ArrowDataset.from_pandas(
+    dataset = arrow_io.ArrowDataset.from_pandas(
         df, preserve_index=False)
     self.run_test_case(dataset, truth_data)
 
@@ -208,7 +208,7 @@ class ArrowDatasetTest(test.TestCase):
 
     batch = self.make_record_batch(truth_data)
     df = batch.to_pandas()
-    dataset = arrow_dataset_ops.ArrowDataset.from_pandas(
+    dataset = arrow_io.ArrowDataset.from_pandas(
         df, preserve_index=True)
 
     # Add index column to test data to check results
@@ -224,7 +224,7 @@ class ArrowDatasetTest(test.TestCase):
         truth_data_with_index.data[1:],
         truth_data_with_index.output_types[1:],
         truth_data_with_index.output_shapes[1:])
-    dataset = arrow_dataset_ops.ArrowDataset.from_pandas(
+    dataset = arrow_io.ArrowDataset.from_pandas(
         df, columns=(1,), preserve_index=True)
     self.run_test_case(dataset, truth_data_selected_with_index)
 
@@ -243,7 +243,7 @@ class ArrowDatasetTest(test.TestCase):
       write_feather(df, f)
 
     # test single file
-    dataset = arrow_dataset_ops.ArrowFeatherDataset(
+    dataset = arrow_io.ArrowFeatherDataset(
         f.name,
         list(range(len(truth_data.output_types))),
         truth_data.output_types,
@@ -251,7 +251,7 @@ class ArrowDatasetTest(test.TestCase):
     self.run_test_case(dataset, truth_data)
 
     # test multiple files
-    dataset = arrow_dataset_ops.ArrowFeatherDataset(
+    dataset = arrow_io.ArrowFeatherDataset(
         [f.name, f.name],
         list(range(len(truth_data.output_types))),
         truth_data.output_types,
@@ -263,7 +263,7 @@ class ArrowDatasetTest(test.TestCase):
     self.run_test_case(dataset, truth_data_doubled)
 
     # test construction from schema
-    dataset = arrow_dataset_ops.ArrowFeatherDataset.from_schema(
+    dataset = arrow_io.ArrowFeatherDataset.from_schema(
         f.name, batch.schema)
     self.run_test_case(dataset, truth_data)
 
@@ -301,7 +301,7 @@ class ArrowDatasetTest(test.TestCase):
     server = threading.Thread(target=run_server, args=(num_batches,))
     server.start()
 
-    dataset = arrow_dataset_ops.ArrowStreamDataset.from_schema(
+    dataset = arrow_io.ArrowStreamDataset.from_schema(
         host, batch.schema)
     truth_data_mult = TruthData(
         [d * num_batches for d in truth_data.data],
@@ -325,7 +325,7 @@ class ArrowDatasetTest(test.TestCase):
 
     batch = self.make_record_batch(truth_data)
 
-    dataset = arrow_dataset_ops.ArrowDataset(
+    dataset = arrow_io.ArrowDataset(
         batch,
         (0,),
         truth_data.output_types,
@@ -338,7 +338,7 @@ class ArrowDatasetTest(test.TestCase):
         self.scalar_shapes)
     batch = self.make_record_batch(truth_data)
 
-    dataset = arrow_dataset_ops.ArrowDataset(
+    dataset = arrow_io.ArrowDataset(
         batch,
         list(range(len(truth_data.output_types))),
         tuple([dtypes.int32 for _ in truth_data.output_types]),

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -28,7 +28,7 @@ from tensorflow import errors
 from tensorflow.compat.v1 import data
 from tensorflow.compat.v1 import resource_loader
 
-from tensorflow_io.hadoop.python.ops import hadoop_dataset_ops
+import tensorflow_io.hadoop as hadoop_io
 
 from tensorflow import test
 
@@ -47,7 +47,7 @@ class SequenceFileDatasetTest(test.TestCase):
 
     num_repeats = 2
 
-    dataset = hadoop_dataset_ops.SequenceFileDataset([filename]).repeat(
+    dataset = hadoop_io.SequenceFileDataset([filename]).repeat(
         num_repeats)
     iterator = data.make_initializable_iterator(dataset)
     init_op = iterator.initializer

--- a/tests/test_ignite.py
+++ b/tests/test_ignite.py
@@ -27,7 +27,7 @@ from tensorflow import errors
 from tensorflow.compat.v1 import data
 from tensorflow.compat.v1 import gfile
 
-from tensorflow_io.ignite import IgniteDataset
+import tensorflow_io.ignite as ignite_io
 
 from tensorflow import test
 
@@ -263,7 +263,7 @@ class IgniteDatasetTest(test.TestCase):
 
     """
     self._clear_env()
-    ds = IgniteDataset(cache_name="SQL_PUBLIC_TEST_CACHE", port=42300)
+    ds = ignite_io.IgniteDataset(cache_name="SQL_PUBLIC_TEST_CACHE", port=42300)
     self._check_dataset(ds)
 
   def test_ignite_dataset_with_plain_client_with_interleave(self):
@@ -272,7 +272,7 @@ class IgniteDatasetTest(test.TestCase):
     """
     self._clear_env()
     ds = data.Dataset.from_tensor_slices(["localhost"]).interleave(
-        lambda host: IgniteDataset(cache_name="SQL_PUBLIC_TEST_CACHE",
+        lambda host: ignite_io.IgniteDataset(cache_name="SQL_PUBLIC_TEST_CACHE",
                                    schema_host="localhost", host=host,
                                    port=42300), cycle_length=4, block_length=16
     )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -28,7 +28,7 @@ from tensorflow import errors
 from tensorflow import image
 from tensorflow.compat.v1 import resource_loader
 
-from tensorflow_io.image.python.ops import image_dataset_ops
+import tensorflow_io.image as image_io
 
 from tensorflow import test
 
@@ -52,7 +52,7 @@ class ImageDatasetTest(test.TestCase):
       png = png_op.eval()
       self.assertEqual(png.shape, (height, width, channel))
 
-      webp_p = image_dataset_ops.decode_webp(webp_contents)
+      webp_p = image_io.decode_webp(webp_contents)
       webp_v = webp_p.eval()
       self.assertEqual(webp_v.shape, (height, width, channel))
 
@@ -77,7 +77,7 @@ class ImageDatasetTest(test.TestCase):
 
     num_repeats = 2
 
-    dataset = image_dataset_ops.WebPDataset([filename]).repeat(
+    dataset = image_io.WebPDataset([filename]).repeat(
         num_repeats)
     iterator = dataset.make_initializable_iterator()
     init_op = iterator.initializer
@@ -113,7 +113,7 @@ class ImageDatasetTest(test.TestCase):
 
     num_repeats = 2
 
-    dataset = image_dataset_ops.TIFFDataset([filename]).repeat(num_repeats)
+    dataset = image_io.TIFFDataset([filename]).repeat(num_repeats)
     iterator = dataset.make_initializable_iterator()
     init_op = iterator.initializer
     get_next = iterator.get_next()

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -27,7 +27,7 @@ from tensorflow.compat.v1 import data
 from tensorflow import dtypes
 from tensorflow import errors
 
-from tensorflow_io.kafka.python.ops import kafka_dataset_ops
+import tensorflow_io.kafka as kafka_io
 
 from tensorflow import test
 
@@ -51,7 +51,7 @@ class KafkaDatasetTest(test.TestCase):
     num_epochs = tensorflow.compat.v1.placeholder(dtypes.int64, shape=[])
     batch_size = tensorflow.compat.v1.placeholder(dtypes.int64, shape=[])
 
-    repeat_dataset = kafka_dataset_ops.KafkaDataset(
+    repeat_dataset = kafka_io.KafkaDataset(
         topics, group="test", eof=True).repeat(num_epochs)
     batch_dataset = repeat_dataset.batch(batch_size)
 
@@ -121,9 +121,9 @@ class KafkaDatasetTest(test.TestCase):
 
     # Start with reading test topic, replace `D` with `e(time)e`,
     # and write to test_e(time)e` topic.
-    dataset = kafka_dataset_ops.KafkaDataset(topics=["test:0:0:4"], group="test", eof=True)
+    dataset = kafka_io.KafkaDataset(topics=["test:0:0:4"], group="test", eof=True)
     dataset = dataset.map(
-        lambda x: kafka_dataset_ops.write_kafka(
+        lambda x: kafka_io.write_kafka(
             tensorflow.strings.regex_replace(x, "D", channel), topic="test_"+channel))
     iterator = dataset.make_initializable_iterator()
     init_op = iterator.initializer
@@ -138,7 +138,7 @@ class KafkaDatasetTest(test.TestCase):
         sess.run(get_next)
 
     # Reading from `test_e(time)e` we should get the same result
-    dataset = kafka_dataset_ops.KafkaDataset(topics=["test_"+channel], group="test", eof=True)
+    dataset = kafka_io.KafkaDataset(topics=["test_"+channel], group="test", eof=True)
     iterator = dataset.make_initializable_iterator()
     init_op = iterator.initializer
     get_next = iterator.get_next()

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -39,7 +39,7 @@ from tensorflow import dtypes
 from tensorflow import errors
 from tensorflow.compat.v1 import data
 
-from tensorflow_io.kinesis.python.ops import kinesis_dataset_ops
+import tensorflow_io.kinesis as kinesis_io
 
 
 class KinesisDatasetTest(test.TestCase):
@@ -71,7 +71,7 @@ class KinesisDatasetTest(test.TestCase):
     num_epochs = tensorflow.compat.v1.placeholder(dtypes.int64, shape=[])
     batch_size = tensorflow.compat.v1.placeholder(dtypes.int64, shape=[])
 
-    repeat_dataset = kinesis_dataset_ops.KinesisDataset(
+    repeat_dataset = kinesis_io.KinesisDataset(
         stream, read_indefinitely=False).repeat(num_epochs)
     batch_dataset = repeat_dataset.batch(batch_size)
 
@@ -122,7 +122,7 @@ class KinesisDatasetTest(test.TestCase):
     num_epochs = tensorflow.compat.v1.placeholder(dtypes.int64, shape=[])
     batch_size = tensorflow.compat.v1.placeholder(dtypes.int64, shape=[])
 
-    repeat_dataset = kinesis_dataset_ops.KinesisDataset(
+    repeat_dataset = kinesis_io.KinesisDataset(
         stream, shard, read_indefinitely=False).repeat(num_epochs)
     batch_dataset = repeat_dataset.batch(batch_size)
 

--- a/tests/test_libsvm.py
+++ b/tests/test_libsvm.py
@@ -23,7 +23,7 @@ import numpy as np
 from tensorflow import dtypes
 from tensorflow import sparse
 
-from tensorflow_io.libsvm.python.ops import libsvm_dataset_ops
+import tensorflow_io.libsvm as libsvm_io
 
 from tensorflow import test
 
@@ -35,7 +35,7 @@ class DecodeLibsvmOpTest(test.TestCase):
           "1 1:3.4 2:0.5 4:0.231", "1 2:2.5 3:inf 5:0.503",
           "2 3:2.5 2:nan 1:0.105"
       ]
-      sparse_features, labels = libsvm_dataset_ops.decode_libsvm(
+      sparse_features, labels = libsvm_io.decode_libsvm(
           content, num_features=6)
       features = sparse.to_dense(
           sparse_features, validate_indices=False)
@@ -53,7 +53,7 @@ class DecodeLibsvmOpTest(test.TestCase):
       content = [["1 1:3.4 2:0.5 4:0.231", "1 1:3.4 2:0.5 4:0.231"],
                  ["1 2:2.5 3:inf 5:0.503", "1 2:2.5 3:inf 5:0.503"],
                  ["2 3:2.5 2:nan 1:0.105", "2 3:2.5 2:nan 1:0.105"]]
-      sparse_features, labels = libsvm_dataset_ops.decode_libsvm(
+      sparse_features, labels = libsvm_io.decode_libsvm(
           content, num_features=6, label_dtype=dtypes.float64)
       features = sparse.to_dense(
           sparse_features, validate_indices=False)

--- a/tests/test_lmdb.py
+++ b/tests/test_lmdb.py
@@ -27,7 +27,7 @@ tensorflow.compat.v1.disable_eager_execution()
 from tensorflow import dtypes
 from tensorflow import errors
 
-from tensorflow_io.lmdb.python.ops import lmdb_dataset_ops
+import tensorflow_io.lmdb as lmdb_io
 
 from tensorflow import test
 
@@ -46,7 +46,7 @@ class LMDBDatasetTest(test.TestCase):
 
     num_repeats = 2
 
-    dataset = lmdb_dataset_ops.LMDBDataset([filename]).repeat(num_repeats)
+    dataset = lmdb_io.LMDBDataset([filename]).repeat(num_repeats)
     iterator = dataset.make_initializable_iterator()
     init_op = iterator.initializer
     get_next = iterator.get_next()

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -28,7 +28,7 @@ from tensorflow import errors
 from tensorflow.compat.v1 import data
 from tensorflow.compat.v1 import resource_loader
 
-from tensorflow_io.parquet.python.ops import parquet_dataset_ops
+import tensorflow_io.parquet as parquet_io
 
 from tensorflow import test
 
@@ -57,7 +57,7 @@ class ParquetDatasetTest(test.TestCase):
         dtypes.bool, dtypes.int32, dtypes.int64, dtypes.float32, dtypes.float64)
     num_repeats = 2
 
-    dataset = parquet_dataset_ops.ParquetDataset(
+    dataset = parquet_io.ParquetDataset(
         filenames, columns, output_types).repeat(num_repeats)
     iterator = data.make_initializable_iterator(dataset)
     init_op = iterator.initializer

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -28,14 +28,14 @@ from tensorflow import errors
 from tensorflow import image
 from tensorflow.keras.applications.resnet50 import ResNet50
 from tensorflow.keras.applications.resnet50 import preprocess_input, decode_predictions
-from tensorflow_io.video import VideoDataset
+import tensorflow_io.video as video_io
 
 video_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_video", "small.mp4")
 
 @pytest.mark.skipif(not (hasattr(tensorflow, "version") and tensorflow.version.VERSION.startswith("2.0.")), reason=None)
 def test_video_predict():
   model = ResNet50(weights='imagenet')
-  x = VideoDataset(video_path).batch(1).map(lambda x: preprocess_input(image.resize(x, (224, 224))))
+  x = video_io.VideoDataset(video_path).batch(1).map(lambda x: preprocess_input(image.resize(x, (224, 224))))
   y = model.predict(x)
   p = decode_predictions(y, top=1)
   assert len(p) == 166
@@ -43,7 +43,7 @@ def test_video_predict():
 def test_video_dataset():
   num_repeats = 2
 
-  dataset = VideoDataset([video_path]).repeat(num_repeats)
+  dataset = video_io.VideoDataset([video_path]).repeat(num_repeats)
   iterator = dataset.make_initializable_iterator()
   init_op = iterator.initializer
   get_next = iterator.get_next()


### PR DESCRIPTION
It looks like some of the symbols are not exported properly. As a result, we may only use through:
```
from tensorflow_io.image.python.ops import ...
```
instead of directly import at the tensorflow_io.image... level

This PR addresses the issue

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>