### PR TITLE
Fix kafka message eof

### DIFF
--- a/tensorflow_io/kafka/kernels/kafka_dataset_ops.cc
+++ b/tensorflow_io/kafka/kernels/kafka_dataset_ops.cc
@@ -136,15 +136,16 @@ class KafkaDatasetOp : public DatasetOpKernel {
                 return Status::OK();
               }
 
-              if (message->err() == RdKafka::ERR__PARTITION_EOF &&
-                  dataset()->eof_) {
-                // EOF current topic
-                break;
+              if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+                  if (dataset()->eof_) break;
               }
-              if (message->err() != RdKafka::ERR__TIMED_OUT) {
-                return errors::Internal("Failed to consume:",
+              else {
+                  if (message->err() != RdKafka::ERR__TIMED_OUT) {
+                      return errors::Internal("Failed to consume:",
                                         message->errstr());
+                  }
               }
+
               message.reset(nullptr);
               consumer_->poll(0);
             }


### PR DESCRIPTION
Old code logic has bug when message reach "RdKafka::ERR__PARTITION_EOF" and eof_ is False

If eof_ is False and reach PARTITION_EOF, then it goes to line 145 then return "Failed to consume:".