### PR TITLE
Add batch support for MNISTDataset

### DIFF
--- a/tensorflow_io/cifar/ops/dataset_ops.cc
+++ b/tensorflow_io/cifar/ops/dataset_ops.cc
@@ -21,6 +21,7 @@ namespace tensorflow {
 
 REGISTER_OP("CIFAR10Dataset")
     .Input("input: T")
+    .Input("batch: int64")
     .Output("handle: variant")
     .Attr("output_types: list(type) >= 1")
     .Attr("output_shapes: list(shape) >= 1")
@@ -30,6 +31,7 @@ REGISTER_OP("CIFAR10Dataset")
 
 REGISTER_OP("CIFAR100Dataset")
     .Input("input: T")
+    .Input("batch: int64")
     .Output("handle: variant")
     .Attr("output_types: list(type) >= 1")
     .Attr("output_shapes: list(shape) >= 1")

--- a/tensorflow_io/core/kernels/dataset_ops.h
+++ b/tensorflow_io/core/kernels/dataset_ops.h
@@ -19,6 +19,7 @@ limitations under the License.
 #define EIGEN_USE_THREADS
 
 #include "tensorflow/core/framework/dataset.h"
+#include "tensorflow/core/util/batch_util.h"
 #include "tensorflow/core/lib/io/inputstream_interface.h"
 #include "tensorflow/core/lib/io/random_inputstream.h"
 #include "tensorflow/core/lib/io/zlib_compression_options.h"
@@ -152,7 +153,7 @@ class DataInput {
   DataInput() {}
   virtual ~DataInput() {}
   virtual Status FromStream(io::InputStreamInterface& s) = 0;
-  virtual Status ReadRecord(io::InputStreamInterface& s, IteratorContext* ctx, std::unique_ptr<T>& state, int64* returned, std::vector<Tensor>* out_tensors) const = 0;
+  virtual Status ReadRecord(io::InputStreamInterface& s, IteratorContext* ctx, std::unique_ptr<T>& state, int64 record_to_read, int64* record_read, std::vector<Tensor>* out_tensors) const = 0;
   virtual void EncodeAttributes(VariantTensorData* data) const = 0;
   virtual bool DecodeAttributes(const VariantTensorData& data) = 0;
 
@@ -298,10 +299,11 @@ class DataInputOp: public OpKernel {
 template<typename InputType, typename StateType>
 class InputDatasetBase : public DatasetBase {
  public:
-  InputDatasetBase(OpKernelContext* ctx, const std::vector<InputType>& input, const DataTypeVector& output_types, const std::vector<PartialTensorShape>& output_shapes)
+  InputDatasetBase(OpKernelContext* ctx, const std::vector<InputType>& input, const int64 batch, const DataTypeVector& output_types, const std::vector<PartialTensorShape>& output_shapes)
       : DatasetBase(DatasetContext(ctx)),
         ctx_(ctx),
         input_(input),
+        batch_(batch),
         output_types_(output_types),
         output_shapes_(output_shapes) {}
 
@@ -339,7 +341,11 @@ class InputDatasetBase : public DatasetBase {
       input_tensor.flat<string>()(i) = message;
     }
     TF_RETURN_IF_ERROR(b->AddTensor(input_tensor, &input_node));
-    TF_RETURN_IF_ERROR(b->AddDataset(this, {input_node }, node));
+    Node* batch_node;
+    Tensor batch_tensor(DT_INT64, TensorShape({}));
+    batch_tensor.scalar<int64>()() = batch_;
+    TF_RETURN_IF_ERROR(b->AddTensor(batch_tensor, &batch_node));
+    TF_RETURN_IF_ERROR(b->AddDataset(this, {input_node, batch_node}, node));
     return Status::OK();
   }
  private:
@@ -353,12 +359,46 @@ class InputDatasetBase : public DatasetBase {
                            std::vector<Tensor>* out_tensors,
                            bool* end_of_sequence) override {
       mutex_lock l(mu_);
-      do {
+      int64 returned = 0;
+      int64 count = dataset()->batch_ == 0 ? 1 : dataset()->batch_;
+      std::vector<Tensor> prefix_tensors;
+      while (returned < count) {
         if (stream_) {
-	  int64 count = 1;
-          int64 returned = 0;
-          TF_RETURN_IF_ERROR(dataset()->input_[current_input_index_].ReadRecord((*stream_.get()), ctx, current_input_state_, &returned, out_tensors));
+          int64 record_read = 0;
+          int64 record_to_read = count - returned;
+          TF_RETURN_IF_ERROR(dataset()->input_[current_input_index_].ReadRecord((*stream_.get()), ctx, current_input_state_, count - returned, &record_read, out_tensors));
+          if (record_read > 0) {
+            if (prefix_tensors.size() != 0) {
+              for (size_t i = 0; i < prefix_tensors.size(); i++) {
+                TensorShape shape = prefix_tensors[i].shape();
+                shape.set_dim(0, shape.dim_size(0) + record_read);
+                Tensor value_tensor(ctx->allocator({}), prefix_tensors[i].dtype(), shape);
+                TensorShape element_shape = shape;
+                element_shape.RemoveDim(0);
+                Tensor element(ctx->allocator({}), prefix_tensors[i].dtype(), element_shape);
+                for (size_t index = 0; index < prefix_tensors[i].shape().dim_size(0); index++) {
+                  TF_RETURN_IF_ERROR(batch_util::CopySliceToElement(prefix_tensors[i], &element, index));
+                  TF_RETURN_IF_ERROR(batch_util::CopyElementToSlice(element, &value_tensor, index));
+                }
+                for (size_t index = 0; index < record_read; index++) {
+                  TF_RETURN_IF_ERROR(batch_util::CopySliceToElement((*out_tensors)[i], &element, index));
+                  TF_RETURN_IF_ERROR(batch_util::CopyElementToSlice(element, &value_tensor, prefix_tensors[i].shape().dim_size(0) + index));
+                }
+                (*out_tensors)[i] = std::move(value_tensor);
+              }
+            }
+            returned += record_read;
+          }
           if (returned == count) {
+            if (dataset()->batch_ == 0) {
+              for (size_t i = 0; i < out_tensors->size(); i++) {
+                TensorShape shape = (*out_tensors)[i].shape();
+                shape.RemoveDim(0);
+                Tensor value_tensor(ctx->allocator({}), (*out_tensors)[i].dtype(), shape);
+                value_tensor.CopyFrom((*out_tensors)[i], shape);
+                (*out_tensors)[i] = std::move(value_tensor);
+              }
+            }
             *end_of_sequence = false;
             return Status::OK();
           }
@@ -368,12 +408,25 @@ class InputDatasetBase : public DatasetBase {
         }
         // Iteration ends when there are no more input to process.
         if (current_input_index_ == dataset()->input_.size()) {
+          if (out_tensors->size() != 0) {
+            if (dataset()->batch_ == 0) {
+              for (size_t i = 0; i < out_tensors->size(); i++) {
+                TensorShape shape = (*out_tensors)[i].shape();
+                shape.RemoveDim(0);
+                Tensor value_tensor(ctx->allocator({}), (*out_tensors)[i].dtype(), shape);
+                value_tensor.CopyFrom((*out_tensors)[i], shape);
+                (*out_tensors)[i] = std::move(value_tensor);
+              }
+            }
+            *end_of_sequence = false;
+            return Status::OK();
+          }
           *end_of_sequence = true;
           return Status::OK();
         }
 
         TF_RETURN_IF_ERROR(SetupStreamsLocked(ctx->env()));
-      } while (true);
+      };
     }
 
    private:
@@ -450,6 +503,7 @@ class InputDatasetBase : public DatasetBase {
   OpKernelContext* ctx_;
  protected:
   std::vector<InputType> input_;
+  int64 batch_;
   const DataTypeVector output_types_;
   const std::vector<PartialTensorShape> output_shapes_;
 };
@@ -490,7 +544,10 @@ class InputDatasetOp : public DatasetOpKernel {
         input.emplace_back(entry);
       }
     }
-    *output = new InputDatasetBase<InputType, StateType>(ctx, input, output_types_, output_shapes_);
+    const Tensor* batch_tensor;
+    OP_REQUIRES_OK(ctx, ctx->input("batch", &batch_tensor));
+    int64 batch = batch_tensor->scalar<int64>()();
+    *output = new InputDatasetBase<InputType, StateType>(ctx, input, batch, output_types_, output_shapes_);
   }
   DataTypeVector output_types_;
   std::vector<PartialTensorShape> output_shapes_;

--- a/tensorflow_io/mnist/ops/dataset_ops.cc
+++ b/tensorflow_io/mnist/ops/dataset_ops.cc
@@ -21,24 +21,26 @@ namespace tensorflow {
 
 REGISTER_OP("MNISTImageDataset")
     .Input("input: T")
+    .Input("batch: int64")
     .Output("handle: variant")
     .Attr("output_types: list(type) >= 1")
     .Attr("output_shapes: list(shape) >= 1")
     .Attr("T: {string, variant} = DT_VARIANT")
     .SetIsStateful()
     .SetShapeFn([](shape_inference::InferenceContext* c) {
-       c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
+       c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim(), c->UnknownDim()}));
        return Status::OK();
      });
 REGISTER_OP("MNISTLabelDataset")
     .Input("input: T")
