### PR TITLE
Remove batch in shape restriction, and use tuple for NestedStructure

### DIFF
--- a/tensorflow_io/core/python/ops/data_ops.py
+++ b/tensorflow_io/core/python/ops/data_ops.py
@@ -47,4 +47,4 @@ class Dataset(tf.compat.v2.data.Dataset):
     ]
     if len(e) == 1:
       return e[0]
-    return tf.data.experimental.NestedStructure(e)
+    return tf.data.experimental.NestedStructure(tuple(e))

--- a/tensorflow_io/mnist/python/ops/mnist_ops.py
+++ b/tensorflow_io/mnist/python/ops/mnist_ops.py
@@ -34,7 +34,7 @@ class MNISTLabelDataset(data_ops.Dataset):
     dtypes = [tf.uint8]
     shapes = [
         tf.TensorShape([])] if batch == 0 else [
-            tf.TensorShape([batch])]
+            tf.TensorShape([None])]
     super(MNISTLabelDataset, self).__init__(
         mnist_ops.mnist_label_dataset,
         mnist_ops.mnist_label_input(filename, ["none", "gz"]),
@@ -53,7 +53,7 @@ class MNISTImageDataset(data_ops.Dataset):
     dtypes = [tf.uint8]
     shapes = [
         tf.TensorShape([None, None])] if batch == 0 else [
-            tf.TensorShape([batch, None, None])]
+            tf.TensorShape([None, None, None])]
     super(MNISTImageDataset, self).__init__(
         mnist_ops.mnist_image_dataset,
         mnist_ops.mnist_image_input(filename, ["none", "gz"]),


### PR DESCRIPTION
batch in shape restriction is only relevant when padding or dropping is in place.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>