### PR TITLE
travis yml refactor repeated code into script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,18 @@ install:
 - export TENSORFLOW_INSTALL="$(python setup.py --package-version)"
 
 stages:
+- lint
 - release
 
 jobs:
   include:
-  - stage: release
-    name: "Lint"
-    script:
-    - bash -x -e .travis/lint.bazel.sh
-    - docker run -i -t --rm -v $PWD:/v -w /v --net=host buildpack-deps:14.04 bash -x -e .travis/lint.python.sh
+  - stage: lint
+    name: Lint Bazel
+    script: bash -x -e .travis/lint.bazel.sh
+  - stage: lint
+    name: Lint Python
+    script: docker run -i -t --rm -v $PWD:/v -w /v --net=host buildpack-deps:14.04 bash -x -e .travis/lint.python.sh
+
   # Preview Release Builds are for TensorFlow 2.0 Preview release.
   # Note only Linux (Ubuntu 18.04) and macOS are supported.
   - stage: release
@@ -47,21 +50,15 @@ jobs:
     script:
     - docker run -i -t --rm -v $PWD:/v -w /v --net=host buildpack-deps:14.04 bash -x -e .travis/python.release.sh tensorflow==2.0.0b1 --preview ${TRAVIS_BUILD_NUMBER} python python3.4 python3.5 python3.6
     - echo "Skip test for now, will fix later"
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_2.0_preview-*.whl
-      fi
+    after_success: bash -x -e after-sucess-tf20.sh
+
   - stage: release
     name: "TensorFlow 2.0 Preview Release Build on Linux with Python 3.7"
     script:
     - docker run -i -t --rm -v $PWD:/v -w /v --net=host ubuntu:16.04 bash -x -e .travis/python3.7+.release.sh python3.7 tensorflow==2.0.0b1 --preview ${TRAVIS_BUILD_NUMBER}
     - echo "Skip test for now, will fix later"
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_2.0_preview-*.whl
-      fi
+    after_success: bash -x -e after-sucess-tf20.sh
+
   - stage: release
     name: "TensorFlow 2.0 Preview Release Build on macOS"
     os: osx
@@ -69,11 +66,7 @@ jobs:
     script:
     - sudo -H bash -x -e .travis/python.release.sh tensorflow==2.0.0b1 --preview ${TRAVIS_BUILD_NUMBER} python
     - sudo -H bash -x -e .travis/wheel.test.sh
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_2.0_preview-*.whl
-      fi
+    after_success: bash -x -e after-sucess-tf20.sh
 
   # Release Builds are for nightly release.
   # Note Python 2.7, 3.4, 3.5, 3.6, 3.7 are supported on Linux
