### PR TITLE
Make sure ./configure.sh installs the same verion of tensorflow as setup.py

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -18,7 +18,7 @@ rm -f .bazelrc
 if python -c "import tensorflow as tf" &> /dev/null; then
     echo 'using installed tensorflow'
 else
-    pip install tensorflow
+    python -m pip install $(python setup.py --package-version)
 fi
 python -m pip install grpcio-tools
 python third_party/tf/configure.py


### PR DESCRIPTION
With multiple version of TensorFlow (1.14, 1.15RC0, 2.0.0Beta, 2.0.0RC0, and our current build of tf-nightly) in the mix, it is necessary to pin the version in `./configure.sh`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>