+    .Input("batch: int64")
     .Output("handle: variant")
     .Attr("output_types: list(type) >= 1")
     .Attr("output_shapes: list(shape) >= 1")
     .Attr("T: {string, variant} = DT_VARIANT")
     .SetIsStateful()
     .SetShapeFn([](shape_inference::InferenceContext* c) {
-       c->set_output(0, c->MakeShape({}));
+       c->set_output(0, c->MakeShape({c->UnknownDim()}));
        return Status::OK();
      });
 

--- a/tensorflow_io/text/ops/text_ops.cc
+++ b/tensorflow_io/text/ops/text_ops.cc
@@ -30,6 +30,7 @@ REGISTER_OP("TextInput")
 
 REGISTER_OP("TextDataset")
     .Input("input: T")
+    .Input("batch: int64")
     .Output("handle: variant")
     .Attr("output_types: list(type) >= 1")
     .Attr("output_shapes: list(shape) >= 1")

--- a/tensorflow_io/text/python/ops/text_ops.py
+++ b/tensorflow_io/text/python/ops/text_ops.py
@@ -27,13 +27,14 @@ class TextDataset(data.Dataset):
   """A Text Dataset
   """
 
-  def __init__(self, filename):
+  def __init__(self, filename, batch=None):
     """Create a Text Reader.
 
     Args:
       filename: A `tf.string` tensor containing one or more filenames.
     """
     self._data_input = text_ops.text_input(filename, ["none", "gz"])
