### PR TITLE
Reveting BigTable connector to use batch-bigtable.googleapis.com

### DIFF
--- a/tensorflow_io/bigtable/kernels/bigtable_kernels.cc
+++ b/tensorflow_io/bigtable/kernels/bigtable_kernels.cc
@@ -77,8 +77,7 @@ class BigtableClientOp : public OpKernel {
                   BigtableClientResource** ret) EXCLUSIVE_LOCKS_REQUIRED(mu_) {
                 auto client_options =
                     google::cloud::bigtable::ClientOptions()
-                        .set_connection_pool_size(connection_pool_size_)
-                        .set_data_endpoint("batch-bigtable.googleapis.com");
+                        .set_connection_pool_size(connection_pool_size_);
                 auto channel_args = client_options.channel_arguments();
                 channel_args.SetMaxReceiveMessageSize(
                     max_receive_message_size_);

--- a/tensorflow_io/bigtable/kernels/bigtable_kernels.cc
+++ b/tensorflow_io/bigtable/kernels/bigtable_kernels.cc
@@ -77,7 +77,8 @@ class BigtableClientOp : public OpKernel {
                   BigtableClientResource** ret) EXCLUSIVE_LOCKS_REQUIRED(mu_) {
                 auto client_options =
                     google::cloud::bigtable::ClientOptions()
-                        .set_connection_pool_size(connection_pool_size_);
+                        .set_connection_pool_size(connection_pool_size_)
+                        .set_data_endpoint("batch-bigtable.googleapis.com");
                 auto channel_args = client_options.channel_arguments();
                 channel_args.SetMaxReceiveMessageSize(
                     max_receive_message_size_);

--- a/tensorflow_io/bigtable/python/ops/bigtable_api.py
+++ b/tensorflow_io/bigtable/python/ops/bigtable_api.py
@@ -686,7 +686,8 @@ class _BigtableScanDataset(dataset_ops.DatasetSource):  # pylint: disable=abstra
         column_families=self._column_families,
         columns=self._columns,
         probability=self._probability)
-    super(_BigtableScanDataset, self).__init__(variant_tensor)
+    super(_BigtableScanDataset, self).__init__()
+    self._variant_tensor_attr = variant_tensor
 
   @property
   def _element_structure(self):


### PR DESCRIPTION
Most probably right fix would be to upgrade gRPC library from 1.19 to 1.21, unfortunately that breaks build and requires more work. Will look into that later.