### PR TITLE
Fix a typo in README.md to make bazel build work for docker container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ $ docker run -it --rm --net=host -v ${PWD}:/v -w /v tfio-dev
 $ # In Docker, configure will install TensorFlow or use existing install
 $ ./configure.sh
 $ # Build TensorFlow I/O C++. For compilation optimization flags, the default (-march=native) optimizes the generated code for your machine's CPU type. [see here](https://www.tensorflow.org/install/source#configuration_options)
-$ bazel build -c opt --copt=-match=native -s --verbose_failures //tensorflow_io/...
+$ bazel build -c opt --copt=-march=native --copt=-fPIC -s --verbose_failures //tensorflow_io/...
 $ # Run tests with PyTest, note: some tests require launching additional containers to run (see below)
 $ pytest tests/
 $ # Build the TensorFlow I/O package


### PR DESCRIPTION
fixes #400 