### PR TITLE
Fix ArrowStreamDataset batch slicing and run thread as daemon

### DIFF
--- a/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
@@ -514,6 +514,7 @@ class ArrowStreamDataset(ArrowBaseDataset):
 
     # Run the server in a thread
     server = threading.Thread(target=run_server)
+    server.daemon = True
     server.start()
 
     if columns is None:
@@ -559,9 +560,9 @@ class ArrowStreamDataset(ArrowBaseDataset):
 
         # If batching, slice DataFrame and convert to record batches
         if batch_size is not None:
-          step = -(-len(df) // batch_size)  # Compute step size (round int up)
-          for start in range(0, len(df), step):
-            df_slice = df[start:start + step]
+          # Pandas will produce a partial batch if there is a remainder
+          for i in range(0, len(df), batch_size):
+            df_slice = df[i:i + batch_size]
             batch = pa.RecordBatch.from_pandas(
                 df_slice, preserve_index=preserve_index)
             yield batch

--- a/tests/test_arrow_eager.py
+++ b/tests/test_arrow_eager.py
@@ -485,6 +485,24 @@ class ArrowDatasetTest(test.TestCase):
         preserve_index=True)
     self.run_test_case(dataset, truth_data, batch_size=batch_size)
 
+  def test_stream_from_pandas_remainder(self):
+    """Test stream from Pandas that produces partial batch"""
+    batch_size = len(self.scalar_data[0]) - 1
+
+    truth_data = TruthData(
+        self.scalar_data,
+        self.scalar_dtypes,
+        self.scalar_shapes)
+
+    batch = self.make_record_batch(truth_data)
+    df = batch.to_pandas()
+
+    dataset = arrow_io.ArrowStreamDataset.from_pandas(
+        df,
+        batch_size=batch_size,
+        preserve_index=False)
+    self.run_test_case(dataset, truth_data, batch_size=batch_size)
+
   def test_stream_from_pandas_iter(self):
     """test_stream_from_pandas_iter"""
 


### PR DESCRIPTION
The `ArrowStreamDataset.from_pandas` was incorrectly slicing the DataFrame into `batch_size` batches, instead of N slices of size `batch_size`. This fix also runs the background thread as daemon.