+    self._batch = 0 if batch is None else batch
     super(TextDataset, self).__init__()
 
   def _inputs(self):
@@ -42,12 +43,15 @@ class TextDataset(data.Dataset):
   def _as_variant_tensor(self):
     return text_ops.text_dataset(
         self._data_input,
+        self._batch,
         output_types=self.output_types,
         output_shapes=self.output_shapes)
 
   @property
   def output_shapes(self):
-    return tuple([tensorflow.TensorShape([])])
+    return tuple([
+        tensorflow.TensorShape([])]) if self._batch == 0 else tuple([
+            tensorflow.TensorShape([None])])
 
   @property
   def output_classes(self):

--- a/tests/test_cifar.py
+++ b/tests/test_cifar.py
@@ -46,7 +46,7 @@ class CIFARDatasetTest(test.TestCase):
 
     num_repeats = 2
 
-    dataset = cifar_io.CIFAR10Dataset(filename).repeat(
+    dataset = cifar_io.CIFAR10Dataset(filename, batch=3).repeat(
         num_repeats)
     iterator = data.make_initializable_iterator(dataset)
     init_op = iterator.initializer
@@ -55,10 +55,19 @@ class CIFARDatasetTest(test.TestCase):
     with self.cached_session() as sess:
       sess.run(init_op)
       for _ in range(num_repeats):  # Dataset is repeated.
-        for i in range(50000):
+        for i in range(16666):
           image, label = sess.run(get_next)
-          self.assertAllEqual(image, x_train[i])
-          self.assertEqual(label, y_train[i])
+          self.assertAllEqual(image[0], x_train[i*3+0])
+          self.assertEqual(label[0], y_train[i*3+0])
+          self.assertAllEqual(image[1], x_train[i*3+1])
+          self.assertEqual(label[1], y_train[i*3+1])
+          self.assertAllEqual(image[2], x_train[i*3+2])
+          self.assertEqual(label[2], y_train[i*3+2])
+        image, label = sess.run(get_next)
+        self.assertAllEqual(image[0], x_train[49998])
+        self.assertEqual(label[0], y_train[49998])
+        self.assertAllEqual(image[1], x_train[49999])
+        self.assertEqual(label[1], y_train[49999])
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 

--- a/tests/test_mnist_eager.py
+++ b/tests/test_mnist_eager.py
@@ -41,7 +41,7 @@ def test_mnist_tutorial():
       image_filename,
       label_filename)
 
