### PR TITLE
Move _load_library to tensorflow_io.core.python.ops

### DIFF
--- a/tensorflow_io/__init__.py
+++ b/tensorflow_io/__init__.py
@@ -17,43 +17,4 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import sys
-import inspect
-
 import tensorflow as tf
-from tensorflow import errors
-
-def _load_library(filename, lib="op"):
-  """_load_library"""
-  f = inspect.getfile(sys._getframe(1)) # pylint: disable=protected-access
-
-  # Construct filename
-  f = os.path.join(os.path.dirname(f), filename)
-  filenames = [f]
-
-  # Add datapath to load if en var is set, used for running tests where shared
-  # libraries are built in a different path
-  datapath = os.environ.get('TFIO_DATAPATH')
-  if datapath is not None:
-    # Build filename from `datapath` + `package_name` + `relpath_to_library`
-    f = os.path.join(
-        datapath, __name__, os.path.relpath(f, os.path.dirname(__file__)))
-    filenames.append(f)
-
-  # Function to load the library, return True if file system library is loaded
-  load_fn = tf.load_op_library if lib == "op" \
-      else lambda f: tf.compat.v1.load_file_system_library(f) is None
-
-  # Try to load all paths for file, fail if none succeed
-  errs = []
-  for f in filenames:
-    try:
-      l = load_fn(f)
-      if l is not None:
-        return l
-    except errors.NotFoundError as e:
-      errs.append(str(e))
-  raise NotImplementedError(
-      "unable to open file: " +
-      "{}, from paths: {}\ncaused by: {}".format(filename, filenames, errs))

--- a/tensorflow_io/bigquery/python/ops/bigquery_api.py
+++ b/tensorflow_io/bigquery/python/ops/bigquery_api.py
@@ -31,7 +31,7 @@ from tensorflow.python.data.experimental.ops import interleave_ops
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import structure
 from tensorflow.python.framework import dtypes
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 
 
 _bigquery_so = _load_library("_bigquery.so")

--- a/tensorflow_io/bigtable/python/ops/bigtable_api.py
+++ b/tensorflow_io/bigtable/python/ops/bigtable_api.py
@@ -36,7 +36,7 @@ from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import structure
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import tensor_shape
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 
 _bigtable_so = _load_library("_bigtable.so")
 

--- a/tensorflow_io/cloud/python/ops/bigquery_reader_ops.py
+++ b/tensorflow_io/cloud/python/ops/bigquery_reader_ops.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import io_ops
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 
 _bigquery_reader_so = _load_library("_bigquery_reader_ops.so")
 

--- a/tensorflow_io/cloud/python/ops/gcs_config_ops.py
+++ b/tensorflow_io/cloud/python/ops/gcs_config_ops.py
@@ -25,7 +25,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.training import training
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 
 _gcs_config_so = _load_library("_gcs_config_ops.so")
 

--- a/tensorflow_io/core/python/ops/__init__.py
+++ b/tensorflow_io/core/python/ops/__init__.py
@@ -17,5 +17,48 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io import _load_library
+import os
+import sys
+import inspect
+
+import tensorflow as tf
+
+def _load_library(filename, lib="op"):
+  """_load_library"""
+  f = inspect.getfile(sys._getframe(1)) # pylint: disable=protected-access
+
+  # Construct filename
+  f = os.path.join(os.path.dirname(f), filename)
+  filenames = [f]
+
+  # Add datapath to load if en var is set, used for running tests where shared
+  # libraries are built in a different path
+  datapath = os.environ.get('TFIO_DATAPATH')
+  if datapath is not None:
+    # Build filename from:
+    # `datapath` + `tensorflow_io` + `package_name` + `relpath_to_library`
+    rootpath = os.path.dirname(sys.modules['tensorflow_io'].__file__)
+    filename = sys.modules[__name__].__file__
+    f = os.path.join(
+        datapath, "tensorflow_io",
+        os.path.relpath(os.path.dirname(filename), rootpath),
+        os.path.relpath(f, os.path.dirname(filename)))
+    filenames.append(f)
+  # Function to load the library, return True if file system library is loaded
+  load_fn = tf.load_op_library if lib == "op" \
+      else lambda f: tf.compat.v1.load_file_system_library(f) is None
+
+  # Try to load all paths for file, fail if none succeed
+  errs = []
+  for f in filenames:
+    try:
+      l = load_fn(f)
+      if l is not None:
+        return l
+    except tf.errors.NotFoundError as e:
+      errs.append(str(e))
+  raise NotImplementedError(
+      "unable to open file: " +
+      "{}, from paths: {}\ncaused by: {}".format(filename, filenames, errs))
+
 core_ops = _load_library('libtensorflow_io.so')

