### PR TITLE
Improve README.md regarding nightly package and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The `tensorflow-io` Python package could be installed with pip directly:
 $ pip install tensorflow-io
 ```
 
+People who are a little more adventurous can also try our nightly binaries:
+```
+$ pip install tensorflow-io-nightly
+```
+
+
 The related module such as Kafka could be imported with python:
 ```
 $  python

--- a/README.md
+++ b/README.md
@@ -84,12 +84,13 @@ $ # In docker
 $ curl -OL https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-linux-x86_64.sh
 $ chmod +x bazel-0.20.0-installer-linux-x86_64.sh
 $ ./bazel-0.20.0-installer-linux-x86_64.sh
+
 $ ./configure.sh
-$ bazel build build_pip_pkg
-$ bazel-bin/build_pip_pkg artifacts
+$ bazel build //tensorflow_io/...
+$ python setup.py --data bazel-bin -q bdist_wheel
 ```
 
-A package file `artifacts/tensorflow_io-*.whl` will be generated after a build is successful.
+A package file `dist/tensorflow_io-*.whl` will be generated after a build is successful.
 
 ### R
 


### PR DESCRIPTION
Two changes:

* Mention the `tensorflow-io-nightly` package in the README.
  (wordings are simply borrowed from the main tensorflow repo)

* Update build instructions for generating python whl package