### PR TITLE
Add initial Kokorun script

### DIFF
--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+# Make sure we're in the project root path.
+SCRIPT_DIR=$( cd ${0%/*} && pwd -P )
+ROOT_DIR=$( cd "$SCRIPT_DIR/.." && pwd -P )
+if [[ ! -d "tensorflow_io" ]]; then
+    echo "ERROR: PWD: $PWD is not project root"
+    exit 1
+fi
+
+set -x
+
+PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
+
+if [[ ${PLATFORM} == "darwin" ]]; then
+    N_JOBS=$(sysctl -n hw.ncpu)
+else
+    N_JOBS=$(grep -c ^processor /proc/cpuinfo)
+fi
+
+
+echo ""
+echo "Bazel will use ${N_JOBS} concurrent job(s)."
+echo ""
+
+export CC_OPT_FLAGS='-mavx'
+export TF_NEED_CUDA=0 # TODO: Verify this is used in GPU custom-op
+
+export PYTHON_BIN_PATH=`which python`
+python --version
+python -m pip --version
+docker  --version
+
+## Run bazel build command.
+bazel build -s \
+  --verbose_failures \
+  --test_output=errors \
+  -- //tensorflow_io/...
+
+exit $?


### PR DESCRIPTION
This is the initial setup of kokorun script.

The script is located in `.kokorun/io_cpu.sh`, so something like `bash -e .kokorun/io_cpu.sh` or `.kokorun/io.cpu.sh` will invoke the script.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>