### PR TITLE
Ignore build/ directory only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ tfio_*.tar.gz
 
 # Setuptools
 *.egg-info
-build
+build/
 dist
 wheelhouse
 


### PR DESCRIPTION
In case-insensitive file systems, such as MacOS, or linux docker running on MacOS, etc. 'build'  entry will match 'BUILD' filenames, results in BUILD file changes silently ignored, which can be very confusing as local build/test would succeed, but pre-review CI would fail.