### PR TITLE
Add ImageInputSequence class for metadata information with a list of images

### DIFF
--- a/tensorflow_io/image/BUILD
+++ b/tensorflow_io/image/BUILD
@@ -5,9 +5,14 @@ package(default_visibility = ["//visibility:public"])
 cc_binary(
     name = 'python/ops/_image_ops.so',
     srcs = [
+        "kernels/image_ops.h",
+        "kernels/image_ops.cc",
         "kernels/webp_dataset_ops.cc",
         "kernels/tiff_dataset_ops.cc",
         "ops/dataset_ops.cc",
+    ],
+    includes = [
+        ".",
     ],
     linkshared = 1,
     deps = [

--- a/tensorflow_io/image/__init__.py
+++ b/tensorflow_io/image/__init__.py
@@ -17,6 +17,7 @@
 @@WebPDataset
 @@TIFFDataset
 @@decode_webp
+@@ImageInputSequence
 """
 
 from __future__ import absolute_import
@@ -26,6 +27,7 @@ from __future__ import print_function
 from tensorflow_io.image.python.ops.image_dataset_ops import WebPDataset
 from tensorflow_io.image.python.ops.image_dataset_ops import TIFFDataset
 from tensorflow_io.image.python.ops.image_dataset_ops import decode_webp
+from tensorflow_io.image.python.ops.image_dataset_ops import ImageInputSequence
 
 from tensorflow.python.util.all_util import remove_undocumented
 
@@ -33,6 +35,7 @@ _allowed_symbols = [
     "WebPDataset",
     "TIFFDataset",
     "decode_webp",
+    "ImageInputSequence",
 ]
 
 remove_undocumented(__name__)

--- a/tensorflow_io/image/kernels/image_ops.cc
+++ b/tensorflow_io/image/kernels/image_ops.cc
@@ -1,0 +1,206 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/resource_op_kernel.h"
+#include "imageio/webpdec.h"
+#include "imageio/metadata.h"
+#include "kernels/image_ops.h"
+namespace tensorflow {
+namespace data {
+class InputSequenceInterface : public ResourceBase {
+ public:
+  virtual ~InputSequenceInterface() override {}
+  virtual Status Initialize(const std::vector<string>& names) = 0;
+  virtual Status Count(int64* count) = 0;
+  virtual Status Type(std::vector<string>* type) = 0;
+};
+class ImageInputSequence : public InputSequenceInterface {
+ public:
+  ImageInputSequence(Env* env)
+      : InputSequenceInterface(),
+        env_(env) {}
+
+  Status Initialize(const std::vector<string>& names) override {
+
+    std::vector<int32> indices;
+    indices.clear();
+    std::vector<string> types;
+    types.clear();
+
+    // First process files
+    for (int i = 0; i < names.size(); ++i) {
+      std::unique_ptr<RandomAccessFile> file;
+      TF_RETURN_IF_ERROR(env_->NewRandomAccessFile(names[i], &file));
+      char buffer[12];
+      StringPiece result;
+      TF_RETURN_IF_ERROR(file->Read(0, sizeof(buffer), &result, buffer));
+      if (memcmp(&buffer[0], "RIFF", 4) == 0 && memcmp(&buffer[8], "WEBP", 4) == 0) {
+        // WebP
+	uint64 size = 0;
+	env_->GetFileSize(names[i], &size);
+        string data;
+	data.resize(size);
+        TF_RETURN_IF_ERROR(file->Read(0, size, &result, &data[0]));
+        WebPDecoderConfig config;
+        WebPInitDecoderConfig(&config);
+        int returned = WebPGetFeatures(reinterpret_cast<const uint8_t *>(data.c_str()), size, &config.input);
+        if (returned != VP8_STATUS_OK) {
+          return errors::InvalidArgument("File could not be decoded as WebP: ", names[i]);
+        }
+        // Note: Always decode with channel = 4.
+	static const int32 channel = 4;
+	int32 height = config.input.height;
+	int32 width = config.input.width;
+
+	indices.push_back(i);
+	types.push_back("webp");
+      } else if (memcmp(&buffer[0], "II*\0", 4) == 0) {
+        // TIFF
+	TiffRandomFile f;
+	TF_RETURN_IF_ERROR(f.Open(env_, names[i]));
+	do {
+          // Note: Always decode with channel = 4.
+	  static const int32 channel = 4;
+	  int32 height;
+          int32 width;
+          // get the size of the tiff
+          TIFFGetField(f.Tiff(), TIFFTAG_IMAGEWIDTH, &width);
+          TIFFGetField(f.Tiff(), TIFFTAG_IMAGELENGTH, &height);
+	  indices.push_back(i);
+	  types.push_back("tiff");
+	} while (TIFFReadDirectory(f.Tiff()));
+      } else {
+        return errors::InvalidArgument("unable to find out the image type for: ", names[i]);
+      }
+    }
+    mutex_lock l(mu_);
+    filenames_.resize(names.size());
+    for (int i = 0; i < names.size(); ++i) {
+      filenames_[i] = names[i];
+    }
+    indices_.resize(indices.size());
+    for (int i = 0; i < indices.size(); ++i) {
+      indices_[i] = indices[i];
+    }
+    types_.resize(types.size());
+    for (int i = 0; i < types.size(); ++i) {
+      types_[i] = types[i];
+    }
+    return Status::OK();
+  }
+
+  Status Count(int64* count) override {
+    mutex_lock l(mu_);
+    *count = indices_.size();
+    return Status::OK();
+  }
+
+  Status Type(std::vector<string>* types) override {
+    mutex_lock l(mu_);
+    types->resize(types_.size());
+    for (int i = 0; i < types_.size(); i++) {
+      (*types)[i] = types_[i];
+    }
+    return Status::OK();
+  }
+
+  string DebugString() const override {
+    mutex_lock l(mu_);
+    return strings::StrCat("ImageInputSequence[]");
+  }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+  std::vector<string> filenames_ GUARDED_BY(mu_);
+  std::vector<int32> indices_ GUARDED_BY(mu_);
+  std::vector<string> types_ GUARDED_BY(mu_);
+};
+
+class ImageInputSequenceOp : public ResourceOpKernel<InputSequenceInterface> {
+ public:
+  explicit ImageInputSequenceOp(OpKernelConstruction* context)
+      : ResourceOpKernel<InputSequenceInterface>(context) {
+    env_ = context->env();
+  }
+ private:
+  void Compute(OpKernelContext* context) override {
+    ResourceOpKernel<InputSequenceInterface>::Compute(context);
+    const Tensor* filenames_tensor;
+    OP_REQUIRES_OK(context, context->input("filenames", &filenames_tensor));
+    OP_REQUIRES(
+        context, filenames_tensor->dims() <= 1,
+        errors::InvalidArgument("`filename` must be a scalar or vector."));
+
+    std::vector<string> filenames;
+    filenames.reserve(filenames_tensor->NumElements());
+    for (int i = 0; i < filenames_tensor->NumElements(); ++i) {
+      filenames.push_back(filenames_tensor->flat<string>()(i));
+    }
+
+    OP_REQUIRES_OK(context, resource_->Initialize(filenames));
+  }
+  Status CreateResource(InputSequenceInterface** sequence)
+      EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+    *sequence = new ImageInputSequence(env_);
+    return Status::OK();
+  }
+  Env* env_;
+};
+class ImageInputSequenceCountOp : public OpKernel {
+ public:
+  explicit ImageInputSequenceCountOp(OpKernelConstruction* ctx)
+      : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* context) override {
+    InputSequenceInterface* sequence;
+    OP_REQUIRES_OK(context, GetResourceFromContext(context, "sequence", &sequence));
+    int64 count = 0;
+    Status status = sequence->Count(&count);
+    sequence->Unref();
+    OP_REQUIRES_OK(context, status);
+    Tensor* count_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({}), &count_tensor));
+    count_tensor->scalar<int64>()() = count;
+  }
+};
+class ImageInputSequenceTypeOp : public OpKernel {
+ public:
+  explicit ImageInputSequenceTypeOp(OpKernelConstruction* ctx)
+      : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* context) override {
+    InputSequenceInterface* sequence;
+    OP_REQUIRES_OK(context, GetResourceFromContext(context, "sequence", &sequence));
+    std::vector<string> type;
+    Status status = sequence->Type(&type);
+    sequence->Unref();
+    OP_REQUIRES_OK(context, status);
+    Tensor* type_tensor;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({type.size()}), &type_tensor));
+    for (int i = 0; i < type.size(); i++) {
+      type_tensor->flat<string>()(i) = type[i];
+    }
+  }
+};
+REGISTER_KERNEL_BUILDER(Name("ImageInputSequence").Device(DEVICE_CPU),
+                        ImageInputSequenceOp);
+REGISTER_KERNEL_BUILDER(Name("ImageInputSequenceCount").Device(DEVICE_CPU),
+                        ImageInputSequenceCountOp);
+REGISTER_KERNEL_BUILDER(Name("ImageInputSequenceType").Device(DEVICE_CPU),
+                        ImageInputSequenceTypeOp);
+
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow_io/image/kernels/image_ops.h
+++ b/tensorflow_io/image/kernels/image_ops.h
@@ -1,0 +1,98 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/platform/file_system.h"
+#include "tiff.h"
+#include "tiffio.h"
+
+namespace tensorflow {
+namespace data {
+
+
+// Base object for wrapping TIFFClientOpen file operation callbacks
+
+class TiffFileBase {
+  std::unique_ptr<TIFF, decltype(&TIFFClose)> tif_;
+
+ public:
+  TIFF* Tiff() { return tif_.get(); }
+
+  TiffFileBase() :  tif_(nullptr, TIFFClose) {}
+  virtual ~TiffFileBase() {}
+
+ protected:
+  Status ClientOpen(const char *name, const char* mode);
+
+
+  void ClientClose() {tif_.reset(); }
+
+ public:
+  virtual size_t  TiffClientRead(void*, size_t) { return 0;}
+  virtual size_t  TiffClientWrite(void*, size_t) { return 0; }
+  virtual off_t   TiffClientSeek(off_t offset, int whence) = 0;
+  virtual int     TiffClientClose() { return 0;}
+  virtual off_t   TiffClientSize() = 0;
+  virtual int     TiffClientMap(void** base, off_t* size) { return 0;}
+  virtual void    TiffClientUnmap(void* base, off_t size) {}
+};
+
+// Use RandomAccessFile for tiff file system operation callbacks
+class TiffRandomFile : public TiffFileBase {
+ public:
+  TiffRandomFile() {}
+  ~TiffRandomFile() override  {
+    Close();
+  }
+
+  Status Open(Env *env, const string& filename) {
+    // Open Random access file
+    std::unique_ptr<RandomAccessFile> file;
+    TF_RETURN_IF_ERROR(env->NewRandomAccessFile(filename, &file));
+    // Read Size and hope we get same file as above
+    uint64 size = 0;
+    TF_RETURN_IF_ERROR(env->GetFileSize(filename, &size));
+    // Open Tiff
+    fileSize_ = static_cast<off_t>(size);
+    offset_ = 0;
+    file_ = std::move(file);
+    Status s = ClientOpen(filename.c_str(), "rm");
+    if (!s.ok()) {
+      file_.reset();
+    }
+    return s;
+  }
+
+  bool IsOpen() {
+    return static_cast<bool>(file_);
+  }
+
+  void Close() {
+    ClientClose();
+    file_.reset();
+  }
+
+ private:
+  size_t  TiffClientRead(void*, size_t) override;
+  off_t   TiffClientSeek(off_t offset, int whence) override;
+  int     TiffClientClose() override;
+  off_t   TiffClientSize() override;
+
+  std::unique_ptr<RandomAccessFile> file_;
+  off_t fileSize_;
+  off_t offset_;
+};
+
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow_io/image/ops/dataset_ops.cc
+++ b/tensorflow_io/image/ops/dataset_ops.cc
@@ -49,4 +49,27 @@ REGISTER_OP("DecodeWebP")
       return Status::OK();
     });
 
+REGISTER_OP("ImageInputSequence")
+    .Input("filenames: string")
+    .Output("sequence: resource")
+    .Attr("container: string = ''")
+    .Attr("shared_name: string = ''")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::ScalarShape);
+
+REGISTER_OP("ImageInputSequenceCount")
+    .Input("sequence: resource")
+    .Output("count: int64")
+    .SetIsStateful()
+    .SetShapeFn(shape_inference::ScalarShape);
+
+REGISTER_OP("ImageInputSequenceType")
+    .Input("sequence: resource")
+    .Output("type: string")
+    .SetIsStateful()
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+       c->set_output(0, c->MakeShape({-1}));
+       return Status::OK();
+     });
+
 }  // namespace tensorflow

--- a/tensorflow_io/image/python/ops/image_dataset_ops.py
+++ b/tensorflow_io/image/python/ops/image_dataset_ops.py
@@ -98,3 +98,15 @@ def decode_webp(contents, name=None):
     A `Tensor` of type `uint8` and shape of `[height, width, 4]` (RGBA).
   """
   return image_ops.decode_web_p(contents, name=name)
+
+class ImageInputSequence:
+  def __init__(self, filenames):
+    self._filenames = tensorflow.convert_to_tensor(
+        filenames, dtype=dtypes.string, name="filenames")
+    self._resource = image_ops.image_input_sequence(filenames=filenames)
+
+  def count(self):
+    return image_ops.image_input_sequence_count(self._resource)
+
+  def type(self):
+    return image_ops.image_input_sequence_type(self._resource)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -32,6 +32,18 @@ import tensorflow_io.image as image_io
 
 from tensorflow import test
 
+def test_image_input_sequence():
+  webp_filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_image", "sample.webp")
+  tiff_filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_image", "small.tiff")
+
+  seq = image_io.ImageInputSequence([webp_filename, tiff_filename])
+  seq_count = seq.count()
+  seq_type = seq.type()
+  # One frame for sample.webp, 5 frames for small.tiff
+  with tensorflow.compat.v1.Session() as sess:
+    assert sess.run(seq_count) == 6
+    assert (sess.run(seq_type) == ["webp", "tiff", "tiff", "tiff", "tiff", "tiff"]).all()
+
 class ImageDatasetTest(test.TestCase):
 
   def test_decode_webp(self):


### PR DESCRIPTION
This PR adds an ImageInputSequence class so that metadata information
of a list of images (one image could have multiple frames) is stored
as a resource. The meta data information could later be
obtained without re-compute (as the information are static).

At the moment two methods are added: `count()` which returns
the number of frames, and `type()` which returns the fourcc
file type of each frame.

Additional meta data information could be added later.

This PR is inspired by #109.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
