### PR TITLE
Add standard flags to build_docs.py

### DIFF
--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -46,8 +46,13 @@ import tensorflow_io as tfio
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import parser
 from tensorflow_docs.api_generator import public_api
+from tensorflow_docs.api_generator import utils
 
 from tensorflow.python.util import tf_inspect
+
+
+# tfio doesn't eagerly import submodules.
+utils.recursive_import(tfio)
 
 # Use tensorflow's `tf_inspect`, which is aware of `tf_decorator`.
 parser.tf_inspect = tf_inspect


### PR DESCRIPTION
Hi, 

To generate docs for tensorflow.org we need to standardize the `FLAGS` so this script works with our pipeline without throwing errors about unrecognized flags.

(See also: tensorflow/addons#518)

This change doesn't affect the output of the script (except path prefixes in .yaml files) 

This change also adds import all the submodules.
A few fail on import. These won't be documented. A simple local installation `pip install tensorflow_io` gives me these failures:

-  bigquery

```
from tensorflow_io.bigquery.python.ops.bigquery_api import BigQueryClient
ModuleNotFoundError: No module named 'tensorflow_io.bigquery.python.ops.bigquery_api'
```
- cloud

```
  File "/usr/local/google/home/markdaoust/venv3/lib/python3.6/site-packages/tensorflow_io/cloud/__init__.py", line 22, in <module>
    from tensorflow_io.cloud.python.ops.bigquery_reader_ops import *
  File "/usr/local/google/home/markdaoust/venv3/lib/python3.6/site-packages/tensorflow_io/cloud/python/ops/bigquery_reader_ops.py", line 25, in <module>
    _bigquery_reader_so = _load_library("_bigquery_reader_ops.so")
  File "/usr/local/google/home/markdaoust/venv3/lib/python3.6/site-packages/tensorflow_io/__init__.py", line 59, in _load_library
    "{}, from paths: {}\ncaused by: {}".format(filename, filenames, errs))
NotImplementedError: unable to open file: _bigquery_reader_ops.so, from paths: ['/usr/local/google/home/markdaoust/venv3/lib/python3.6/site-packages/tensorflow_io/cloud/python/ops/_bigquery_reader_ops.so']
caused by: ['/usr/local/google/home/markdaoust/venv3/lib/python3.6/site-packages/tensorflow_io/cloud/python/ops/_bigquery_reader_ops.so: undefined symbol: _ZTVN10tensorflow10ReaderBaseE']
```
- dicom

```
  File "/usr/local/google/home/markdaoust/venv3/lib/python3.6/site-packages/tensorflow_io/dicom/__init__.py", line 26, in <module>
    from tensorflow_io.dicom.python.ops.dicom_ops import decode_dicom_data
  File "/usr/local/google/home/markdaoust/venv3/lib/python3.6/site-packages/tensorflow_io/dicom/python/ops/dicom_ops.py", line 25, in <module>
    decode_dicom_data = dicom_ops.decode_dicom_data
AttributeError: module '0bb84602ad9137f5e6d7401094b24438' has no attribute 'decode_dicom_data'
```


