### PR TITLE
Centralising bazel copts similar to tf main repo

### DIFF
--- a/tensorflow_io/arrow/BUILD
+++ b/tensorflow_io/arrow/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_arrow_ops.so",
     srcs = [
@@ -12,11 +17,7 @@ cc_binary(
         "kernels/arrow_util.h",
         "ops/dataset_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "@arrow",

--- a/tensorflow_io/audio/BUILD
+++ b/tensorflow_io/audio/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "audio_ops",
     srcs = [
         "kernels/audio_input.cc",
         "ops/audio_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",

--- a/tensorflow_io/avro/BUILD
+++ b/tensorflow_io/avro/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "avro_ops",
     srcs = [
         "kernels/avro_input.cc",
         "ops/avro_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],

--- a/tensorflow_io/azure/BUILD
+++ b/tensorflow_io/azure/BUILD
@@ -2,11 +2,10 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-c_opts = [
-    "-pthread",
-    "-std=c++11",
-    "-DNDEBUG",
-]
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
 
 cc_library(
     name = "azfs_ops",
@@ -15,7 +14,7 @@ cc_library(
         "azfs/azfs.h",
         "azfs/azfs_ops.cc",
     ],
-    copts = c_opts,
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         ":azfs_random_access_file",
@@ -32,7 +31,7 @@ cc_library(
     hdrs = [
         "azfs/azfs_client.h",
     ],
-    copts = c_opts,
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "@com_github_azure_azure_storage_cpplite//:azure",
@@ -49,7 +48,7 @@ cc_library(
     hdrs = [
         "azfs/azfs_writable_file.h",
     ],
-    copts = c_opts,
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         ":azfs_client",
@@ -64,7 +63,7 @@ cc_library(
     hdrs = [
         "azfs/azfs_random_access_file.h",
     ],
-    copts = c_opts,
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         ":azfs_client",
@@ -76,7 +75,7 @@ cc_library(
     srcs = [
         "azfs/azfs_readonly_memory_region.h",
     ],
-    copts = c_opts,
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "@local_config_tf//:libtensorflow_framework",

--- a/tensorflow_io/bigquery/BUILD
+++ b/tensorflow_io/bigquery/BUILD
@@ -4,6 +4,10 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
 
 KERNEL_FILES = [
     "kernels/bigquery_kernels.cc",
@@ -15,11 +19,7 @@ cc_binary(
     srcs = KERNEL_FILES + [
         "ops/bigquery_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         ":bigquery_lib_cc",
@@ -37,11 +37,7 @@ cc_binary(
         "kernels/test_kernels/bigquery_test_client_op.cc",
         "ops/bigquery_test_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         ":bigquery_fake",
@@ -70,11 +66,7 @@ cc_library(
     name = "bigquery_fake",
     srcs = ["kernels/test_kernels/fake_bigquery_storage_service.cc"],
     hdrs = ["kernels/test_kernels/fake_bigquery_storage_service.h"],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "@com_github_grpc_grpc//:grpc++",
@@ -89,11 +81,7 @@ cc_library(
     name = "bigquery_lib_cc",
     srcs = ["kernels/bigquery_lib.cc"],
     hdrs = ["kernels/bigquery_lib.h"],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "@avro",

--- a/tensorflow_io/bigtable/BUILD
+++ b/tensorflow_io/bigtable/BUILD
@@ -1,6 +1,11 @@
 # Cloud Bigtable client for TensorFlow
 licenses(["notice"])  # Apache 2.0
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_bigtable.so",
     srcs = [
@@ -15,11 +20,7 @@ cc_binary(
         "kernels/bigtable_scan_dataset_op.cc",
         "ops/bigtable_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         ":bigtable_lib_cc",
@@ -35,11 +36,7 @@ cc_library(
         "kernels/test_kernels/bigtable_test_client_op.cc",
         "ops/bigtable_test_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         ":bigtable_lib_cc",
@@ -72,11 +69,7 @@ cc_library(
     hdrs = [
         "kernels/test_kernels/bigtable_test_client.h",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "@com_github_googleapis_google_cloud_cpp//google/cloud/bigtable:bigtable_client",
@@ -91,11 +84,7 @@ cc_library(
     name = "bigtable_lib_cc",
     srcs = ["kernels/bigtable_lib.cc"],
     hdrs = ["kernels/bigtable_lib.h"],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "@com_github_googleapis_google_cloud_cpp//google/cloud/bigtable:bigtable_client",

--- a/tensorflow_io/cifar/BUILD
+++ b/tensorflow_io/cifar/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "cifar_ops",
     srcs = [
         "kernels/cifar_input.cc",
         "ops/cifar_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -2,16 +2,17 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "sequence_ops",
     srcs = [
         "kernels/sequence_ops.h",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],
@@ -28,11 +29,7 @@ cc_library(
     srcs = [
         "kernels/dataset_ops.h",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],
@@ -50,11 +47,7 @@ cc_library(
         "kernels/ffmpeg_reader.cc",
         "kernels/ffmpeg_reader.h",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = ["."],
     linkstatic = True,
     deps = [
@@ -69,11 +62,7 @@ cc_library(
         "kernels/ffmpeg_reader.cc",
         "kernels/ffmpeg_reader.h",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = ["."],
     linkstatic = True,
     deps = [
@@ -88,11 +77,7 @@ cc_library(
         "kernels/ffmpeg_reader.cc",
         "kernels/ffmpeg_reader.h",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = ["."],
     linkstatic = True,
     deps = [
@@ -103,11 +88,7 @@ cc_library(
 
 cc_binary(
     name = "python/ops/libtensorflow_io.so",
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "//tensorflow_io/audio:audio_ops",
@@ -128,11 +109,7 @@ cc_binary(
 
 cc_binary(
     name = "python/ops/libtensorflow_io_ffmpeg_3.4.so",
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "//tensorflow_io/ffmpeg:ffmpeg_3.4_ops",
@@ -141,11 +118,7 @@ cc_binary(
 
 cc_binary(
     name = "python/ops/libtensorflow_io_ffmpeg_2.8.so",
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "//tensorflow_io/ffmpeg:ffmpeg_2.8_ops",
@@ -154,11 +127,7 @@ cc_binary(
 
 cc_binary(
     name = "python/ops/libtensorflow_io_libav_9.20.so",
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "//tensorflow_io/ffmpeg:libav_9.20_ops",

--- a/tensorflow_io/ffmpeg/BUILD
+++ b/tensorflow_io/ffmpeg/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "ffmpeg_3.4_ops",
     srcs = [
@@ -13,11 +18,7 @@ cc_library(
         "kernels/video_ffmpeg_reader.h",
         "ops/ffmpeg_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = ["."],
     linkstatic = True,
     deps = [
@@ -36,11 +37,7 @@ cc_library(
         "kernels/video_ffmpeg_reader.h",
         "ops/ffmpeg_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = ["."],
     linkstatic = True,
     deps = [
@@ -59,11 +56,7 @@ cc_library(
         "kernels/video_ffmpeg_reader.h",
         "ops/ffmpeg_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = ["."],
     linkstatic = True,
     deps = [

--- a/tensorflow_io/grpc/BUILD
+++ b/tensorflow_io/grpc/BUILD
@@ -3,6 +3,10 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
 
 genrule(
     name = "endpoint_py",
@@ -44,11 +48,7 @@ cc_binary(
         "kernels/grpc_input.cc",
         "ops/grpc_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],

--- a/tensorflow_io/hadoop/BUILD
+++ b/tensorflow_io/hadoop/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_hadoop_ops.so",
     srcs = [
         "kernels/hadoop_dataset_ops.cc",
         "ops/dataset_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "@local_config_tf//:libtensorflow_framework",

--- a/tensorflow_io/hdf5/BUILD
+++ b/tensorflow_io/hdf5/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "hdf5_ops",
     srcs = [
         "kernels/hdf5_input.cc",
         "ops/hdf5_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],

--- a/tensorflow_io/ignite/BUILD
+++ b/tensorflow_io/ignite/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "ignite_ops",
     srcs = [
@@ -42,11 +47,7 @@ cc_library(
         "ops/ggfs_ops.cc",
         "ops/igfs_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "@boringssl//:ssl",

--- a/tensorflow_io/image/BUILD
+++ b/tensorflow_io/image/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_image_ops.so",
     srcs = [
@@ -12,11 +17,7 @@ cc_binary(
         "kernels/webp_dataset_ops.cc",
         "ops/dataset_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],

--- a/tensorflow_io/kafka/BUILD
+++ b/tensorflow_io/kafka/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_kafka_ops.so",
     srcs = [
@@ -10,11 +15,7 @@ cc_binary(
         "ops/dataset_ops.cc",
         "ops/kafka_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "//tensorflow_io/core:sequence_ops",

--- a/tensorflow_io/kinesis/BUILD
+++ b/tensorflow_io/kinesis/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_kinesis_ops.so",
     srcs = [
         "kernels/kinesis_dataset_ops.cc",
         "ops/dataset_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "@aws",

--- a/tensorflow_io/libsvm/BUILD
+++ b/tensorflow_io/libsvm/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_libsvm_ops.so",
     srcs = [
         "kernels/decode_libsvm_op.cc",
         "ops/libsvm_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "@local_config_tf//:libtensorflow_framework",

--- a/tensorflow_io/lmdb/BUILD
+++ b/tensorflow_io/lmdb/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "lmdb_ops",
     srcs = [
         "kernels/lmdb_input.cc",
         "ops/lmdb_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",

--- a/tensorflow_io/mnist/BUILD
+++ b/tensorflow_io/mnist/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "mnist_ops",
     srcs = [
         "kernels/mnist_input.cc",
         "ops/mnist_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",

--- a/tensorflow_io/oss/BUILD
+++ b/tensorflow_io/oss/BUILD
@@ -4,6 +4,11 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_oss_ops.so",
     srcs = [
@@ -11,11 +16,7 @@ cc_binary(
         "kernels/ossfs/oss_file_system.h",
         "ops/ossfs_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "@aliyun_oss_c_sdk",

--- a/tensorflow_io/parquet/BUILD
+++ b/tensorflow_io/parquet/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_parquet_ops.so",
     srcs = [
         "kernels/parquet_input.cc",
         "ops/parquet_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "//tensorflow_io/core:dataset_ops",

--- a/tensorflow_io/pcap/BUILD
+++ b/tensorflow_io/pcap/BUILD
@@ -2,17 +2,18 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_binary(
     name = "python/ops/_pcap_ops.so",
     srcs = [
         "kernels/pcap_input.cc",
         "ops/pcap_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "//tensorflow_io/core:dataset_ops",

--- a/tensorflow_io/prometheus/BUILD
+++ b/tensorflow_io/prometheus/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "prometheus_ops",
     srcs = [
@@ -10,11 +15,7 @@ cc_library(
         "kernels/prometheus_input.cc",
         "ops/prometheus_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],

--- a/tensorflow_io/pubsub/BUILD
+++ b/tensorflow_io/pubsub/BUILD
@@ -3,6 +3,10 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
 
 cc_binary(
     name = "python/ops/_pubsub_ops.so",
@@ -10,11 +14,7 @@ cc_binary(
         "kernels/pubsub_dataset_ops.cc",
         "ops/dataset_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     linkshared = 1,
     deps = [
         "@com_github_grpc_grpc//:grpc++",

--- a/tensorflow_io/tensorflow_io.bzl
+++ b/tensorflow_io/tensorflow_io.bzl
@@ -1,0 +1,11 @@
+def tf_io_copts():
+  return (
+      [
+          "-std=c++11",
+          "-DNDEBUG",
+      ] + 
+      select({
+          "@bazel_tools//src/conditions:darwin": [],
+          "//conditions:default": ["-pthread"]
+      })
+  )

--- a/tensorflow_io/text/BUILD
+++ b/tensorflow_io/text/BUILD
@@ -2,6 +2,11 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//tensorflow_io:tensorflow_io.bzl",
+    "tf_io_copts",
+)
+
 cc_library(
     name = "text_ops",
     srcs = [
@@ -9,11 +14,7 @@ cc_library(
         "kernels/text_sequence.cc",
         "ops/text_ops.cc",
     ],
-    copts = [
-        "-pthread",
-        "-std=c++11",
-        "-DNDEBUG",
-    ],
+    copts = tf_io_copts(),
     includes = [
         ".",
     ],


### PR DESCRIPTION
Same copts as all libraries were using anyway, but not passing `-pthread` opts on Darwin which it's unused as argument is a large number of log messages in travis macOS build