### PR TITLE
Disable Kinesis test on macOS

### DIFF
--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -28,6 +28,8 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import sys
+import pytest
 import boto3
 
 import tensorflow
@@ -39,6 +41,9 @@ from tensorflow import test                # pylint: disable=wrong-import-positi
 from tensorflow.compat.v1 import data      # pylint: disable=wrong-import-position
 
 import tensorflow_io.kinesis as kinesis_io # pylint: disable=wrong-import-position
+
+if sys.platform == "darwin":
+  pytest.skip("kinesis/localstack is failing on macOS", allow_module_level=True)
 
 class KinesisDatasetTest(test.TestCase):
   """Tests for KinesisDataset."""


### PR DESCRIPTION
The localstack (kinesis emulator) is failing on macOS,
this fix temporarily disables kinesis tests on macOS.
Note our support on macOS is best effort, with pubsub
and kinesis disabled, and video not enabled.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>