### PR TITLE
Enable Kafka test on macOS

### DIFF
--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import sys
 import time
 import pytest
 
@@ -31,9 +30,6 @@ from tensorflow import test            # pylint: disable=wrong-import-position
 from tensorflow.compat.v1 import data  # pylint: disable=wrong-import-position
 
 import tensorflow_io.kafka as kafka_io # pylint: disable=wrong-import-position
-
-if sys.platform == "darwin":
-  pytest.skip("kafka is failing on macOS", allow_module_level=True)
 
 class KafkaDatasetTest(test.TestCase):
   """Tests for KafkaDataset."""


### PR DESCRIPTION
I think issue #131 likely should have be fixed by PR #192,
so give it a try to enable Kafka on macOS.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>