--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import ctypes
 
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 
 import _ctypes
 

--- a/tensorflow_io/gcs/python/ops/gcs_config_ops.py
+++ b/tensorflow_io/gcs/python/ops/gcs_config_ops.py
@@ -26,7 +26,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.training import training
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 
 # Some GCS operations may be pre-defined and available via tf.contrib in
 # earlier TF versions. Because these ops are pre-registered, they will not be

--- a/tensorflow_io/grpc/python/ops/grpc_ops.py
+++ b/tensorflow_io/grpc/python/ops/grpc_ops.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import tensorflow as tf
 from tensorflow.compat.v1 import data
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 grpc_ops = _load_library('_grpc_ops.so')
 
 class GRPCDataset(data.Dataset):

--- a/tensorflow_io/hadoop/python/ops/hadoop_dataset_ops.py
+++ b/tensorflow_io/hadoop/python/ops/hadoop_dataset_ops.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import tensorflow as tf
 from tensorflow import dtypes
 from tensorflow.compat.v1 import data
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 hadoop_ops = _load_library('_hadoop_ops.so')
 
 

--- a/tensorflow_io/image/python/ops/image_dataset_ops.py
+++ b/tensorflow_io/image/python/ops/image_dataset_ops.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import tensorflow as tf
 from tensorflow import dtypes
 from tensorflow.compat.v1 import data
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 image_ops = _load_library('_image_ops.so')
 
 

--- a/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import tensorflow as tf
 from tensorflow import dtypes
 from tensorflow.compat.v1 import data
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 kafka_ops = _load_library('_kafka_ops.so')
 
 class KafkaDataset(data.Dataset):

--- a/tensorflow_io/kafka/python/ops/kafka_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_ops.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 kafka_ops = _load_library('_kafka_ops.so')
 
 

--- a/tensorflow_io/kinesis/python/ops/kinesis_dataset_ops.py
+++ b/tensorflow_io/kinesis/python/ops/kinesis_dataset_ops.py
@@ -21,7 +21,7 @@ import tensorflow as tf
 
 from tensorflow import dtypes
 from tensorflow.compat.v1 import data
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 kinesis_ops = _load_library('_kinesis_ops.so')
 
 class KinesisDataset(data.Dataset):

--- a/tensorflow_io/libsvm/python/ops/libsvm_dataset_ops.py
+++ b/tensorflow_io/libsvm/python/ops/libsvm_dataset_ops.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 from tensorflow import sparse
 from tensorflow.compat.v1 import data
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 gen_libsvm_ops = _load_library('_libsvm_ops.so')
 
 

--- a/tensorflow_io/oss/python/ops/ossfs_ops.py
+++ b/tensorflow_io/oss/python/ops/ossfs_ops.py
@@ -22,6 +22,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 
 _load_library("_oss_ops.so")

--- a/tensorflow_io/pcap/python/ops/pcap_ops.py
+++ b/tensorflow_io/pcap/python/ops/pcap_ops.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """PcapDataset"""
 import tensorflow as tf
-from tensorflow_io.core.python.ops import data_ops as data_ops
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import data_ops
+from tensorflow_io.core.python.ops import _load_library
 pcap_ops = _load_library('_pcap_ops.so')
 
 

--- a/tensorflow_io/pubsub/python/ops/pubsub_dataset_ops.py
+++ b/tensorflow_io/pubsub/python/ops/pubsub_dataset_ops.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import tensorflow as tf
 from tensorflow import dtypes
 from tensorflow.compat.v1 import data
-from tensorflow_io import _load_library
+from tensorflow_io.core.python.ops import _load_library
 pubsub_ops = _load_library('_pubsub_ops.so')
 
 class PubSubDataset(data.Dataset):


### PR DESCRIPTION
_load_library used to be defined in tensorflow_io/__init__.py which is not really desired as we actually want to use tensorflow_io/__init__.py to expose "top level APIs"

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>