### PR TITLE
[WIP] Expose top level tfio.Dataset as a superset of tf.data.Dataset

### DIFF
--- a/tensorflow_io/__init__.py
+++ b/tensorflow_io/__init__.py
@@ -57,3 +57,7 @@ def _load_library(filename, lib="op"):
   raise NotImplementedError(
       "unable to open file: " +
       "{}, from paths: {}\ncaused by: {}".format(filename, filenames, errs))
+
+from tensorflow_io.core.python.ops import dataset_ops # pylint: disable=wrong-import-position
+
+Dataset = dataset_ops.create_dataste_class()

--- a/tensorflow_io/core/python/ops/__init__.py
+++ b/tensorflow_io/core/python/ops/__init__.py
@@ -17,5 +17,5 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io import _load_library
+from tensorflow_io import _load_library # pylint: disable=cyclic-import
 core_ops = _load_library('libtensorflow_io.so')

--- a/tensorflow_io/core/python/ops/data_ops.py
+++ b/tensorflow_io/core/python/ops/data_ops.py
@@ -18,40 +18,6 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow_io.core.python.ops import core_ops
-
-class _AdjustBatchDataset(tf.compat.v2.data.Dataset):
-  """AdjustBatchDataset"""
-
-  def __init__(self, input_dataset, batch_size, batch_mode=""):
-    """Create a AdjustBatchDataset."""
-    self._input_dataset = input_dataset
-    self._batch_size = batch_size
-    self._batch_mode = batch_mode
-
-    self._structure = input_dataset._element_structure._unbatch()._batch(None) # pylint: disable=protected-access
-
-    variant_tensor = core_ops.adjust_batch_dataset(
-        self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-        batch_size=self._batch_size,
-        batch_mode=self._batch_mode,
-        output_types=self._structure._flat_types, # pylint: disable=protected-access
-        output_shapes=self._structure._flat_shapes) # pylint: disable=protected-access
-
-    super(_AdjustBatchDataset, self).__init__(variant_tensor)
-
-  def _inputs(self):
-    return [self._input_dataset]
-
-  @property
-  def _element_structure(self):
-    return self._structure
-
-def rebatch(batch_size, batch_mode=""):
-  def _apply_fn(dataset):
-    return _AdjustBatchDataset(dataset, batch_size, batch_mode)
-
-  return _apply_fn
 
 # Note: BaseDataset could be used by Dataset implementations
 # that does not utilize DataInput implementation.

