### PR TITLE
Release 0.4.0

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tfio
 Type: Package
 Title: Interface to 'TensorFlow IO'
-Version: 0.3.0
+Version: 0.4.0
 Authors@R: c(
   person("TensorFlow IO Contributors", role = c("aut", "cph"),
          email = "io@tensorflow.org",

--- a/R-package/NEWS.md
+++ b/R-package/NEWS.md
@@ -1,3 +1,21 @@
+# tfio 0.4.0
+
+## Major Features
+* Support Google Cloud Pub/Sub Dataset.
+* Support MNIST file format.
+* Support `decode_webp` in image.
+* Support `write_kafka` in kafka.
+
+## Thanks to our Contributors
+
+This release contains contributions from many people:
+
+Bryan Cutler, Jongwook Choi, Sergii Khomenko, Stephan Uphoff,
+Yong Tang, Yuan (Terry) Tang
+
+We are also grateful to all who filed issues or helped resolve them, asked and
+answered questions, and were part of inspiring discussions.
+
 # tfio 0.3.0
 
 ## Major Features

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ At the moment TensorFlow I/O supports the following data sources:
 - `tensorflow_io.video`: Video file support with FFmpeg.
 - `tensorflow_io.parquet`: Apache Parquet data format support.
 - `tensorflow_io.lmdb`: LMDB file format support.
+- `tensorflow_io.mnist`: MNIST file format support.
+- `tensorflow_io.pubsub`: Google Cloud Pub/Sub support.
 
 ## Installation
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,21 @@
+# Release 0.4.0
+
+## Major Features
+* `tensorflow_io.pubsub`: Google Cloud Pub/Sub Dataset support.
+* `tensorflow_io.mnist`: MNIST file format support.
+* `tensorflow_io.image`: `decode_webp` support.
+* `tensorflow_io.kafka`: `write_kafka` support.
+
+## Thanks to our Contributors
+
+This release contains contributions from many people:
+
+Bryan Cutler, Jongwook Choi, Sergii Khomenko, Stephan Uphoff,
+Yong Tang, Yuan (Terry) Tang
+
+We are also grateful to all who filed issues or helped resolve them, asked and
+answered questions, and were part of inspiring discussions.
+
 # Release 0.3.0
 
 ## Major Features


### PR DESCRIPTION
This PR is for the Release of 0.4.0 to match tensorflow 1.13.1. We will see if we want additional contents in.

This is is related to #121.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>