### PR TITLE
Change from libtensorflowio.so to libtensorflow_io.so

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -102,7 +102,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "python/ops/libtensorflowio.so",
+    name = "python/ops/libtensorflow_io.so",
     copts = [
         "-pthread",
         "-std=c++11",
@@ -126,7 +126,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "python/ops/libtensorflowio_ffmpeg_3.4.so",
+    name = "python/ops/libtensorflow_io_ffmpeg_3.4.so",
     copts = [
         "-pthread",
         "-std=c++11",
@@ -139,7 +139,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "python/ops/libtensorflowio_ffmpeg_2.8.so",
+    name = "python/ops/libtensorflow_io_ffmpeg_2.8.so",
     copts = [
         "-pthread",
         "-std=c++11",
@@ -152,7 +152,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "python/ops/libtensorflowio_libav_9.20.so",
+    name = "python/ops/libtensorflow_io_libav_9.20.so",
     copts = [
         "-pthread",
         "-std=c++11",

--- a/tensorflow_io/core/python/ops/__init__.py
+++ b/tensorflow_io/core/python/ops/__init__.py
@@ -18,4 +18,4 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_io import _load_library
-core_ops = _load_library('libtensorflowio.so')
+core_ops = _load_library('libtensorflow_io.so')

--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -46,19 +46,19 @@ def _load_dependency_and_library(p):
   raise NotImplementedError("could not find ffmpeg after search through ", p)
 
 _ffmpeg_ops = _load_dependency_and_library({
-    'libtensorflowio_ffmpeg_3.4.so': [
+    'libtensorflow_io_ffmpeg_3.4.so': [
         "libavformat.so.57",
         "libavformat.so.57",
         "libavutil.so.55",
         "libswscale.so.4",
     ],
-    'libtensorflowio_ffmpeg_2.8.so': [
+    'libtensorflow_io_ffmpeg_2.8.so': [
         "libavformat-ffmpeg.so.56",
         "libavcodec-ffmpeg.so.56",
         "libavutil-ffmpeg.so.54",
         "libswscale-ffmpeg.so.3",
     ],
-    'libtensorflowio_libav_9.20.so': [
+    'libtensorflow_io_libav_9.20.so': [
         "libavformat.so.54",
         "libavcodec.so.54",
         "libavutil.so.52",


### PR DESCRIPTION
This fix change the .so name from libtensorflowio.so to libtensorflow_io.so,
this is to match tensorflow's setup of libtensorflow_core.so and
libtensorflow_framework.so

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>