### PR TITLE
Change dev Docker image to use tensorflow:custom-op as base

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,14 +1,13 @@
-FROM ubuntu:18.04
+FROM tensorflow/tensorflow:custom-op
 
 RUN apt-get update && \
     apt-get install -y \
-    build-essential \
     curl \
     nano \
     unzip \
     ffmpeg
 
-ARG BAZEL_VERSION=0.20.0
+ARG BAZEL_VERSION=0.24.1
 ARG BAZEL_OS=linux
 
 RUN curl -sL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh -o bazel-install.sh && \
@@ -39,6 +38,7 @@ RUN /bin/bash -c "source activate tfio-dev && python -m pip install \
     pytest \
     pylint \
     boto3 \
+    google-cloud-pubsub==0.39.1 \
     pyarrow==${ARROW_VERSION} \
     pandas \
     ${PIP_ADD_PACKAGES} \


### PR DESCRIPTION
This changes the tensorflow-io developer Docker file to be based from tensorflow/tensorflow:custom-op. Using this base image gives us Ubuntu 14.04 and gcc 4.8, which is in-line with what TensorFlow is using to allow for better compatibility. The remaining dev image stays the same, installing a newer Bazel version and conda environment with required packages for building/testing.

Fixes #173 