### PR TITLE
Remove unintended question mark symbol in OSS README

### DIFF
--- a/tensorflow_io/oss/README.md
+++ b/tensorflow_io/oss/README.md
@@ -23,7 +23,7 @@ from tensorflow.python.platform import gfile
 
 gfile.MkDir('oss://your_bucket_name/test_dir')
 ```
-
+
 With the extension installed, OSS files can be use with Dataset Ops, etc., in the same fashion as other files.
 
 ```python


### PR DESCRIPTION
This is not shown in the diff though. You'll be able to see the question mark symbol when you view the actual markdown file.