--- a/tensorflow_io/core/python/ops/dataset_ops.py
+++ b/tensorflow_io/core/python/ops/dataset_ops.py
@@ -1,0 +1,116 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dataset."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import functools
+import inspect
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
+
+class _Dataset(tf.compat.v2.data.Dataset):
+  """"_Dataset"""
+
+  @abc.abstractmethod
+  def _inputs(self):
+    """Returns a list of the input datasets of the dataset."""
+
+    raise NotImplementedError("Dataset._inputs")
+
+  @abc.abstractproperty
+  def _element_structure(self):
+    """The structure of an element of this dataset.
+    Returns:
+      A `Structure` object representing the structure of an element of this
+      dataset.
+    """
+    raise NotImplementedError("Dataset._element_structure")
+
+  def rebatch(self, batch_size, batch_mode=""):
+    def _apply_fn(dataset):
+      return _AdjustBatchDataset(dataset, batch_size, batch_mode)
+
+    return self.apply(_apply_fn)
+
+class _AdjustBatchDataset(_Dataset):
+  """AdjustBatchDataset"""
+
+  def __init__(self, input_dataset, batch_size, batch_mode=""):
+    """Create a AdjustBatchDataset."""
+    self._input_dataset = input_dataset
+    self._batch_size = batch_size
+    self._batch_mode = batch_mode
+    self._structure = input_dataset._element_structure._unbatch()._batch(None) # pylint: disable=protected-access
+    variant_tensor = core_ops.adjust_batch_dataset(
+        self._input_dataset._variant_tensor, # pylint: disable=protected-access
+        batch_size=self._batch_size,
+        batch_mode=self._batch_mode,
+        output_types=self._structure._flat_types, # pylint: disable=protected-access
+        output_shapes=self._structure._flat_shapes) # pylint: disable=protected-access
+
+    super(_AdjustBatchDataset, self).__init__(variant_tensor)
+
+  def _inputs(self):
+    return [self._input_dataset]
+
+  @property
+  def _element_structure(self):
+    return self._structure
+
+
+class _DatasetAdapter(_Dataset):
+  """_DatasetAdapter"""
+
+  def __init__(self, dataset):
+    self._dataset = dataset
+    super(_DatasetAdapter, self).__init__(self._dataset._variant_tensor) # pylint: disable=protected-access
+
+  def _inputs(self):
+    return self._dataset._inputs() # pylint: disable=protected-access
+
+  @property
+  def _element_structure(self):
+    return self._dataset._element_structure # pylint: disable=protected-access
+
+def dataset_decorator(func):
+  @functools.wraps(func)
+  def f(*args, **kwargs):
+    v = func(*args, **kwargs)
+    if ((isinstance(v, tf.compat.v2.data.Dataset)) and
+        (not isinstance(v, _DatasetAdapter))):
+      return _DatasetAdapter(v)
+    return v
+  return f
+
+def create_dataste_class():
+  """create_dataste_class"""
+  for k, f in inspect.getmembers(
+      tf.compat.v2.data.Dataset,
+      lambda f: inspect.isfunction(f) or inspect.ismethod(f)):
+    if k not in _Dataset.__dict__:
+      # alternative: inspect.ismethod(f) and f.__self__ is not None
+      if ((k in tf.compat.v2.data.Dataset.__dict__) and
+          (isinstance(tf.compat.v2.data.Dataset.__dict__[k], classmethod))):
+        setattr(_Dataset, k, classmethod(dataset_decorator(f)))
+      elif ((k in tf.compat.v2.data.Dataset.__dict__) and
+            (isinstance(tf.compat.v2.data.Dataset.__dict__[k], staticmethod))):
+        setattr(_Dataset, k, staticmethod(dataset_decorator(f)))
+      else:
+        setattr(_Dataset, k, dataset_decorator(f))
+  return _Dataset

--- a/tests/test_api_eager.py
+++ b/tests/test_api_eager.py
@@ -1,0 +1,55 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""High level API tests for tensorflow_io.Dataset"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+import tensorflow as tf
+if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
+  tf.compat.v1.enable_eager_execution()
+import tensorflow.compat.v2.data as data # pylint: disable=wrong-import-position
+import tensorflow_io as tfio # pylint: disable=wrong-import-position
+
+def test_dataset():
+  """test_dataset"""
+  def assert_equal(io_v, tf_v):
+    assert isinstance(io_v, tfio.Dataset)
+    assert np.all(tf.stack(
+        [v for v in io_v]).numpy() == tf.stack(
+            [v for v in tf_v]).numpy())
+
+  io_v = tfio.Dataset.range(1, 4)
+  tf_v = data.Dataset.range(1, 4)
+  assert_equal(io_v, tf_v)
+
+  io_v = io_v.concatenate(tfio.Dataset.range(4, 8))
+  tf_v = tf_v.concatenate(data.Dataset.range(4, 8))
+  assert_equal(io_v, tf_v)
+
+  io_v = io_v.filter(lambda x: x < 3)
+  tf_v = tf_v.filter(lambda x: x < 3)
+  assert_equal(io_v, tf_v)
+
+  io_v = io_v.batch(3).rebatch(5).rebatch(3)
+  tf_v = tf_v.batch(3)
+  assert_equal(io_v, tf_v)
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tests/test_grpc_eager.py
+++ b/tests/test_grpc_eager.py
@@ -22,7 +22,9 @@ import pytest
 import numpy as np
 
 import tensorflow as tf
