### PR TITLE
Alias FFmpeg with Video

### DIFF
--- a/tensorflow_io/video/__init__.py
+++ b/tensorflow_io/video/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Alias of FFmpeg Video Dataset.
+
+@@VideoDataset
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow_io.ffmpeg.python.ops.ffmpeg_ops import VideoDataset
+
+from tensorflow.python.util.all_util import remove_undocumented
+
+_allowed_symbols = [
+    "VideoDataset",
+]
+
+remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)


### PR DESCRIPTION
It looks like tensorflow_io.video has been referenced:
https://towardsdatascience.com/how-to-build-a-custom-dataset-for-tensorflow-1fe3967544d8

I think we will need to alias it.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>