### PR TITLE
Ignore font for github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+font_*.h linguist-generated=true


### PR DESCRIPTION
At the moment the language of the repo was incorrectly
labeled as C. That was because Font binary code was
generated. It should not be part of the source code.

This fix excludes font binary code.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>