### PR TITLE
Allow running lint concurrently with Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,11 @@ install:
 - export TENSORFLOW_INSTALL="$(python setup.py --package-version)"
 
 stages:
-- lint
 - release
 
 jobs:
   include:
-  - stage: lint
+  - stage: release
     name: "Lint"
     script:
     - bash -x -e .travis/lint.bazel.sh


### PR DESCRIPTION
Before this PR the Travis Ci build was set in a way such that
lint runs before any other tests (and fails immediately). See for example PR #303.

Think it makes sense to allow running lint concurrently with
other tests, so that people could fix all build failures (including lint)
in one update.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>