### PR TITLE
Better slicing and indexing for `__getitem__`

### DIFF
--- a/tensorflow_io/core/python/ops/io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/io_tensor_ops.py
@@ -170,18 +170,12 @@ class BaseIOTensor(_IOTensor):
     (start, stop, step) = index.indices(self.shape[0])
     if start >= self.shape[0]:
       raise IndexError("index %s is out of range" % key)
-    if stop == start + 1:
-      return tf.squeeze(self._function(
-          self._resource,
-          start, stop, step,
-          component=self._component,
-          shape=self.spec.shape, dtype=self.spec.dtype), axis=[0])
-    return self._function(
+    item = self._function(
         self._resource,
         start, stop, step,
         component=self._component,
         shape=self.spec.shape, dtype=self.spec.dtype)
-
+    return tf.squeeze(item, axis=[0]) if (stop == start + 1) else item
 
   def __len__(self):
     """Returns the total number of items of this IOTensor."""


### PR DESCRIPTION
Python's `slice()` class has a very convenient method of `indices(len)` which safely converts a `slice` to a tuple of safe `(start, stop, step)`, based on the length of the list `len`.

This PR replced the handcrafted (and error prune) slicing management with native `indices()` method.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>