### PR TITLE
Support repeat in ArrowStreamDataset

### DIFF
--- a/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
@@ -193,9 +193,9 @@ class ArrowDataset(ArrowBaseDataset):
   @classmethod
   def from_record_batches(cls,
                           record_batches,
-                          columns,
                           output_types,
                           output_shapes=None,
+                          columns=None,
                           batch_size=None,
                           batch_mode='keep_remainder'):
     """Create an ArrowDataset directly from Arrow record batches.
@@ -203,7 +203,6 @@ class ArrowDataset(ArrowBaseDataset):
 
     Args:
       record_batches: An Arrow record batch or sequence of record batches
-      columns: A list of column indices to be used in the Dataset
       output_types: Tensor dtypes of the output tensors
       output_shapes: TensorShapes of the output tensors or None to
                      infer partial
@@ -215,6 +214,7 @@ class ArrowDataset(ArrowBaseDataset):
                   "keep_remainder" (default, keeps partial batch data),
                   "drop_remainder" (discard partial batch data),
                   "auto" (size to number of records in Arrow record batch)
+      columns: A list of column indices to be used in the Dataset
     """
     import pyarrow as pa
     if isinstance(record_batches, pa.RecordBatch):
@@ -272,11 +272,11 @@ class ArrowDataset(ArrowBaseDataset):
     output_types, output_shapes = arrow_schema_to_tensor_types(batch.schema)
     return cls.from_record_batches(
         batch,
-        columns,
         output_types,
         output_shapes,
-        batch_size,
-        batch_mode)
+        columns=columns,
+        batch_size=batch_size,
+        batch_mode=batch_mode)
 
 
 class ArrowFeatherDataset(ArrowBaseDataset):

--- a/tests/test_arrow_eager.py
+++ b/tests/test_arrow_eager.py
@@ -545,6 +545,34 @@ class ArrowDatasetTest(test.TestCase):
         preserve_index=False)
     self.run_test_case(dataset, truth_data)
 
+  def test_stream_from_pandas_repeat(self):
+    """test_stream_from_pandas_repeat"""
+
+    batch_data = TruthData(
+        self.scalar_data,
+        self.scalar_dtypes,
+        self.scalar_shapes)
+
+    batch = self.make_record_batch(batch_data)
+    df = batch.to_pandas()
+
+    num_repeat = 10
+
+    dataset = arrow_io.ArrowStreamDataset.from_pandas(
+        df,
+        batch_size=2,
+        preserve_index=False).repeat(num_repeat)
+
+    # patch columns attr so run_test_case can use
+    dataset.columns = list(range(len(batch_data.output_types)))
+
+    truth_data = TruthData(
+        [d * num_repeat for d in batch_data.data],
+        batch_data.output_types,
+        batch_data.output_shapes)
+
+    self.run_test_case(dataset, truth_data, batch_size=2)
+
   def test_bool_array_type(self):
     """
     NOTE: need to test this seperately because to_pandas fails with

--- a/tests/test_arrow_eager.py
+++ b/tests/test_arrow_eager.py
@@ -208,7 +208,6 @@ class ArrowDatasetTest(test.TestCase):
     # test all columns selected
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batch,
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes)
     self.run_test_case(dataset, truth_data)
@@ -217,9 +216,9 @@ class ArrowDatasetTest(test.TestCase):
     columns = (1, 3, len(truth_data.output_types) - 1)
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batch,
-        columns,
         tuple([truth_data.output_types[c] for c in columns]),
-        tuple([truth_data.output_shapes[c] for c in columns]))
+        tuple([truth_data.output_shapes[c] for c in columns]),
+        columns=columns)
     self.run_test_case(dataset, truth_data)
 
     # test construction from pd.DataFrame
@@ -589,9 +588,9 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batch,
-        (0,),
         truth_data.output_types,
-        truth_data.output_shapes)
+        truth_data.output_shapes,
+        columns=(0,))
     self.run_test_case(dataset, truth_data)
 
   def test_incorrect_column_type(self):
@@ -602,7 +601,6 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batch,
-        list(range(len(truth_data.output_types))),
         tuple([dtypes.int32 for _ in truth_data.output_types]),
         truth_data.output_shapes)
     with self.assertRaisesRegex(errors.OpError, 'Arrow type mismatch'):
@@ -619,7 +617,6 @@ class ArrowDatasetTest(test.TestCase):
     batch = self.make_record_batch(truth_data)
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batch,
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes)
 
@@ -745,7 +742,6 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batches,
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes,
         batch_mode='auto')
@@ -776,7 +772,6 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batches,
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes,
         batch_size=batch_size)
@@ -808,7 +803,6 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batches,
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes,
         batch_size=batch_size)
@@ -836,7 +830,6 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         batches,
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes,
         batch_size=batch_size)
@@ -859,7 +852,6 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         [batch],
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes,
         batch_size=batch_size)
@@ -880,7 +872,6 @@ class ArrowDatasetTest(test.TestCase):
 
     dataset = arrow_io.ArrowDataset.from_record_batches(
         [batch],
-        list(range(len(truth_data.output_types))),
         truth_data.output_types,
         truth_data.output_shapes,
         batch_size=batch_size)
@@ -899,7 +890,6 @@ class ArrowDatasetTest(test.TestCase):
     with self.assertRaisesRegex(ValueError, 'Unsupported batch_mode.*doh'):
       arrow_io.ArrowDataset.from_record_batches(
           [self.make_record_batch(truth_data)],
-          list(range(len(truth_data.output_types))),
           truth_data.output_types,
           truth_data.output_shapes,
           batch_mode='doh')


### PR DESCRIPTION
This change adds support for repeating the `ArrowStreamDataset` when using `from_pandas` and `from_record_batches`.  Also changed `ArrowDataset.from_record_batches` column argument to have a default value of None, to match `ArrowStreamDataset`.