### PR TITLE
Fix mnist dataset's shape and count issue

### DIFF
--- a/tensorflow_io/mnist/kernels/mnist_dataset_ops.cc
+++ b/tensorflow_io/mnist/kernels/mnist_dataset_ops.cc
@@ -210,10 +210,9 @@ class MNISTDatasetOp : public DatasetOpKernel {
           return errors::InvalidArgument("mnist image file header must starts with `0x00000803`");
         }
         index_ = 0;
-        count_ = (((int32)header[4]) << 24) | (((int32)header[5]) << 16) | (((int32)header[6]) << 8) | (((int32)header[7]));
-        rows_ = (((int32)header[8]) << 24) | (((int32)header[9]) << 16) | (((int32)header[10]) << 8) | (((int32)header[11]));
-        cols_ = (((int32)header[12]) << 24) | (((int32)header[13]) << 16) | (((int32)header[14]) << 8) | (((int32)header[15]));
-
+        count_ = (((int32)header[4] & 0xFF) << 24) | (((int32)header[5] & 0xFF) << 16) | (((int32)header[6] & 0xFF) << 8) | (((int32)header[7] & 0xFF));
+        rows_ = (((int32)header[8] & 0xFF) << 24) | (((int32)header[9] & 0xFF) << 16) | (((int32)header[10] & 0xFF) << 8) | (((int32)header[11] & 0xFF));
+        cols_ = (((int32)header[12] & 0xFF) << 24) | (((int32)header[13] & 0xFF) << 16) | (((int32)header[14] & 0xFF) << 8) | (((int32)header[15] & 0xFF));
         return Status::OK();
       }
       Status ReadRecord(IteratorContext* ctx, std::vector<Tensor>* out_tensors) override {
@@ -237,7 +236,7 @@ class MNISTDatasetOp : public DatasetOpKernel {
           return errors::InvalidArgument("mnist label file header must starts with `0x00000801`");
         }
         index_ = 0;
-        count_ = (((int32)header[4]) << 24) | (((int32)header[5]) << 16) | (((int32)header[6]) << 8) | (((int32)header[7]));
+        count_ = (((int32)header[4] & 0xFF) << 24) | (((int32)header[5] & 0xFF) << 16) | (((int32)header[6] & 0xFF) << 8) | (((int32)header[7] & 0xFF));
 
         return Status::OK();
       }

--- a/tensorflow_io/mnist/python/ops/mnist_dataset_ops.py
+++ b/tensorflow_io/mnist/python/ops/mnist_dataset_ops.py
@@ -59,10 +59,6 @@ class _MNISTBaseDataset(data.Dataset):
     return tensorflow.Tensor
 
   @property
-  def output_shapes(self):
-    return tensorflow.TensorShape([None, None])
-
-  @property
   def output_types(self):
     return dtypes.uint8
 
@@ -83,6 +79,11 @@ class MNISTImageDataset(_MNISTBaseDataset):
         filenames,
         compression_type=compression_type)
 
+  @property
+  def output_shapes(self):
+    return tensorflow.TensorShape([None, None])
+
+
 class MNISTLabelDataset(_MNISTBaseDataset):
   """A MNIST Label Dataset
   """
@@ -99,3 +100,7 @@ class MNISTLabelDataset(_MNISTBaseDataset):
         mnist_ops.mnist_label_dataset,
         filenames,
         compression_type=compression_type)
+
+  @property
+  def output_shapes(self):
+    return tensorflow.TensorShape([])

--- a/tests/test_mnist.py
+++ b/tests/test_mnist.py
@@ -43,6 +43,10 @@ class MNISTDatasetTest(test.TestCase):
 
     image_dataset = mnist_dataset_ops.MNISTImageDataset([image_filename], compression_type="GZIP")
     label_dataset = mnist_dataset_ops.MNISTLabelDataset([label_filename], compression_type="GZIP")
+
+    self.assertEqual(image_dataset.output_shapes.as_list(), [None, None])
+    self.assertEqual(label_dataset.output_shapes.as_list(), [])
+
     iterator = data.Dataset.zip((image_dataset, label_dataset)).make_initializable_iterator()
     init_op = iterator.initializer
     get_next = iterator.get_next()


### PR DESCRIPTION
This PR fixes a couple of issues in mnist dataset:
- The shape of label files should be scalar (`[]`). Before this PR it was `[None, None]`
- When calculating count from the file, the 0xFF was not applied. This caused
  the incorrect calculation as header[i] is (signed) char, casting to uint32 will overflow.

This PR fixes the above issues.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>