### PR TITLE
[DICOM] Fix memory leak

### DIFF
--- a/tensorflow_io/dicom/kernels/decode_dicom_image.cc
+++ b/tensorflow_io/dicom/kernels/decode_dicom_image.cc
@@ -82,19 +82,19 @@ class DecodeDICOMImageOp : public OpKernel {
     const auto in_contents_scalar = in_contents.scalar<string>()();
 
     // Load Dicom Image
-    DcmInputBufferStream dataBuf;
-    dataBuf.setBuffer(in_contents_scalar.data(), in_contents_scalar.length());
-    dataBuf.setEos();
+    DcmInputBufferStream data_buf;
+    data_buf.setBuffer(in_contents_scalar.data(), in_contents_scalar.length());
+    data_buf.setEos();
 
-    DcmFileFormat *dfile = new DcmFileFormat();
-    dfile->transferInit();
-    OFCondition cond = dfile->read(dataBuf);
-    dfile->transferEnd();
+    DcmFileFormat dicom_file;
+    dicom_file.transferInit();
+    OFCondition cond = dicom_file.read(data_buf);
+    dicom_file.transferEnd();
 
     DicomImage *image = NULL;
     try {
       image =
-          new DicomImage(dfile, EXS_Unknown, CIF_DecompressCompletePixelData);
+          new DicomImage(&dicom_file, EXS_Unknown, CIF_DecompressCompletePixelData);
     } catch (...) {
       image = NULL;
     }


### PR DESCRIPTION
This change fixes a memory leak by allocating the `DcmFileFormat` object on the stack. Previously, this was allocated on the heap and never deleted.

Note: even though `DcmFileFormat` object exists on the stack, the DICOM data read into `DcmFileFormat`'s `DcmDataset` [is on the heap](https://github.com/DCMTK/dcmtk/blob/6c8799a470804d5c46fea61b2a1f7607f5606066/dcmdata/libsrc/dcfilefo.cc#L65-L66) (so we should not have to worry about filling up the stack on reading in large images). 

The variables in the scope of this change were also renamed to adhere to Google's C++ styleguide [guidance on naming](https://google.github.io/styleguide/cppguide.html#Variable_Names), though the rest of the file does not yet adhere to this. 