### PR TITLE
Add git and dnsutil to dev Dockerfile

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -2,10 +2,12 @@ FROM tensorflow/tensorflow:custom-op
 
 RUN apt-get update && \
     apt-get install -y \
+    git \
     curl \
     nano \
     unzip \
-    ffmpeg
+    ffmpeg \
+    dnsutils
 
 ARG BAZEL_VERSION=0.24.1
 ARG BAZEL_OS=linux


### PR DESCRIPTION
With code consists of golang code, git is needed (will automatically
pull go build from bazel so no need to install golang directly)
The dnsutils is for testing prometheus+coredns

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>