### PR TITLE
Add pylint instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ $ bash -x -e tests/test_kafka/kafka_test.sh start kafka
 $ bash -x -e tests/test_kinesis/kinesis_test.sh start kinesis
 ```
 
+#### Running Python Style Checks
+
+Style checks for Python can be run with the following commands:
+
+```sh
+$ curl -o .pylint -sSL https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/tools/ci_build/pylintrc
+$ find . -name '*.py' | xargs pylint --rcfile=.pylint
+```
+
 ### R
 
 We provide a reference Dockerfile [here](R-package/scripts/Dockerfile) for you

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -37,6 +37,7 @@ ARG PIP_ADD_PACKAGES=""
 
 RUN /bin/bash -c "source activate tfio-dev && python -m pip install \
     pytest \
+    pylint \
     boto3 \
     pyarrow==${ARROW_VERSION} \
     pandas \


### PR DESCRIPTION
Add instructions for running pylint style checks to README.md and add pylint module to dev docker image.