### PR TITLE
Improvements to ArrowStreamDataset

### DIFF
--- a/tensorflow_io/arrow/BUILD
+++ b/tensorflow_io/arrow/BUILD
@@ -8,6 +8,8 @@ cc_binary(
         "kernels/arrow_dataset_ops.cc",
         "kernels/arrow_stream_client.h",
         "kernels/arrow_stream_client_unix.cc",
+        "kernels/arrow_util.cc",
+        "kernels/arrow_util.h",
         "ops/dataset_ops.cc",
     ],
     copts = [

--- a/tensorflow_io/arrow/README.md
+++ b/tensorflow_io/arrow/README.md
@@ -76,20 +76,24 @@ a given `pyarrow.Schema`, e.g. `dataset = ArrowFeatherDataset.from_schema(filena
 
 ## From a Stream of Arrow Record Batches
 
-The `ArrowStreamDataset` provides a Dataset that will connect to a host over
-a socket that is serving Arrow record batches in the Arrow stream format. See
-[here](https://arrow.apache.org/docs/python/ipc.html#writing-and-reading-streams)
-for more on the stream format. The following example will create an
-`ArrowStreamDataset` that will connect to a host that is serving an Arrow
-stream of record batches with 2 columns of dtypes=(int32, float32):
+The `ArrowStreamDataset` provides a Dataset that will connect to one or more
+hosts over a socket that is serving Arrow record batches in the Arrow stream
+format. See [here](https://arrow.apache.org/docs/python/ipc.html#writing-and-reading-streams)
+for more on the stream format. Supported socket families are `AF_INET` and
+`AF_UNIX`, specified by the `host_type` parameter (default is `AF_INET`). The
+following example will create an `ArrowStreamDataset` that will connect to a
+host that is serving an Arrow stream of record batches with 2 columns of
+dtypes=(int32, float32):
 
 ```python
 import tensorflow as tf
 from tensorflow_io.arrow import ArrowStreamDataset
 
-# The str `host` should be in the format '<HOSTNAME>:<PORT>'
+# The parameter `hosts` can be a Python string or a list of strings and should
+# be in the format '<HOSTNAME>:<PORT>' for `host_type` of `AF_INET` or path
+# for `host_type` of `AF_UNIX`
 dataset = ArrowStreamDataset(
-    host,
+    hosts,
     columns=(0, 1),
     output_types=(tf.int32, tf.float32),
     output_shapes=([], []))

--- a/tensorflow_io/arrow/README.md
+++ b/tensorflow_io/arrow/README.md
@@ -77,23 +77,26 @@ a given `pyarrow.Schema`, e.g. `dataset = ArrowFeatherDataset.from_schema(filena
 ## From a Stream of Arrow Record Batches
 
 The `ArrowStreamDataset` provides a Dataset that will connect to one or more
-hosts over a socket that is serving Arrow record batches in the Arrow stream
+endpoints that are serving Arrow record batches in the Arrow stream
 format. See [here](https://arrow.apache.org/docs/python/ipc.html#writing-and-reading-streams)
-for more on the stream format. Supported socket families are `AF_INET` and
-`AF_UNIX`, specified by the `host_type` parameter (default is `AF_INET`). The
-following example will create an `ArrowStreamDataset` that will connect to a
-host that is serving an Arrow stream of record batches with 2 columns of
-dtypes=(int32, float32):
+for more on the stream format. Currently supported endpoints are a POSIX IPv4
+socket with endpoint "<IP>:<PORT>" or "tcp://<IP>:<PORT>", a Unix Domain Socket
+with endpoint "unix://<pathname>", and STDIN with endpoint "fd://0" or "fd://-".
+
+The following example will create an `ArrowStreamDataset` that will connect to
+a local host endpoint that is serving an Arrow stream of record batches with 2
+columns of dtypes=(int32, float32):
 
 ```python
 import tensorflow as tf
 from tensorflow_io.arrow import ArrowStreamDataset
 
-# The parameter `hosts` can be a Python string or a list of strings and should
-# be in the format '<HOSTNAME>:<PORT>' for `host_type` of `AF_INET` or path
-# for `host_type` of `AF_UNIX`
+# The parameter `endpoints` can be a Python string or a list of strings and
+# should be in the format '<HOSTNAME>:<PORT>' for an IPv4 host
+endpoints = '127.0.0.1:8999'
+
 dataset = ArrowStreamDataset(
-    hosts,
+    endpoints,
     columns=(0, 1),
     output_types=(tf.int32, tf.float32),
     output_shapes=([], []))

--- a/tensorflow_io/arrow/kernels/arrow_stream_client.h
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client.h
@@ -20,16 +20,10 @@ limitations under the License.
 
 namespace tensorflow {
 
-// Supported Address Families
-enum ArrowStreamFamily {
-  AF_INET_SOCKET,
-  AF_UNIX_SOCKET,  // For UNIX systems only
-};
-
 // Class to wrap a socket as a readable Arrow InputStream
 class ArrowStreamClient : public arrow::io::InputStream {
  public:
-  ArrowStreamClient(const std::string& host, const ArrowStreamFamily family);
+  ArrowStreamClient(const std::string& endpoint);
   ~ArrowStreamClient() override;
 
   arrow::Status Connect();
@@ -40,8 +34,7 @@ class ArrowStreamClient : public arrow::io::InputStream {
                      std::shared_ptr<arrow::Buffer>* out) override;
 
  private:
-  const std::string host_;
-  ArrowStreamFamily family_;
+  const std::string endpoint_;
   int sock_;
   int64_t pos_;
 };

--- a/tensorflow_io/arrow/kernels/arrow_stream_client.h
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client.h
@@ -20,10 +20,16 @@ limitations under the License.
 
 namespace tensorflow {
 
+// Supported Address Families
+enum ArrowStreamFamily {
+  AF_INET_SOCKET,
+  AF_UNIX_SOCKET,  // For UNIX systems only
+};
+
 // Class to wrap a socket as a readable Arrow InputStream
 class ArrowStreamClient : public arrow::io::InputStream {
  public:
-  ArrowStreamClient(const std::string& host);
+  ArrowStreamClient(const std::string& host, const ArrowStreamFamily family);
   ~ArrowStreamClient() override;
 
   arrow::Status Connect();
@@ -35,6 +41,7 @@ class ArrowStreamClient : public arrow::io::InputStream {
 
  private:
   const std::string host_;
+  ArrowStreamFamily family_;
   int sock_;
   int64_t pos_;
 };

--- a/tensorflow_io/arrow/kernels/arrow_stream_client_windows.cc
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client_windows.cc
@@ -29,9 +29,8 @@ limitations under the License.
 
 namespace tensorflow {
 
-ArrowStreamClient::ArrowStreamClient(const std::string& host,
-                                     const ArrowStreamFamily family)
-    : host_(host), family_(family), sock_(-1), pos_(0) {}
+ArrowStreamClient::ArrowStreamClient(const std::string& endpoint)
+    : endpoint_(endpoint), sock_(-1), pos_(0) {}
 
 ArrowStreamClient::~ArrowStreamClient() {
   if (sock_ != -1) {
@@ -40,18 +39,26 @@ ArrowStreamClient::~ArrowStreamClient() {
 }
 
 arrow::Status ArrowStreamClient::Connect() {
-  if (family_ == ArrowStreamFamily::AF_UNIX_SOCKET) {
+  string socket_family;
+  string host;
+  Status status;
+
+  status = ParseEndpoint(endpoint_, &socket_family, &host);
+  if (!status.ok()) {
     return arrow::Status::Invalid(
-        "Unsupported socket family: " + std::to_string(family_));
+        "Error parsing endpoint string: " + endpoint_);
+  }
+  if (socket_family == "unix") {
+    return arrow::Status::Invalid(
+        "Unsupported socket family: " + socket_family);
   }
 
-  size_t sep_pos = host_.find(':');
-  if (sep_pos == std::string::npos || sep_pos == host_.size()) {
-    return arrow::Status::Invalid(
-        "Expected host to be in format <host>:<port> but got: " + host_);
+  string addr_str;
+  string port_str;
+  status = ParseHost(host, &addr_str, &port_str);
+  if (!status.ok()) {
+    return arrow::Status::Invalid("Error parsing host string: " + host);
   }
-  std::string host_str = host_.substr(0, sep_pos);
-  std::string port_str = host_.substr(sep_pos + 1, host_.size() - sep_pos);
 
   WSADATA wsaData;
   addrinfo *result = NULL, *ptr = NULL, hints;
@@ -67,7 +74,7 @@ arrow::Status ArrowStreamClient::Connect() {
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = IPPROTO_TCP;
 
-  res = getaddrinfo(host_str.c_str(), port_str.c_str(), &hints,
+  res = getaddrinfo(addr_str.c_str(), port_str.c_str(), &hints,
                     &result);
   if (res != 0) {
     return arrow::Status::IOError("Getaddrinfo failed with error: ",

--- a/tensorflow_io/arrow/kernels/arrow_stream_client_windows.cc
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client_windows.cc
@@ -29,8 +29,9 @@ limitations under the License.
 
 namespace tensorflow {
 
-ArrowStreamClient::ArrowStreamClient(const std::string& host)
-    : host_(host), sock_(-1), pos_(0) {}
+ArrowStreamClient::ArrowStreamClient(const std::string& host,
+                                     const ArrowStreamFamily family)
+    : host_(host), family_(family), sock_(-1), pos_(0) {}
 
 ArrowStreamClient::~ArrowStreamClient() {
   if (sock_ != -1) {
@@ -39,6 +40,11 @@ ArrowStreamClient::~ArrowStreamClient() {
 }
 
 arrow::Status ArrowStreamClient::Connect() {
+  if (family_ == ArrowStreamFamily::AF_UNIX_SOCKET) {
+    return arrow::Status::Invalid(
+        "Unsupported socket family: " + std::to_string(family_));
+  }
+
   size_t sep_pos = host_.find(':');
   if (sep_pos == std::string::npos || sep_pos == host_.size()) {
     return arrow::Status::Invalid(

--- a/tensorflow_io/arrow/kernels/arrow_util.cc
+++ b/tensorflow_io/arrow/kernels/arrow_util.cc
@@ -1,0 +1,60 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow_io/arrow/kernels/arrow_util.h"
+
+namespace tensorflow {
+
+Status ParseEndpoint(std::string endpoint, std::string* endpoint_type,
+                     std::string* endpoint_value) {
+  size_t sep_pos = endpoint.find(':');
+
+  // Check for a proper format
+  if (sep_pos == std::string::npos) {
+    return errors::InvalidArgument(
+        "Expected endpoint to be in format <endpoint_type>://<endpoint_value> "
+        "or <host>:<port> for tcp IPv4, but got: " + endpoint);
+  }
+
+  // If IPv4 and no endpoint type specified, descriptor is entire endpoint
+  if (endpoint.substr(sep_pos + 1, 2) != "//") {
+    *endpoint_type = "";
+    *endpoint_value = endpoint;
+    return Status::OK();
+  }
+
+  // Parse string as <endpoint_type>://<endpoint_value>
+  *endpoint_type = endpoint.substr(0, sep_pos);
+  *endpoint_value = endpoint.substr(sep_pos + 3);
+
+  return Status::OK();
+}
+
+Status ParseHost(std::string host, std::string* host_address, std::string* host_port) {
+  size_t sep_pos = host.find(':');
+  if (sep_pos == std::string::npos || sep_pos == host.length()) {
+    return errors::InvalidArgument(
+        "Expected host to be in format <host>:<port> but got: " + host);
+  }
+
+  *host_address = host.substr(0, sep_pos);
+  *host_port = host.substr(sep_pos + 1);
+
+  return Status::OK();
+}
+
+}  // namespace tensorflow

--- a/tensorflow_io/arrow/kernels/arrow_util.h
+++ b/tensorflow_io/arrow/kernels/arrow_util.h
@@ -1,0 +1,30 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_IO_ARROW_UTIL_H_
+#define TENSORFLOW_IO_ARROW_UTIL_H_
+
+namespace tensorflow {
+
+// Parse the given endpoint to extract type and value strings
+Status ParseEndpoint(std::string endpoint, std::string* endpoint_type,
+                     std::string* endpoint_value);
+
+// Parse the given IPv4 host string to get address and port
+Status ParseHost(std::string host, std::string* host_address, std::string* host_port);
+
+}  // namespace tensorflow
+
+#endif

--- a/tensorflow_io/arrow/ops/dataset_ops.cc
+++ b/tensorflow_io/arrow/ops/dataset_ops.cc
@@ -52,7 +52,7 @@ filenames: One or more file paths.
 )doc");
 
 REGISTER_OP("ArrowStreamDataset")
-    .Input("host: string")
+    .Input("hosts: string")
     .Input("host_type: string")
     .Input("columns: int32")
     .Input("batch_size: int64")
@@ -65,7 +65,7 @@ REGISTER_OP("ArrowStreamDataset")
     .Doc(R"doc(
 Creates a dataset that connects to a host serving Arrow RecordBatches in stream format.
 
-host: A host address that is serving an Arrow stream.
+hosts: One or more host addresses that are serving an Arrow stream.
 )doc");
 
 }  // namespace tensorflow

--- a/tensorflow_io/arrow/ops/dataset_ops.cc
+++ b/tensorflow_io/arrow/ops/dataset_ops.cc
@@ -53,6 +53,7 @@ filenames: One or more file paths.
 
 REGISTER_OP("ArrowStreamDataset")
     .Input("host: string")
+    .Input("host_type: string")
     .Input("columns: int32")
     .Input("batch_size: int64")
     .Input("batch_mode: string")

--- a/tensorflow_io/arrow/ops/dataset_ops.cc
+++ b/tensorflow_io/arrow/ops/dataset_ops.cc
@@ -52,8 +52,7 @@ filenames: One or more file paths.
 )doc");
 
 REGISTER_OP("ArrowStreamDataset")
-    .Input("hosts: string")
-    .Input("host_type: string")
+    .Input("endpoints: string")
     .Input("columns: int32")
     .Input("batch_size: int64")
     .Input("batch_mode: string")
@@ -65,7 +64,7 @@ REGISTER_OP("ArrowStreamDataset")
     .Doc(R"doc(
 Creates a dataset that connects to a host serving Arrow RecordBatches in stream format.
 
-hosts: One or more host addresses that are serving an Arrow stream.
+endpoints: One or more host addresses that are serving an Arrow stream.
 )doc");
 
 }  // namespace tensorflow

--- a/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
@@ -360,7 +360,7 @@ class ArrowStreamDataset(ArrowBaseDataset):
   host_types_supported = ('AF_INET', 'AF_UNIX', 'STDIN')
 
   def __init__(self,
-               host,
+               hosts,
                columns,
                output_types,
                output_shapes=None,
@@ -370,7 +370,8 @@ class ArrowStreamDataset(ArrowBaseDataset):
     """Create an ArrowDataset from an input stream.
 
     Args:
-      host: A `tf.string` tensor or Python string defining the input stream.
+      hosts: A `tf.string` tensor, Python list or scalar string defining the
+             input stream.
       columns: A list of column indices to be used in the Dataset
       output_types: Tensor dtypes of the output tensors
       output_shapes: TensorShapes of the output tensors or None to
@@ -392,12 +393,12 @@ class ArrowStreamDataset(ArrowBaseDataset):
       raise ValueError(
           "Unsupported host_type: '{}', must be one of {}"
           .format(host_type, self.host_types_supported))
-    host = tf.convert_to_tensor(
-        host,
+    hosts = tf.convert_to_tensor(
+        hosts,
         dtype=dtypes.string,
-        name="host")
+        name="hosts")
     super(ArrowStreamDataset, self).__init__(
-        partial(arrow_ops.arrow_stream_dataset, host, host_type),
+        partial(arrow_ops.arrow_stream_dataset, hosts, host_type),
         columns,
         output_types,
         output_shapes,
@@ -406,7 +407,7 @@ class ArrowStreamDataset(ArrowBaseDataset):
 
   @classmethod
   def from_schema(cls,
-                  host,
+                  hosts,
                   schema,
                   columns=None,
                   batch_size=None,
@@ -417,7 +418,8 @@ class ArrowStreamDataset(ArrowBaseDataset):
     This method requires pyarrow to be installed.
 
     Args:
-      host: A `tf.string` tensor or Python string defining the input stream.
+      hosts: A `tf.string` tensor, Python list or scalar string defining the
+             input stream.
       schema: Arrow schema defining the record batch data in the stream
       columns: A list of column indicies to use from the schema, None for all
       batch_size: Batch size of output tensors, setting a batch size here
@@ -437,7 +439,7 @@ class ArrowStreamDataset(ArrowBaseDataset):
       columns = list(range(len(schema)))
     output_types, output_shapes = arrow_schema_to_tensor_types(schema)
     return cls(
-        host,
+        hosts,
         columns,
         output_types,
         output_shapes,

--- a/tests/test_arrow_eager.py
+++ b/tests/test_arrow_eager.py
@@ -384,8 +384,10 @@ class ArrowDatasetTest(test.TestCase):
     server = threading.Thread(target=run_server, args=(num_batches,))
     server.start()
 
+    endpoint = 'unix://{}'.format(host)
+
     dataset = arrow_io.ArrowStreamDataset.from_schema(
-        host, batch.schema, host_type='AF_UNIX')
+        endpoint, batch.schema)
     truth_data_mult = TruthData(
         [d * num_batches for d in truth_data.data],
         truth_data.output_types,
@@ -439,9 +441,10 @@ class ArrowDatasetTest(test.TestCase):
       return server
 
     servers = [start_server(h) for h in hosts]
+    endpoints = ['unix://{}'.format(h) for h in hosts]
 
     dataset = arrow_io.ArrowStreamDataset.from_schema(
-        hosts, batch.schema, host_type='AF_UNIX')
+        endpoints, batch.schema)
     truth_data_mult = TruthData(
         [d * len(hosts) for d in truth_data.data],
         truth_data.output_types,


### PR DESCRIPTION
This makes the following improvements to the `ArrowStreamDataset`:

* Adds the option to use a Unix Domain Socket, with the benefit of using simple file permission to create a secure local socket

* Allow the `ArrowStreamDataset` to accept multiple hostnames for input

* Adds the ability to create a `ArrowStreamDataset` from a Pandas DataFrame where slices are streamed to the dataset over a local socket