### PR TITLE
Migrate MNIST to 2.0 tf.data.Dataset 

### DIFF
--- a/tensorflow_io/core/python/ops/data_ops.py
+++ b/tensorflow_io/core/python/ops/data_ops.py
@@ -1,0 +1,50 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dataset."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+class Dataset(tf.compat.v2.data.Dataset):
+  """A base Dataset"""
+
+  def __init__(self, fn, data_input, batch, dtypes, shapes):
+    """Create a base Dataset."""
+    self._fn = fn
+    self._data_input = data_input
+    self._batch = 0 if batch is None else batch
+    self._dtypes = dtypes
+    self._shapes = shapes
+    super(Dataset, self).__init__(fn(
+        self._data_input,
+        self._batch,
+        output_types=self._dtypes,
+        output_shapes=self._shapes))
+
+  def _inputs(self):
+    return []
+
+  @property
+  def _element_structure(self):
+    e = [
+        tf.data.experimental.TensorStructure(
+            p, q.as_list()) for (p, q) in zip(
+                self._dtypes, self._shapes)
+    ]
+    if len(e) == 1:
+      return e[0]
+    return tf.data.experimental.NestedStructure(e)


### PR DESCRIPTION
With the upcoming TF 1.14.0 (rc0 released, final could be released in several weeks) and TF 2.0 beta  (expected to be released next week) release. It is time for us to move forward with 2.0 version of the tf.data.Dataset.

There are lots of changes in tf.data.DatasetV2. The biggest one being iteration now could be done in eager mode with `for ...` (instead of the previous awkward `tf.Session.run()` iteration).

For tensorflow-io, one immediate question is: with the co-existence of 1.x and 2.0, what should we support? I was also asked multiple times about what exactly is the advantage of using tf.data pipeline vs. graph with custom-written ops.

For tf.data, there are several useful aspects:
1. The most valuable one is the direct input support for tf.keras (and integration with distribution strategy). It gives a nice pipeline that could be easily optimized.
2. Iteration through list of tensors. This one is a little controversial as I don't see many users really like the `tf.Session.run(init_ops); tf.Session.run(next_ops);` pattern. However, with the upcoming 2.0 it is possible to iterate through dataset with `for ...` now.
3. Potentially integration with `@tf.function`. As we could see `@tf.function` carries a signature of `tf.TensorSpec` which could fit into tf.data. This could be something we want to explore.
4. Future expansion of tf.data usages. It looks like tf.data might fits into pandas or R's dataset, but let's find some concrete usages first.

I think the idea is to clean up anything that does not carry enough value. For example, should we really test the iteration in V1 with `tf.Session.run(init_ops); tf.Session.run(next_ops);` where most user will never use?

This PR is an effort to clean up and rework on MNISTDataset, so that it fits into DatasetV2, and allows future expansions:
1. All unnecessary exposed methods (e.g., output_types, output_classes, output_shapes) are dropped. We could add back if we could find some concrete usage like with tf.keras or tf.function.
2. In the tests, the following cases are tested:
    a. tf.keras support in 1.x with non-eager mode (default mode in 1.x)
    b. tf.keras support in 2.0 with eager-mode (default mode in 2.0)
    c. iteration with `for ...` in 2.0 eager-mode (default mode in 2.0)
    d. iteration with `for ...` in 1.x eager-mode (non-default mode in 1.x)
    e. iteration with tf.session in 1.x non-eager mode has been dropped.
3. The combination of dataset with tf.functions has not bee fully tests. I will update in follow-up PRs.

Note: This is a rework of #195.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>