### PR TITLE
Deprecate SequenceFile Dataset

### DIFF
--- a/tensorflow_io/hadoop/__init__.py
+++ b/tensorflow_io/hadoop/__init__.py
@@ -21,9 +21,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 from tensorflow_io.hadoop.python.ops.hadoop_dataset_ops import SequenceFileDataset
 
 from tensorflow.python.util.all_util import remove_undocumented
+
+warnings.warn(
+    "SequenceFileDataset is deprecated and will be removed in the next release",
+    DeprecationWarning)
 
 _allowed_symbols = [
     "SequenceFileDataset",


### PR DESCRIPTION
SequenceFile Dataset was never in good use,
and the trend of industry aggressively switching from
self-managed Hadoop system to cloud-vendor provided storage (S3/GCS/etc)
makes this Dataset format less and less relevant.
This PR deprecates SequenceFile Dataset

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>