### PR TITLE
Remove define _GLIBCXX_USE_CXX11_ABI

### DIFF
--- a/tensorflow_io/oss/BUILD
+++ b/tensorflow_io/oss/BUILD
@@ -12,7 +12,9 @@ cc_binary(
         "ops/ossfs_ops.cc",
     ],
     copts = [
-        "-D_GLIBCXX_USE_CXX11_ABI=0",
+        "-pthread",
+        "-std=c++11",
+        "-DNDEBUG",
     ],
     linkshared = 1,
     deps = [


### PR DESCRIPTION

Since D_GLIBCXX_USE_CXX11_ABI is now handled by configure.sh/config_helper.py
automatically, it is not needed to specify D_GLIBCXX_USE_CXX11_ABI explicitly
anymore.

This fix removeds the usage of D_GLIBCXX_USE_CXX11_ABI

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>