### PR TITLE
Add linkstatic = True for cc_library

### DIFF
--- a/tensorflow_io/bigtable/BUILD
+++ b/tensorflow_io/bigtable/BUILD
@@ -77,6 +77,7 @@ cc_library(
         "-std=c++11",
         "-DNDEBUG",
     ],
+    linkstatic = True,
     deps = [
         "@com_github_googlecloudplatform_google_cloud_cpp//google/cloud/bigtable:bigtable_client",
         "@com_googlesource_code_re2//:re2",
@@ -95,6 +96,7 @@ cc_library(
         "-std=c++11",
         "-DNDEBUG",
     ],
+    linkstatic = True,
     deps = [
         "@com_github_googlecloudplatform_google_cloud_cpp//google/cloud/bigtable:bigtable_client",
         "@local_config_tf//:libtensorflow_framework",

--- a/tensorflow_io/cifar/BUILD
+++ b/tensorflow_io/cifar/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "-std=c++11",
         "-DNDEBUG",
     ],
+    linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",
     ],

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -15,6 +15,7 @@ cc_library(
     includes = [
         ".",
     ],
+    linkstatic = True,
     deps = [
         "@libarchive",
         "@local_config_tf//:libtensorflow_framework",
@@ -35,6 +36,7 @@ cc_library(
     includes = [
         ".",
     ],
+    linkstatic = True,
     deps = [
         "@libarchive",
         "@local_config_tf//:libtensorflow_framework",

--- a/tensorflow_io/mnist/BUILD
+++ b/tensorflow_io/mnist/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "-std=c++11",
         "-DNDEBUG",
     ],
+    linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",
     ],

--- a/tensorflow_io/text/BUILD
+++ b/tensorflow_io/text/BUILD
@@ -17,6 +17,7 @@ cc_library(
     includes = [
         ".",
     ],
+    linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",
         "//tensorflow_io/core:sequence_ops",


### PR DESCRIPTION
For some reason, bazel will create two copies of libraries
(one in .a and one in .so) with cc_library if `linkstatic = True`
is not specified. That created duplicated .so files that are not
needed. This fix adds `linkstatic = True` to cc_library
so that no unneeded .so are distributed in whl files.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>