### PR TITLE
Split out the bazel build to trigger Travis CI cache.

### DIFF
--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -57,7 +57,7 @@ bazel build \
   --noshow_loading_progress \
   --verbose_failures \
   --test_output=errors \
-  -- //tensorflow_io/...
+  -- //tensorflow_io/core:all
 
 rm -rf build && mkdir -p build
 


### PR DESCRIPTION
Split out the bazel build to trigger Travis CI cache.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>