### PR TITLE
Drop python 3.4 support for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ jobs:
     os: osx
     osx_image: xcode9
     script:
-    - sudo -H bash -x -e .travis/python.release.sh "${TENSORFLOW_INSTALL}" --nightly ${TRAVIS_BUILD_NUMBER} python python3.4.6 python3.5.3 python3.6.2
+    - sudo -H bash -x -e .travis/python.release.sh "${TENSORFLOW_INSTALL}" --nightly ${TRAVIS_BUILD_NUMBER} python python3.5.3 python3.6.2
     - sudo -H bash -x -e .travis/wheel.test.sh
     after_success:
     - |

--- a/.travis/wheel.configure.sh
+++ b/.travis/wheel.configure.sh
@@ -3,7 +3,7 @@ set -e
 python --version
 python -m pip --version
 if [[ $(uname) == "Darwin" ]]; then
-  for pyVersion in {3.4.6,3.5.3,3.6.2}; do 
+  for pyVersion in {3.5.3,3.6.2}; do
     pyenv install --skip-existing $pyVersion
     pyenv local $pyVersion
     pyPath=$(pyenv which python)


### PR DESCRIPTION
Since 3.4 has been end-of-life I think it makes sense to drop 3.4 for macOS

https://devguide.python.org/devcycle/


/cc @damienpontifex 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>