### PR TITLE
Add tfio.IOTensor.from_parquet support

### DIFF
--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -29,6 +29,7 @@ from tensorflow_io.core.python.ops import feather_io_tensor_ops
 from tensorflow_io.core.python.ops import csv_io_tensor_ops
 from tensorflow_io.core.python.ops import avro_io_tensor_ops
 from tensorflow_io.core.python.ops import ffmpeg_io_tensor_ops
+from tensorflow_io.core.python.ops import parquet_io_tensor_ops
 
 class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
   """IOTensor
@@ -422,3 +423,20 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
     with tf.name_scope(kwargs.get("name", "IOFromFFmpeg")):
       return ffmpeg_io_tensor_ops.FFmpegIOTensor(
           filename, internal=True)
+
+  @classmethod
+  def from_parquet(cls,
+                   filename,
+                   **kwargs):
+    """Creates an `IOTensor` from a parquet file.
+
+    Args:
+      filename: A string, the filename of a parquet file.
+      name: A name prefix for the IOTensor (optional).
+
+    Returns:
+      A `IOTensor`.
+
+    """
+    with tf.name_scope(kwargs.get("name", "IOFromParquet")):
+      return parquet_io_tensor_ops.ParquetIOTensor(filename, internal=True)

--- a/tensorflow_io/core/python/ops/parquet_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/parquet_io_tensor_ops.py
@@ -1,0 +1,60 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""ParquetIOTensor"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import uuid
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import io_tensor_ops
+from tensorflow_io.core.python.ops import core_ops
+
+class ParquetIOTensor(io_tensor_ops._TableIOTensor): # pylint: disable=protected-access
+  """ParquetIOTensor"""
+
+  #=============================================================================
+  # Constructor (private)
+  #=============================================================================
+  def __init__(self,
+               filename,
+               capacity=None,
+               internal=False):
+    with tf.name_scope("ParquetIOTensor") as scope:
+      resource, columns = core_ops.parquet_indexable_init(
+          filename,
+          container=scope,
+          shared_name="%s/%s" % (filename, uuid.uuid4().hex))
+      partitions = None
+      if capacity is not None:
+        partitions = core_ops.parquet_indexable_partitions(resource)
+        partitions = partitions.numpy().tolist()
+        if capacity > 0:
+          partitions = [
+              v for e in partitions for v in list(
+                  [capacity] * (e // capacity) + [e % capacity])]
+      columns = [column.decode() for column in columns.numpy().tolist()]
+      spec = []
+      for column in columns:
+        shape, dtype = core_ops.parquet_indexable_spec(resource, column)
+        shape = tf.TensorShape(shape.numpy())
+        dtype = tf.as_dtype(dtype.numpy())
+        spec.append(tf.TensorSpec(shape, dtype, column))
+      spec = tuple(spec)
+      super(ParquetIOTensor, self).__init__(
+          spec, columns,
+          resource, core_ops.parquet_indexable_read,
+          partitions=partitions, internal=internal)

--- a/tensorflow_io/parquet/kernels/parquet_kernels.cc
+++ b/tensorflow_io/parquet/kernels/parquet_kernels.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow_io/core/kernels/io_interface.h"
 #include "tensorflow_io/arrow/kernels/arrow_kernels.h"
 #include "parquet/api/reader.h"
 
@@ -218,5 +219,186 @@ REGISTER_KERNEL_BUILDER(Name("ReadParquet").Device(DEVICE_CPU),
 
 
 }  // namespace
+
+
+class ParquetIndexable : public IOIndexableInterface {
+ public:
+  ParquetIndexable(Env* env)
+  : env_(env) {}
+
+  ~ParquetIndexable() {}
+  Status Init(const std::vector<string>& input, const std::vector<string>& metadata, const void* memory_data, const int64 memory_size) override {
+    if (input.size() > 1) {
+      return errors::InvalidArgument("more than 1 filename is not supported");
+    }
+    const string& filename = input[0];
+    file_.reset(new SizedRandomAccessFile(env_, filename, memory_data, memory_size));
+    TF_RETURN_IF_ERROR(file_->GetFileSize(&file_size_));
+
+    parquet_file_.reset(new ArrowRandomAccessFile(file_.get(), file_size_));
+
+    parquet_file_.reset(new ArrowRandomAccessFile(file_.get(), file_size_));
+    parquet_reader_ = parquet::ParquetFileReader::Open(parquet_file_);
+    parquet_metadata_ = parquet_reader_->metadata();
+
+    shapes_.clear();
+    dtypes_.clear();
+    columns_.clear();
+    for (size_t i = 0; i < parquet_metadata_->num_columns(); i++) {
+      ::tensorflow::DataType dtype;
+      switch(parquet_metadata_->schema()->Column(i)->physical_type()) {
+      case parquet::Type::BOOLEAN:
+        dtype = ::tensorflow::DT_BOOL;
+        break;
+      case parquet::Type::INT32:
+        dtype = ::tensorflow::DT_INT32;
+        break;
+      case parquet::Type::INT64:
+        dtype = ::tensorflow::DT_INT64;
+        break;
+      case parquet::Type::INT96: // Deprecated, thrown out exception when access with __getitem__
+        dtype = ::tensorflow::DT_INT64;
+        break;
+      case parquet::Type::FLOAT:
+        dtype = ::tensorflow::DT_FLOAT;
+        break;
+      case parquet::Type::DOUBLE:
+        dtype = ::tensorflow::DT_DOUBLE;
+        break;
+      case parquet::Type::BYTE_ARRAY:
+        dtype = ::tensorflow::DT_STRING;
+        break;
+      case parquet::Type::FIXED_LEN_BYTE_ARRAY:
+        dtype = ::tensorflow::DT_STRING;
+        break;
+      default:
+        return errors::InvalidArgument("parquet data type is not supported: ", parquet_metadata_->schema()->Column(i)->physical_type());
+        break;
+      }
+      shapes_.push_back(TensorShape({static_cast<int64>(parquet_metadata_->num_rows())}));
+      dtypes_.push_back(dtype);
+      columns_.push_back(parquet_metadata_->schema()->Column(i)->path().get()->ToDotString());
+      columns_index_[parquet_metadata_->schema()->Column(i)->path().get()->ToDotString()] = i;
+    }
+
+    return Status::OK();
+  }
+  Status Partitions(std::vector<int64> *partitions) override {
+    partitions->clear();
+    for (int row_group = 0; row_group < parquet_metadata_->num_row_groups(); row_group++) {
+      std::shared_ptr<parquet::RowGroupReader> row_group_reader = parquet_reader_->RowGroup(row_group);
+      partitions->push_back(row_group_reader->metadata()->num_rows());
+    }
+    return Status::OK();
+  }
+  Status Components(std::vector<string>* components) override {
+    components->clear();
+    for (size_t i = 0; i < columns_.size(); i++) {
+      components->push_back(columns_[i]);
+    }
+    return Status::OK();
+  }
+  Status Spec(const string& component, PartialTensorShape* shape, DataType* dtype, bool label) override {
+    if (columns_index_.find(component) == columns_index_.end()) {
+      return errors::InvalidArgument("component ", component, " is invalid");
+    }
+    int64 column_index = columns_index_[component];
+    *shape = shapes_[column_index];
+    *dtype = dtypes_[column_index];
+    return Status::OK();
+  }
+
+  Status Read(const int64 start, const int64 stop, const string& component, Tensor* value, Tensor* label) override {
+    if (columns_index_.find(component) == columns_index_.end()) {
+      return errors::InvalidArgument("component ", component, " is invalid");
+    }
+    int64 column_index = columns_index_[component];
+    const string& column = component;
+
+    int64 row_group_offset = 0;
+    for (int row_group = 0; row_group < parquet_metadata_->num_row_groups(); row_group++) {
+      std::shared_ptr<parquet::RowGroupReader> row_group_reader = parquet_reader_->RowGroup(row_group);
+      // Skip if row group is not within [start..stop]
+      if ((row_group_offset + row_group_reader->metadata()->num_rows() < start) || (stop <= row_group_offset)) {
+        row_group_offset += row_group_reader->metadata()->num_rows();
+        continue;
+      }
+      // Find row_to_read range
+      int64 row_to_read_start = row_group_offset > start ? row_group_offset : start;
+      int64 row_to_read_final = (row_group_offset + row_group_reader->metadata()->num_rows()) < (stop) ? (row_group_offset + row_group_reader->metadata()->num_rows()) : (stop);
+      int64 row_to_read_count = row_to_read_final - row_to_read_start;
+
+      // TODO: parquet is RowGroup based so ideally the RowGroup should be cached
+      // with the hope of indexing and slicing happens on each row. For now no caching
+      // is done yet.
+      std::shared_ptr<parquet::ColumnReader> column_reader = row_group_reader->Column(column_index);
+
+      // buffer to fill location is value.data()[row_to_read_start - start]
+
+      #define PARQUET_PROCESS_TYPE(ptype, type) { \
+          parquet::TypedColumnReader<ptype>* reader = \
+              static_cast<parquet::TypedColumnReader<ptype>*>( \
+                  column_reader.get()); \
+          if (row_to_read_start > row_group_offset) { \
+            reader->Skip(row_to_read_start - row_group_offset); \
+          } \
+          ptype::c_type* value_p = (ptype::c_type *)(void *)(&(value->flat<type>().data()[row_to_read_start - start])); \
+          int64_t values_read; \
+          int64_t levels_read = reader->ReadBatch(row_to_read_count, nullptr, nullptr, value_p, &values_read); \
+          if (!(levels_read == values_read && levels_read == row_to_read_count)) { \
+            return errors::InvalidArgument("null value in column: ", column); \
+          } \
+        }
+      switch (parquet_metadata_->schema()->Column(column_index)->physical_type()) {
+      case parquet::Type::BOOLEAN:
+        PARQUET_PROCESS_TYPE(parquet::BooleanType, bool);
+        break;
+      case parquet::Type::INT32:
+        PARQUET_PROCESS_TYPE(parquet::Int32Type, int32);
+        break;
+      case parquet::Type::INT64:
+        PARQUET_PROCESS_TYPE(parquet::Int64Type, int64);
+          break;
+      case parquet::Type::FLOAT:
+        PARQUET_PROCESS_TYPE(parquet::FloatType, float);
+        break;
+      case parquet::Type::DOUBLE:
+        PARQUET_PROCESS_TYPE(parquet::DoubleType, double);
+        break;
+      default:
+        return errors::InvalidArgument("invalid data type: ", parquet_metadata_->schema()->Column(column_index)->physical_type());
+      }
+      row_group_offset += row_group_reader->metadata()->num_rows();
+    }
+    return Status::OK();
+  }
+
+  string DebugString() const override {
+    mutex_lock l(mu_);
+    return strings::StrCat("ParquetIndexable");
+  }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+  std::unique_ptr<SizedRandomAccessFile> file_ GUARDED_BY(mu_);
+  uint64 file_size_ GUARDED_BY(mu_);
+  std::shared_ptr<ArrowRandomAccessFile> parquet_file_;
+  std::unique_ptr<::parquet::ParquetFileReader> parquet_reader_;
+  std::shared_ptr<::parquet::FileMetaData> parquet_metadata_;
+
+  std::vector<DataType> dtypes_;
+  std::vector<TensorShape> shapes_;
+  std::vector<string> columns_;
+  std::unordered_map<string, int64> columns_index_;
+};
+
+REGISTER_KERNEL_BUILDER(Name("ParquetIndexableInit").Device(DEVICE_CPU),
+                        IOInterfaceInitOp<ParquetIndexable>);
+REGISTER_KERNEL_BUILDER(Name("ParquetIndexableSpec").Device(DEVICE_CPU),
+                        IOInterfaceSpecOp<ParquetIndexable>);
+REGISTER_KERNEL_BUILDER(Name("ParquetIndexablePartitions").Device(DEVICE_CPU),
+                        IOIndexablePartitionsOp<ParquetIndexable>);
+REGISTER_KERNEL_BUILDER(Name("ParquetIndexableRead").Device(DEVICE_CPU),
+                        IOIndexableReadOp<ParquetIndexable>);
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/parquet/ops/parquet_ops.cc
+++ b/tensorflow_io/parquet/ops/parquet_ops.cc
@@ -44,5 +44,52 @@ REGISTER_OP("ReadParquet")
        c->set_output(0, c->MakeShape({c->UnknownDim()}));
        return Status::OK();
      });
+REGISTER_OP("ParquetIndexableInit")
+  .Input("input: string")
+  .Output("resource: resource")
+  .Output("components: string")
+  .Attr("container: string = ''")
+  .Attr("shared_name: string = ''")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->Scalar());
+    c->set_output(1, c->MakeShape({}));
+    return Status::OK();
+   });
+
+REGISTER_OP("ParquetIndexableSpec")
+  .Input("input: resource")
+  .Output("shape: int64")
+  .Output("dtype: int64")
+  .Attr("component: string")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->MakeShape({c->UnknownDim()}));
+    c->set_output(1, c->MakeShape({}));
+    return Status::OK();
+   });
+
+REGISTER_OP("ParquetIndexableRead")
+  .Input("input: resource")
+  .Input("start: int64")
+  .Input("stop: int64")
+  .Output("value: dtype")
+  .Attr("component: string")
+  .Attr("shape: shape")
+  .Attr("dtype: type")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    PartialTensorShape shape;
+    TF_RETURN_IF_ERROR(c->GetAttr("shape", &shape));
+    shape_inference::ShapeHandle entry;
+    TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(shape, &entry));
+    c->set_output(0, entry);
+    return Status::OK();
+   });
+
+REGISTER_OP("ParquetIndexablePartitions")
+  .Input("input: resource")
+  .Output("partitions: int64")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->MakeShape({c->UnknownDim()}));
+    return Status::OK();
+   });
 
 }  // namespace tensorflow

--- a/tensorflow_io/parquet/python/ops/parquet_ops.py
+++ b/tensorflow_io/parquet/python/ops/parquet_ops.py
@@ -17,9 +17,17 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops as parquet_ops
 from tensorflow_io.core.python.ops import data_ops
+
+warnings.warn(
+    "The tensorflow_io.parquet.ParquetDataset is "
+    "deprecated. Please look for tfio.IOTensor.from_parquet "
+    "for reading parquet files into tensorflow.",
+    DeprecationWarning)
 
 def list_parquet_columns(filename, **kwargs):
   """list_parquet_columns"""

--- a/tests/test_avro_eager.py
+++ b/tests/test_avro_eager.py
@@ -119,6 +119,7 @@ def test_avro_dataset_partition():
       assert im.numpy() == 100.0 + i
       assert re.numpy() == 100.0 * i
       i += 1
+    assert i == 100
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Parquet columnar file format that naturally fits into a table/column data. Since Parquet file itself is indexable, degenerating parquet into an iterable dataset is not desirable as it loses convenience and flexibility.

This PR adds tfio.IOTensor.from_parquet support so that it is possible to acess parquet data through natual `__getitem__` operations.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>