### PR TITLE
Add zlib dependency to libarchive.BUILD

### DIFF
--- a/third_party/libarchive.BUILD
+++ b/third_party/libarchive.BUILD
@@ -33,6 +33,9 @@ cc_library(
         "libarchive",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@zlib",
+    ],
 )
 
 genrule(


### PR DESCRIPTION
With the addition of #140, the libarchive build is dependent on the zlib library. This PR adds zlib as a dependency to libarchive.BUILD