-import tensorflow_io.grpc as grpc_io
+if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
+  tf.compat.v1.enable_eager_execution()
+import tensorflow_io.grpc as grpc_io # pylint: disable=wrong-import-position
 
 @pytest.mark.skipif(
     not (hasattr(tf, "version") and

--- a/tests/test_text_eager.py
+++ b/tests/test_text_eager.py
@@ -27,7 +27,6 @@ import tensorflow as tf
 if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
   tf.compat.v1.enable_eager_execution()
 import tensorflow_io.text as text_io # pylint: disable=wrong-import-position
-import tensorflow_io.core.python.ops.data_ops as core_io # pylint: disable=wrong-import-position
 
 def test_read_text():
   """test_read_text"""
@@ -78,34 +77,6 @@ def test_text_input():
       assert lines[i] == v.numpy()[1]
       i += 1
   assert i == len(lines)
-
-  for batch in [1, 2, 3, 4, 5]:
-    rebatch_dataset = text_dataset.apply(core_io.rebatch(batch))
-    i = 0
-    for v in rebatch_dataset:
-      for vv in v.numpy():
-        assert lines[i] == vv
-        i += 1
-    assert i == len(lines)
-
-  rebatch_dataset = text_dataset.apply(core_io.rebatch(5, "drop"))
-  i = 0
-  for v in rebatch_dataset:
-    for vv in v.numpy():
-      assert lines[i] == vv
-      i += 1
-  assert i == 45
-
-  rebatch_dataset = text_dataset.apply(core_io.rebatch(5, "pad"))
-  i = 0
-  for v in rebatch_dataset:
-    for vv in v.numpy():
-      if i < len(lines):
-        assert lines[i] == vv
-      else:
-        assert vv.decode() == ""
-      i += 1
-  assert i == 50
 
 def test_text_output_sequence():
   """Test case based on fashion mnist tutorial"""


### PR DESCRIPTION
This PR expose top level tfio.Dataset as a superset of tf.data.Dataset.

In the past, we have been trying to place different Dataset implementations
into individual modules. For example, we have tensorflow_io.arrow.ArrowFeatherDataset
under `tensorflow_io.arrow`. As the project grow we already have too many modules and
it is getting harder to find the features we want.

This PR tries to expose a top level tfio.Dataset as a superset of tf.data.Dataset,
so that users could use tfio.Dataset the same way as tf.data.Dataset and
with additional functionalities.

To achive that first we have to expose all functions in tf.data.Dataset to tfio.Dataset.
Since tfio.Dataset is a subclass we also have to fix the return types so that
`tfio.Dataset.range(5)` will returns a subclass of `tfio.Dataset` (even though
we redirect tfio.Dataset.range(5) to tf.data.Dataset.range(5) which by nature
will return a subclass of `tf.data.Dataset`.)

This PR creates an wrapper of `_DatasetAdapter` and `dataset_decorator` so that
return type could be adjusted.

Also, all functions/methods of `tf.data.Dataset` are routed with `tfio.Dataset`
automatically. (We could decide to manually define those functions/methods instead,
if we feel it is much better).

In addition to create a class of tfio.Dataset, this PR also adds the `rebatch()`
as part of `tfio.Dataset`, so that user could use it in an natural way.
```
tfio.Dataset.range(5).batch(3).rebatch(5)
```

Further, I think we could also start exposing individual datasets as part of
the static method in `tfio.Dataset`. For example, we could imagine:
```
tfio.Dataset.from_arrow(filename)
```
which would be very similiar to:
```
tf.data.Dataset.from_tensors(...)
```

Note those static methods of `from_arrow` has not been added yet, we could discuss
what would be the best API to expose those.

Finally the way of using `inspect.getmembers` with `_DatasetAdapter` and `dataset_decorator`
in this PR may not be the best way. A more pythonic way might be to use metaclass.
However, as tf.data.Dataset is also a metaclass so things are complicated. This PR is
what I can think of so far but ideas or contributions to make the mechanism more elegant
are welcomed.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>