### PR TITLE
* Actually allow allowed symbols

### DIFF
--- a/tensorflow_io/arrow/__init__.py
+++ b/tensorflow_io/arrow/__init__.py
@@ -35,4 +35,4 @@ _allowed_symbols = [
     "ArrowStreamDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/bigtable/__init__.py
+++ b/tensorflow_io/bigtable/__init__.py
@@ -35,4 +35,4 @@ _allowed_symbols = [
     'BigtableTable',
 ]
 
-remove_undocumented(__name__, _allowed_symbols)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/cifar/__init__.py
+++ b/tensorflow_io/cifar/__init__.py
@@ -32,4 +32,4 @@ _allowed_symbols = [
     "CIFAR100Dataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/hadoop/__init__.py
+++ b/tensorflow_io/hadoop/__init__.py
@@ -29,4 +29,4 @@ _allowed_symbols = [
     "SequenceFileDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/ignite/__init__.py
+++ b/tensorflow_io/ignite/__init__.py
@@ -39,4 +39,4 @@ _allowed_symbols = [
     "IgniteDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/image/__init__.py
+++ b/tensorflow_io/image/__init__.py
@@ -38,4 +38,4 @@ _allowed_symbols = [
     "decode_webp",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/kafka/__init__.py
+++ b/tensorflow_io/kafka/__init__.py
@@ -35,4 +35,4 @@ _allowed_symbols = [
     "write_kafka",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/kinesis/__init__.py
+++ b/tensorflow_io/kinesis/__init__.py
@@ -29,4 +29,4 @@ _allowed_symbols = [
     "KinesisDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/libsvm/__init__.py
+++ b/tensorflow_io/libsvm/__init__.py
@@ -32,4 +32,4 @@ _allowed_symbols = [
     "decode_libsvm",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/lmdb/__init__.py
+++ b/tensorflow_io/lmdb/__init__.py
@@ -29,4 +29,4 @@ _allowed_symbols = [
     "LMDBDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/mnist/__init__.py
+++ b/tensorflow_io/mnist/__init__.py
@@ -35,4 +35,4 @@ _allowed_symbols = [
     "MNISTLabelDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/parquet/__init__.py
+++ b/tensorflow_io/parquet/__init__.py
@@ -29,4 +29,4 @@ _allowed_symbols = [
     "ParquetDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/pubsub/__init__.py
+++ b/tensorflow_io/pubsub/__init__.py
@@ -29,4 +29,4 @@ _allowed_symbols = [
     "PubSubDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/text/__init__.py
+++ b/tensorflow_io/text/__init__.py
@@ -32,4 +32,4 @@ _allowed_symbols = [
     "TextDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/video/__init__.py
+++ b/tensorflow_io/video/__init__.py
@@ -29,4 +29,4 @@ _allowed_symbols = [
     "VideoDataset",
 ]
 
-remove_undocumented(__name__)
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)


### PR DESCRIPTION
[`remove_undocumented` ](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/util/all_util.py#L86) removes undocumented symbols from the module, but allow exceptions to be passed via `allowed_exception_list` argument. These packages defined allowed symbols but forgot to pass them into `remove_undocumented` and thus has no effect. Actually, since all these symbols are documented so passing them to the function has no effect either, but this PR fixed the intention.