### PR TITLE
[Discussion] Add wrapper to use tf.keras.util.Sequence

### DIFF
--- a/tensorflow_io/__init__.py
+++ b/tensorflow_io/__init__.py
@@ -18,3 +18,4 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow_io.core.python.ops.io_tensor import IOTensor
+from tensorflow_io.core.python.ops.io_sequence import IOSequence

--- a/tensorflow_io/core/python/ops/io_sequence.py
+++ b/tensorflow_io/core/python/ops/io_sequence.py
@@ -1,0 +1,72 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""IOSequence is a subclass of tf.keras.util.Sequence"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+import tensorflow as tf
+
+class IOSequence(tf.keras.utils.Sequence):
+  """IOSequence
+
+  An `IOSequence` is a subclass of tf.keras.util.Sequence
+  that could be used to pass collections of IOTensor to tf.keras
+  for training purposes.
+
+  Since IOTensor is always repeatable, multiple runs will not change
+  the underlying data, it could avoid the cases where steaming dataset
+  are not able to be used in tf.keras due to unreliable re-run.
+
+  Example:
+
+  ```python
+
+  x = tfio.IOTensor.from_tensor(tf.reshape(
+      tf.image.convert_image_dtype(x_train, tf.float32), [-1, 28, 28]))
+  y = tfio.IOTensor.from_tensor(y_train)
+
+  d_train = tfio.IOSequence(batch_size=1, x=x, y=y)
+
+  model = tf.keras.models.Sequential([
+      tf.keras.layers.Flatten(input_shape=(28, 28)),
+      tf.keras.layers.Dense(512, activation=tf.nn.relu),
+      tf.keras.layers.Dropout(0.2),
+      tf.keras.layers.Dense(10, activation=tf.nn.softmax)
+  ])
+  model.compile(optimizer='adam',
+                loss='sparse_categorical_crossentropy',
+                metrics=['accuracy'])
+
+  model.fit(d_train, epochs=5)
+  ```
+  """
+
+  def __init__(self, batch_size, x, y):
+    self.batch_size = batch_size
+    self.x = x
+    self.y = y
+
+  def __len__(self):
+    return int(np.ceil(len(self.x) / float(self.batch_size)))
+
+  def __getitem__(self, idx):
+    batch_x = self.x[idx * self.batch_size:(idx + 1) * self.batch_size]
+    batch_y = self.y[idx * self.batch_size:(idx + 1) * self.batch_size]
+    if self.batch_size == 1:
+      return tf.expand_dims(batch_x, 0), tf.expand_dims(batch_y, 0)
+    return batch_x, batch_y

--- a/tests/test_io_sequence_eager.py
+++ b/tests/test_io_sequence_eager.py
@@ -1,0 +1,57 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for IOSequence with Keras"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import numpy as np
+
+import tensorflow as tf
+if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
+  tf.compat.v1.enable_eager_execution()
+import tensorflow_io as tfio # pylint: disable=wrong-import-position
+
+def test_mnist_tutorial():
+  """test_mnist_tutorial"""
+  mnist_filename = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_mnist",
+      "mnist.npz")
+  with np.load(mnist_filename) as f:
+    (x_test, y_test) = f['x_test'], f['y_test']
+
+  x = tfio.IOTensor.from_tensor(tf.reshape(
+      tf.image.convert_image_dtype(x_test, tf.float32), [-1, 28, 28]))
+  y = tfio.IOTensor.from_tensor(y_test)
+
+  d_train = tfio.IOSequence(batch_size=1, x=x, y=y)
+
+  model = tf.keras.models.Sequential([
+      tf.keras.layers.Flatten(input_shape=(28, 28)),
+      tf.keras.layers.Dense(512, activation=tf.nn.relu),
+      tf.keras.layers.Dropout(0.2),
+      tf.keras.layers.Dense(10, activation=tf.nn.softmax)
+  ])
+  model.compile(optimizer='adam',
+                loss='sparse_categorical_crossentropy',
+                metrics=['accuracy'])
+
+  model.fit(d_train, epochs=5)
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
There are multiple ways to pass data to tf.keras. While
dataset could be used, it assumes that dataset is always repeatable
which means multiple runs produce the same type of data.
But that is not necesssarily the case for streaming
where data is not repeatable.

For example, prometheus largely depends on the time to
generate the data so unless the timestamp is passes, multiple
runs will have different data produced.

To avoid confusion, this PR adds a wrapper to tf.keras.util.Sequence
so that data is guaranteed to be repeatable when data is passed to tf.keras.

/cc @terrytangyuan @BryanCutler 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>