-  d_train = d_train.map(lambda x, y: (tf.image.convert_image_dtype(x, tf.float32), y)).batch(32)
+  d_train = d_train.map(lambda x, y: (tf.image.convert_image_dtype(x, tf.float32), y)).batch(1000)
 
   model = tf.keras.models.Sequential([
       tf.keras.layers.Flatten(input_shape=(28, 28)),
@@ -72,7 +72,7 @@ def test_mnist_tutorial_uncompressed():
       image_filename,
       label_filename)
 
-  d_train = d_train.map(lambda x, y: (tf.image.convert_image_dtype(x, tf.float32), y)).batch(32)
+  d_train = d_train.map(lambda x, y: (tf.image.convert_image_dtype(x, tf.float32), y)).batch(1)
 
   model = tf.keras.models.Sequential([
       tf.keras.layers.Flatten(input_shape=(28, 28)),

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -39,20 +39,20 @@ def test_text_input():
       os.path.dirname(os.path.abspath(__file__)), "test_text", "lorem.txt.gz")
   gzip_text_filename = "file://" + gzip_text_filename
 
-  num_repeats = 2
-
-  filenames = [text_filename, gzip_text_filename]
-  dataset = text_io.TextDataset(filenames).repeat(num_repeats)
+  lines = lines * 3
+  filenames = [text_filename, gzip_text_filename, text_filename]
+  dataset = text_io.TextDataset(filenames, batch=2)
   iterator = dataset.make_initializable_iterator()
   init_op = iterator.initializer
   get_next = iterator.get_next()
   with tensorflow.compat.v1.Session() as sess:
     sess.run(init_op)
-    for _ in range(num_repeats):
-      for _ in filenames:
-        for i in lines:
-          v = sess.run(get_next)
-          assert i == v
+    for i in range(0, len(lines) - 2, 2):
+      v = sess.run(get_next)
+      assert lines[i] == v[0]
+      assert lines[i + 1] == v[1]
+    v = sess.run(get_next)
+    assert lines[len(lines) - 1] == v[0]
     with pytest.raises(errors.OutOfRangeError):
       sess.run(get_next)
 


### PR DESCRIPTION
This fix add batch support for MNISTDataset. Originally, Dataset does not have a built in batch support at the time of Dataset creation. The batch is typically specified with `batch(n)` call. This helps with low memory footprint but may not be performance when working with small records data where each record may only have several bytes.

This fix adds the option to specify the batch at creation, and allows to read a batch (e.g, 1000) to improve I/O throughput.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>