@@ -83,37 +76,15 @@ jobs:
     script:
     - docker run -i -t --rm -v $PWD:/v -w /v --net=host buildpack-deps:14.04 bash -x -e .travis/python.release.sh "${TENSORFLOW_INSTALL}" --nightly ${TRAVIS_BUILD_NUMBER} python python3 python3.5 python3.6
     - echo "Skip test for nightly build, as it has been covered in install build"
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_nightly-*.whl
-        for entry in wheelhouse/tensorflow_io-*.whl ; do
-          sha256sum $entry
-          STATUS=$(curl --write-out %{http_code} --silent --output /dev/null -X POST https://content.dropboxapi.com/2/files/upload --header "Authorization: Bearer ${DROPBOX_ACCESS_TOKEN}" --header "Dropbox-API-Arg: {\"path\": \"/release/${TRAVIS_BUILD_NUMBER}/$entry\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}" --header "Content-Type: application/octet-stream" --data-binary @$entry)
-          if [[ "$STATUS" -ne 200 ]] ; then
-            echo "Upload to Dropbox: $STATUS"
-            exit 1
-          fi
-        done
-      fi
+    after_success: bash -x -e .travis/after-success.sh
+
   - stage: release
     name: "Nightly Release Build on Linux with Python 3.7"
     script:
     - docker run -i -t --rm -v $PWD:/v -w /v --net=host ubuntu:16.04 bash -x -e .travis/python3.7+.release.sh python3.7 "${TENSORFLOW_INSTALL}" --nightly ${TRAVIS_BUILD_NUMBER}
     - echo "Skip test for now, will fix later"
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_nightly-*.whl
-        for entry in wheelhouse/tensorflow_io-*.whl ; do
-          sha256sum $entry
-          STATUS=$(curl --write-out %{http_code} --silent --output /dev/null -X POST https://content.dropboxapi.com/2/files/upload --header "Authorization: Bearer ${DROPBOX_ACCESS_TOKEN}" --header "Dropbox-API-Arg: {\"path\": \"/release/${TRAVIS_BUILD_NUMBER}/$entry\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}" --header "Content-Type: application/octet-stream" --data-binary @$entry)
-          if [[ "$STATUS" -ne 200 ]] ; then
-            echo "Upload to Dropbox: $STATUS"
-            exit 1
-          fi
-        done
-      fi
+    after_success: bash -x -e .travis/after-success.sh
+
   - stage: release
     name: "Nightly Release Build on macOS 2.7"
     os: osx
@@ -121,19 +92,8 @@ jobs:
     script:
     - sudo -H bash -x -e .travis/python.release.sh "${TENSORFLOW_INSTALL}" --nightly ${TRAVIS_BUILD_NUMBER} python
     - sudo -H bash -x -e .travis/wheel.test.sh python
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_nightly-*.whl
-        for entry in wheelhouse/tensorflow_io-*.whl ; do
-          shasum -a 256 $entry
-          STATUS=$(curl --write-out %{http_code} --silent --output /dev/null -X POST https://content.dropboxapi.com/2/files/upload --header "Authorization: Bearer ${DROPBOX_ACCESS_TOKEN}" --header "Dropbox-API-Arg: {\"path\": \"/release/${TRAVIS_BUILD_NUMBER}/$entry\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}" --header "Content-Type: application/octet-stream" --data-binary @$entry)
-          if [[ "$STATUS" -ne 200 ]] ; then
-            echo "Upload to Dropbox: $STATUS"
-            exit 1
-          fi
-        done
-      fi
+    after_success: bash -x -e .travis/after-success.sh
+    
   - stage: release
     name: "Nightly Release Build on macOS 3.5"
     os: osx
@@ -141,19 +101,8 @@ jobs:
     script:
     - sudo -H bash -x -e .travis/python.release.sh "${TENSORFLOW_INSTALL}" --nightly ${TRAVIS_BUILD_NUMBER} python3.5.3
     - sudo -H bash -x -e .travis/wheel.test.sh python3.5.3
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_nightly-*.whl
-        for entry in wheelhouse/tensorflow_io-*.whl ; do
-          shasum -a 256 $entry
-          STATUS=$(curl --write-out %{http_code} --silent --output /dev/null -X POST https://content.dropboxapi.com/2/files/upload --header "Authorization: Bearer ${DROPBOX_ACCESS_TOKEN}" --header "Dropbox-API-Arg: {\"path\": \"/release/${TRAVIS_BUILD_NUMBER}/$entry\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}" --header "Content-Type: application/octet-stream" --data-binary @$entry)
-          if [[ "$STATUS" -ne 200 ]] ; then
-            echo "Upload to Dropbox: $STATUS"
-            exit 1
-          fi
-        done
-      fi
+    after_success: bash -x -e .travis/after-success.sh
+
   - stage: release
     name: "Nightly Release Build on macOS 3.6"
     os: osx
@@ -161,19 +110,7 @@ jobs:
     script:
     - sudo -H bash -x -e .travis/python.release.sh "${TENSORFLOW_INSTALL}" --nightly ${TRAVIS_BUILD_NUMBER} python3.6.2
     - sudo -H bash -x -e .travis/wheel.test.sh python3.6.2
-    after_success:
-    - |
-      if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
-        twine upload wheelhouse/tensorflow_io_nightly-*.whl
-        for entry in wheelhouse/tensorflow_io-*.whl ; do
-          shasum -a 256 $entry
-          STATUS=$(curl --write-out %{http_code} --silent --output /dev/null -X POST https://content.dropboxapi.com/2/files/upload --header "Authorization: Bearer ${DROPBOX_ACCESS_TOKEN}" --header "Dropbox-API-Arg: {\"path\": \"/release/${TRAVIS_BUILD_NUMBER}/$entry\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}" --header "Content-Type: application/octet-stream" --data-binary @$entry)
-          if [[ "$STATUS" -ne 200 ]] ; then
-            echo "Upload to Dropbox: $STATUS"
-            exit 1
-          fi
-        done
-      fi
+    after_success: bash -x -e .travis/after-success.sh
 
 notifications:
 - email: false

--- a/.travis/after-success-tf20.sh
+++ b/.travis/after-success-tf20.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
+
+  twine upload wheelhouse/tensorflow_io_2.0_preview-*.whl
+
+fi

--- a/.travis/after-success.sh
+++ b/.travis/after-success.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+if [[ ( ${TRAVIS_BRANCH} == "master" ) && ( ${TRAVIS_EVENT_TYPE} != "pull_request" ) ]]; then
+
+  twine upload wheelhouse/tensorflow_io_nightly-*.whl
+
+  for entry in wheelhouse/tensorflow_io-*.whl ; do
+    if [[ $(uname) == "Darwin" ]]; then
+      shasum -a 256 $entry
+    else
+      sha256sum $entry
+    fi
+
+    STATUS=$(curl --write-out %{http_code} --silent --output /dev/null -X POST https://content.dropboxapi.com/2/files/upload --header "Authorization: Bearer ${DROPBOX_ACCESS_TOKEN}" --header "Dropbox-API-Arg: {\"path\": \"/release/${TRAVIS_BUILD_NUMBER}/$entry\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}" --header "Content-Type: application/octet-stream" --data-binary @$entry)
+
+    if [[ "$STATUS" -ne 200 ]] ; then
+      echo "Upload to Dropbox: $STATUS"
+      exit 1
+    fi
+  done
+fi

--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -1,20 +1,16 @@
 set -e
 
-if [[ $(uname) == "Darwin" ]]; then
-# The -DGRPC_BAZEL_BUILD is needed because gRPC does not compile on macOS unless
-# it is set.
-  bazel build \
-    --copt=-DGRPC_BAZEL_BUILD \
-    --noshow_progress \
-    --noshow_loading_progress \
-    --verbose_failures \
-    --test_output=errors \
-    -- //tensorflow_io/...
-else
-  bazel build \
-    --noshow_progress \
-    --noshow_loading_progress \
-    --verbose_failures \
-    --test_output=errors \
-    -- //tensorflow_io/...
+args=()
+if [[ $(uname) == "Darwin" ]]; then 
+  # The -DGRPC_BAZEL_BUILD is needed because gRPC does not compile on macOS unless
+  # it is set.
+  args+=(--copt=-DGRPC_BAZEL_BUILD)
 fi
+
+bazel build \
+  "${args[@]}" \
+  --noshow_progress \
+  --noshow_loading_progress \
+  --verbose_failures \
+  --test_output=errors \
+  //tensorflow_io/...


### PR DESCRIPTION
There's a lot of repeated code in the `after_success` block for Travis. Taking this out into a script which slims up the travis definition and puts the common code into a distinct place