### PR TITLE
Add tfio.IOTensor.from_hdf5 support

### DIFF
--- a/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
@@ -1,0 +1,51 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""HDF5IOTensor"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import uuid
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import io_tensor_ops
+from tensorflow_io.core.python.ops import core_ops
+
+class HDF5IOTensor(io_tensor_ops._CollectionIOTensor): # pylint: disable=protected-access
+  """HDF5IOTensor"""
+
+  #=============================================================================
+  # Constructor (private)
+  #=============================================================================
+  def __init__(self,
+               filename,
+               internal=False):
+    with tf.name_scope("HDF5IOTensor") as scope:
+      resource, columns = core_ops.hdf5_indexable_init(
+          filename,
+          container=scope,
+          shared_name="%s/%s" % (filename, uuid.uuid4().hex))
+      columns = [column.decode() for column in columns.numpy().tolist()]
+      spec = []
+      for column in columns:
+        shape, dtype = core_ops.hdf5_indexable_spec(resource, column)
+        shape = tf.TensorShape(shape)
+        dtype = tf.as_dtype(dtype.numpy())
+        spec.append(tf.TensorSpec(shape, dtype, column))
+      spec = tuple(spec)
+      super(HDF5IOTensor, self).__init__(
+          spec, columns,
+          resource, core_ops.hdf5_indexable_get_item,
+          internal=internal)

--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 from tensorflow_io.core.python.ops import io_tensor_ops
 from tensorflow_io.core.python.ops import audio_io_tensor_ops
 from tensorflow_io.core.python.ops import json_io_tensor_ops
+from tensorflow_io.core.python.ops import hdf5_io_tensor_ops
 from tensorflow_io.core.python.ops import kafka_io_tensor_ops
 from tensorflow_io.core.python.ops import lmdb_io_tensor_ops
 from tensorflow_io.core.python.ops import prometheus_io_tensor_ops
@@ -346,3 +347,20 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
     """
     with tf.name_scope(kwargs.get("name", "IOFromLMDB")):
       return lmdb_io_tensor_ops.LMDBIOTensor(filename, internal=True)
+
+  @classmethod
+  def from_hdf5(cls,
+                filename,
+                **kwargs):
+    """Creates an `IOTensor` from an hdf5 file.
+
+    Args:
+      filename: A string, the filename of an hdf5 file.
+      name: A name prefix for the IOTensor (optional).
+
+    Returns:
+      A `IOTensor`.
+
+    """
+    with tf.name_scope(kwargs.get("name", "IOFromHDF5")):
+      return hdf5_io_tensor_ops.HDF5IOTensor(filename, internal=True)

--- a/tensorflow_io/core/python/ops/io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/io_tensor_ops.py
@@ -316,6 +316,48 @@ class _TableIOTensor(_IOTensor):
         spec, self._resource, self._function,
         component=column, internal=True)
 
+class _CollectionIOTensor(_IOTensor):
+  """_CollectionIOTensor
+
+  `CollectionIOTensor` is differnt from `TableIOTensor` in that each
+  component could have different shapes. While additional table-wide
+  operations are planned to be supported for `TableIOTensor` so that
+  the same operations could be applied to every column, there is no plan
+  to support the same in `CollectionIOTensor`. In other words,
+  `CollectionIOTensor` is only a dictionary with values consisting
+  of `BaseIOTensor`.
+  """
+
+  def __init__(self,
+               spec,
+               keys,
+               resource,
+               function,
+               internal=False):
+    self._keys = keys
+    self._resource = resource
+    self._function = function
+    super(_CollectionIOTensor, self).__init__(
+        spec, keys, internal=internal)
+
+  #=============================================================================
+  # Accessors
+  #=============================================================================
+
+  @property
+  def keys(self):
+    """The names of columns"""
+    return self._keys
+
+  def __call__(self, key):
+    """Return a BaseIOTensor with key named `key`"""
+    key_index = self.keys.index(
+        next(e for e in self.keys if e == key))
+    spec = tf.nest.flatten(self.spec)[key_index]
+    return BaseIOTensor(
+        spec, self._resource, self._function,
+        component=key, internal=True)
+
 class _SeriesIOTensor(_IOTensor):
   """_SeriesIOTensor"""
 

--- a/tensorflow_io/hdf5/ops/hdf5_ops.cc
+++ b/tensorflow_io/hdf5/ops/hdf5_ops.cc
@@ -19,6 +19,46 @@ limitations under the License.
 
 namespace tensorflow {
 
+REGISTER_OP("HDF5IndexableInit")
+  .Input("input: string")
+  .Output("output: resource")
+  .Output("component: string")
+  .Attr("container: string = ''")
+  .Attr("shared_name: string = ''")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->Scalar());
+    c->set_output(1, c->MakeShape({}));
+    return Status::OK();
+   });
+REGISTER_OP("HDF5IndexableSpec")
+  .Input("input: resource")
+  .Input("component: string")
+  .Output("shape: int64")
+  .Output("dtype: int64")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->MakeShape({c->UnknownDim()}));
+    c->set_output(1, c->MakeShape({}));
+    return Status::OK();
+   });
+
+REGISTER_OP("HDF5IndexableGetItem")
+  .Input("input: resource")
+  .Input("start: int64")
+  .Input("stop: int64")
+  .Input("step: int64")
+  .Input("component: string")
+  .Output("output: dtype")
+  .Attr("shape: shape")
+  .Attr("dtype: type")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    PartialTensorShape shape;
+    TF_RETURN_IF_ERROR(c->GetAttr("shape", &shape));
+    shape_inference::ShapeHandle entry;
+    TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(shape, &entry));
+    c->set_output(0, entry);
+    return Status::OK();
+   });
+
 REGISTER_OP("ListHDF5Datasets")
     .Input("filename: string")
     .Input("memory: string")

--- a/tensorflow_io/hdf5/python/ops/hdf5_ops.py
+++ b/tensorflow_io/hdf5/python/ops/hdf5_ops.py
@@ -17,9 +17,17 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops
 from tensorflow_io.core.python.ops import data_ops
+
+warnings.warn(
+    "The tensorflow_io.hdf5.HDF5Dataset is "
+    "deprecated. Please look for tfio.IOTensor.from_hdf5 "
+    "for reading HDF5 files into tensorflow.",
+    DeprecationWarning)
 
 def list_hdf5_datasets(filename, **kwargs):
   """list_hdf5_datasets"""


### PR DESCRIPTION
HDF5 file is a widely used format. It normally stores data into each named `dataset` which is a block of array with shape. It is not exactly columnar as different `dataset` in HDF5 could have different shapes unrelated to each other. From that standpoint it is more like a storage for collections of tensors (where each `dataset` represent one `tensor`).

HDF5 does allow slicing and indexing. In fact, the slicing and indexing in HDF5 are much more powerful than many other formats.

This PR adds tfio.IOTensor.from_hdf5. It treats HDF5 as a collection of BaseIOTensor which could be further used for slicing and indexing.

Note the `collection` here essentially is just a dictionary of key with BaseIOTensor as the value. It is different from Columnar IOTensor's case like Parquet or Avro.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>