### PR TITLE
Fix soname issue in tf-nightly (and 1.14.0)

### DIFF
--- a/config_helper.py
+++ b/config_helper.py
@@ -75,6 +75,13 @@ def write_config():
 
       bazel_rc.write('build --action_env TF_SHARED_LIBRARY_DIR="{}"\n'
                      .format(libdir_list[0][2:]))
+      library_name = library_list[0][2:]
+      if library_name.startswith(":"):
+        library_name = library_name[1:]
+      else:
+        library_name = "lib" + library_name + ".so"
+      bazel_rc.write('build --action_env TF_SHARED_LIBRARY_NAME="{}"\n'
+                     .format(library_name))
       bazel_rc.close()
   except OSError:
     print("ERROR: Writing .bazelrc")

--- a/third_party/tf/tf_configure.bzl
+++ b/third_party/tf/tf_configure.bzl
@@ -2,6 +2,7 @@
 
 _TF_HEADER_DIR = "TF_HEADER_DIR"
 _TF_SHARED_LIBRARY_DIR = "TF_SHARED_LIBRARY_DIR"
+_TF_SHARED_LIBRARY_NAME = "TF_SHARED_LIBRARY_NAME"
 
 def _tpl(repository_ctx, tpl, substitutions = {}, out = None):
     if not out:
@@ -182,14 +183,15 @@ def _tf_pip_impl(repository_ctx):
     )
 
     tf_shared_library_dir = repository_ctx.os.environ[_TF_SHARED_LIBRARY_DIR]
-    tf_shared_library_path = "%s/libtensorflow_framework.so" % tf_shared_library_dir
+    tf_shared_library_name = repository_ctx.os.environ[_TF_SHARED_LIBRARY_NAME]
+    tf_shared_library_path = "%s/%s" % (tf_shared_library_dir, tf_shared_library_name)
     tf_shared_library_rule = _symlink_genrule_for_dir(
         repository_ctx,
         None,
         "",
         "libtensorflow_framework.so",
         [tf_shared_library_path],
-        ["libtensorflow_framework.so"],
+        [tf_shared_library_name],
     )
 
     _tpl(repository_ctx, "BUILD", {
@@ -202,5 +204,6 @@ tf_configure = repository_rule(
     environ = [
         _TF_HEADER_DIR,
         _TF_SHARED_LIBRARY_DIR,
+        _TF_SHARED_LIBRARY_NAME,
     ],
 )


### PR DESCRIPTION
Looks like tf-nightly (and potentially tf 1.14.0) changes the shared object extension, so update of the build script is needed.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>