### PR TITLE
Skip pubsub and prometheus setup on macOS, as they are not supported anyway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,17 @@ install:
 - curl https://bootstrap.pypa.io/get-pip.py | sudo -H python
 - |
   if [[ $(uname) == "Darwin" ]]; then
-    sudo -H python -m pip install --upgrade pip setuptools
+    # Travis CI is questionable about setuptools update.
+    # sudo -H python -m pip install --upgrade pip setuptools
 
     # Ignite probably takes more resource so start it first,
     # otherwise it may run into issues competing with other services.
     bash -x -e tests/test_ignite/start_ignite.sh
     bash -x -e tests/test_kafka/kafka_test.sh start kafka
     bash -x -e tests/test_kinesis/kinesis_test.sh start kinesis
-    bash -x -e tests/test_pubsub/pubsub_test.sh start pubsub
-    bash -x -e tests/test_prometheus/prometheus_test.sh start
+    # Skip pubsub and prometheus on macOS
+    # bash -x -e tests/test_pubsub/pubsub_test.sh start pubsub
+    # bash -x -e tests/test_prometheus/prometheus_test.sh start
   fi
 - sudo -H python -m pip install -q -U twine --ignore-installed six
 - twine --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - |
   if [[ $(uname) == "Darwin" ]]; then
     # Travis CI is questionable about setuptools update.
-    # sudo -H python -m pip install --upgrade pip setuptools
+    sudo -H python -m pip install --user --upgrade pip setuptools
 
     # Ignite probably takes more resource so start it first,
     # otherwise it may run into issues competing with other services.


### PR DESCRIPTION
Skip pubsub and prometheus setup on macOS, as they are not supported anyway

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>