### PR TITLE
Update to use tensorflow==2.0.0alpha for preview version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
   - stage: release
     name: "TensorFlow 2.0 Preview Release Build on Linux"
     script:
-    - docker run -i -t --rm -v $PWD:/v -v $PWD/.cache/pip/:/root/.cache/pip -w /v --net=host buildpack-deps:14.04 bash -x -e .travis/python.release.sh tf-nightly-2.0-preview --preview ${TRAVIS_BUILD_NUMBER} python python3.6
+    - docker run -i -t --rm -v $PWD:/v -v $PWD/.cache/pip/:/root/.cache/pip -w /v --net=host buildpack-deps:14.04 bash -x -e .travis/python.release.sh tensorflow==2.0.0alpha --preview ${TRAVIS_BUILD_NUMBER} python python3.6
     - docker run -i -t --rm -v $PWD:/v -v $PWD/.cache/pip/:/root/.cache/pip -w /v --net=host buildpack-deps:18.04 bash -x -e .travis/wheel.test.sh
     after_success:
     - |
@@ -80,7 +80,7 @@ jobs:
     os: osx
     osx_image: xcode9
     script:
-    - sudo -H bash -x -e .travis/python.release.sh tf-nightly-2.0-preview --preview ${TRAVIS_BUILD_NUMBER} python
+    - sudo -H bash -x -e .travis/python.release.sh tensorflow==2.0.0alpha --preview ${TRAVIS_BUILD_NUMBER} python
     - sudo -H bash -x -e .travis/wheel.test.sh
     after_success:
     - |

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ if '--nightly' in sys.argv:
 if '--preview' in sys.argv:
   preview_idx = sys.argv.index('--preview')
   version = version + ".dev" + sys.argv[preview_idx + 1]
-  package = 'tf-nightly-2.0-preview'
+  package = 'tensorflow==2.0.0alpha'
   project = 'tensorflow-io-2.0-preview'
   sys.argv.remove('--preview')
   sys.argv.pop(preview_idx)


### PR DESCRIPTION
Change preview to use tensorflow==2.0.0alpha to stabilize and use 2.0 alpha version.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>