### PR TITLE
Add save method for TextDataset

### DIFF
--- a/tensorflow_io/text/BUILD
+++ b/tensorflow_io/text/BUILD
@@ -11,6 +11,7 @@ cc_library(
     name = "text_ops",
     srcs = [
         "kernels/text_input.cc",
+        "kernels/text_output.cc",
         "kernels/text_sequence.cc",
         "ops/text_ops.cc",
     ],

--- a/tensorflow_io/text/__init__.py
+++ b/tensorflow_io/text/__init__.py
@@ -16,6 +16,7 @@
 
 @@TextOutputSequence
 @@TextDataset
+@@save_text
 """
 
 from __future__ import absolute_import
@@ -24,12 +25,14 @@ from __future__ import print_function
 
 from tensorflow_io.text.python.ops.text_ops import TextOutputSequence
 from tensorflow_io.text.python.ops.text_ops import TextDataset
+from tensorflow_io.text.python.ops.text_ops import save_text
 
 from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = [
     "TextOutputSequence",
     "TextDataset",
+    "save_text",
 ]
 
 remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/text/kernels/text_output.cc
+++ b/tensorflow_io/text/kernels/text_output.cc
@@ -1,0 +1,107 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/core/framework/dataset.h"
+#include "tensorflow/core/framework/function_handle_cache.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/lib/core/threadpool.h"
+#include "tensorflow/core/lib/io/record_writer.h"
+#include "tensorflow/core/platform/file_system.h"
+
+namespace tensorflow {
+namespace data {
+namespace {
+
+class TextDatasetOutputOp : public AsyncOpKernel {
+ public:
+  explicit TextDatasetOutputOp(OpKernelConstruction* ctx)
+      : AsyncOpKernel(ctx),
+        background_worker_(ctx->env(), "text_dataset_output") {}
+
+  template <typename T>
+  Status ParseScalarArgument(OpKernelContext* ctx,
+                             const StringPiece& argument_name, T* output) {
+    const Tensor* argument_t;
+    TF_RETURN_IF_ERROR(ctx->input(argument_name, &argument_t));
+    if (!TensorShapeUtils::IsScalar(argument_t->shape())) {
+      return errors::InvalidArgument(argument_name, " must be a scalar");
+    }
+    *output = argument_t->scalar<T>()();
+    return Status::OK();
+  }
+
+  void ComputeAsync(OpKernelContext* ctx, DoneCallback done) override {
+    // The call to `iterator->GetNext()` may block and depend on an inter-op
+    // thread pool thread, so we issue the call using a background thread.
+    background_worker_.Schedule([this, ctx, done]() {
+      string filename;
+      OP_REQUIRES_OK_ASYNC(
+          ctx, ParseScalarArgument<string>(ctx, "filename", &filename), done);
+      std::unique_ptr<WritableFile> file;
+      OP_REQUIRES_OK_ASYNC(ctx, ctx->env()->NewWritableFile(filename, &file),
+                           done);
+
+      DatasetBase* dataset;
+      OP_REQUIRES_OK_ASYNC(
+          ctx, GetDatasetFromVariantTensor(ctx->input(0), &dataset), done);
+      std::unique_ptr<IteratorBase> iterator;
+      IteratorContext::Params params(ctx);
+      std::unique_ptr<FunctionHandleCache> function_handle_cache =
+          absl::make_unique<FunctionHandleCache>(params.flr);
+      params.function_handle_cache = function_handle_cache.get();
+      IteratorContext iter_ctx(std::move(params));
+
+      OP_REQUIRES_OK_ASYNC(
+          ctx,
+          dataset->MakeIterator(&iter_ctx, "TextDatasetOutputOpIterator", &iterator),
+          done);
+      std::vector<Tensor> components;
+      components.reserve(dataset->output_dtypes().size());
+      bool end_of_sequence;
+      do {
+        OP_REQUIRES_OK_ASYNC(
+            ctx, iterator->GetNext(&iter_ctx, &components, &end_of_sequence),
+            done);
+
+        if (!end_of_sequence) {
+          // TODO (yongtang): In case of TextDataset the shapes of output can
+          // only be either a scalar (`batch = 0`) or an 1-D tensor (`batch != 0`)
+          // so the following could be simplified by just calling flat<string>.
+          // Once other dataset has been introduced for write then additional
+          // logic would be neededto handle `batch = 0` vs `batch != 0` case.
+          for (int64 i = 0; i < components[0].NumElements(); i++) {
+            OP_REQUIRES_OK_ASYNC(
+                ctx, file.get()->Append(components[0].flat<string>()(i)), done);
+            OP_REQUIRES_OK_ASYNC(
+                ctx, file.get()->Append("\n"), done);
+          }
+        }
+        components.clear();
+      } while (!end_of_sequence);
+          OP_REQUIRES_OK_ASYNC(
+              ctx, file.get()->Flush(), done);
+      done();
+    });
+  }
+
+ private:
+  BackgroundWorker background_worker_;
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("TextDatasetOutput").Device(DEVICE_CPU), TextDatasetOutputOp);
+
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow_io/text/ops/text_ops.cc
+++ b/tensorflow_io/text/ops/text_ops.cc
@@ -67,6 +67,14 @@ REGISTER_OP("TextDataset")
        return Status::OK();
      });
 
+REGISTER_OP("TextDatasetOutput")
+    .Input("dataset: variant")
+    .Input("filename: string")
+    .SetIsStateful()
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+       return Status::OK();
+     });
+
 REGISTER_OP("TextOutputSequence")
     .Input("destination: string")
     .Output("sequence: resource")

--- a/tensorflow_io/text/python/ops/text_ops.py
+++ b/tensorflow_io/text/python/ops/text_ops.py
@@ -45,6 +45,16 @@ class TextDataset(data_ops.Dataset):
         data_input,
         batch, dtypes, shapes)
 
+  @staticmethod
+  def save(dataset, filename):
+    """Save Dataset to disk.
+
+    Args:
+      dataset: A TextDataset to be saved.
+      filename: A `tf.string` tensor containing filename.
+    """
+    return text_ops.text_dataset_output(dataset._variant_tensor, filename) # pylint: disable=protected-access
+
 
 class TextOutputSequence(object):
   """TextOutputSequence"""

--- a/tensorflow_io/text/python/ops/text_ops.py
+++ b/tensorflow_io/text/python/ops/text_ops.py
@@ -21,6 +21,16 @@ import tensorflow as tf
 from tensorflow_io.core.python.ops import data_ops as data_ops
 from tensorflow_io.core.python.ops import core_ops as text_ops
 
+def save_text(dataset, filename):
+  """Save Dataset to disk.
+
+  Args:
+    dataset: A TextDataset to be saved.
+    filename: A `tf.string` tensor containing filename.
+  """
+  return text_ops.text_dataset_output(dataset._variant_tensor, filename) # pylint: disable=protected-access
+
+
 class TextDataset(data_ops.Dataset):
   """A Text Dataset"""
 
@@ -44,16 +54,6 @@ class TextDataset(data_ops.Dataset):
         fn,
         data_input,
         batch, dtypes, shapes)
-
-  @staticmethod
-  def save(dataset, filename):
-    """Save Dataset to disk.
-
-    Args:
-      dataset: A TextDataset to be saved.
-      filename: A `tf.string` tensor containing filename.
-    """
-    return text_ops.text_dataset_output(dataset._variant_tensor, filename) # pylint: disable=protected-access
 
 
 class TextOutputSequence(object):

--- a/tests/test_text_eager.py
+++ b/tests/test_text_eager.py
@@ -110,22 +110,20 @@ def test_text_output():
     lines = [line.strip() for line in f]
   text_filename = "file://" + text_filename
 
-  text_dataset = text_io.TextDataset([text_filename, text_filename], batch=2)
-
-  text_dataset = text_dataset.map(lambda x: tf.strings.join([x[0], x[1]]))
-
   f, filename = tempfile.mkstemp()
   os.close(f)
 
-  text_io.TextDataset.save(text_dataset, filename)
+  df = text_io.TextDataset(text_filename)
+  df = df.take(5)
+  text_io.save_text(df, filename)
 
   with open(filename, 'rb') as f:
     saved_lines = [line.strip() for line in f]
-  for i, _ in enumerate(saved_lines):
-    assert saved_lines[i] == lines[
-        (2 * i) % len(lines)] + lines[
-            (2 * i + 1) % len(lines)]
-  assert len(saved_lines) == len(lines)
+  i = 0
+  for line in saved_lines:
+    assert lines[i] == line
+    i += 1
+  assert i == 5
 
 if __name__ == "__main__":
   test.main()

--- a/tests/test_text_eager.py
+++ b/tests/test_text_eager.py
@@ -102,5 +102,30 @@ def test_text_output_sequence():
   for line, prediction in zip(lines, predictions):
     assert line == prediction
 
+def test_text_output():
+  """test_text_output"""
+  text_filename = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)), "test_text", "lorem.txt")
+  with open(text_filename, 'rb') as f:
+    lines = [line.strip() for line in f]
+  text_filename = "file://" + text_filename
+
+  text_dataset = text_io.TextDataset([text_filename, text_filename], batch=2)
+
+  text_dataset = text_dataset.map(lambda x: tf.strings.join([x[0], x[1]]))
+
+  f, filename = tempfile.mkstemp()
+  os.close(f)
+
+  text_io.TextDataset.save(text_dataset, filename)
+
+  with open(filename, 'rb') as f:
+    saved_lines = [line.strip() for line in f]
+  for i, _ in enumerate(saved_lines):
+    assert saved_lines[i] == lines[
+        (2 * i) % len(lines)] + lines[
+            (2 * i + 1) % len(lines)]
+  assert len(saved_lines) == len(lines)
+
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This is an experimental implementation of the `save` (write) method for TextDataset in order to allow saving the content of Dataset into files.

TextDataset itself is straightforward so it may not be that useful. However, it setup an example for saving to other future format (e.g., Parquet/Arrow/etc).

This PR is related to #315

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>