### PR TITLE
Fix 1.15.0 compatibility issue

### DIFF
--- a/tensorflow_io/core/python/ops/avro_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/avro_io_tensor_ops.py
@@ -52,7 +52,7 @@ class AvroIOTensor(io_tensor_ops._TableIOTensor): # pylint: disable=protected-ac
       spec = []
       for column in columns:
         shape, dtype = core_ops.avro_indexable_spec(resource, column)
-        shape = tf.TensorShape(shape)
+        shape = tf.TensorShape(shape.numpy())
         dtype = tf.as_dtype(dtype.numpy())
         spec.append(tf.TensorSpec(shape, dtype, column))
       spec = tuple(spec)

--- a/tensorflow_io/core/python/ops/csv_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/csv_io_tensor_ops.py
@@ -41,7 +41,7 @@ class CSVIOTensor(io_tensor_ops._TableIOTensor): # pylint: disable=protected-acc
       spec = []
       for column in columns:
         shape, dtype = core_ops.csv_indexable_spec(resource, column)
-        shape = tf.TensorShape(shape)
+        shape = tf.TensorShape(shape.numpy())
         dtype = tf.as_dtype(dtype.numpy())
         spec.append(tf.TensorSpec(shape, dtype, column))
       spec = tuple(spec)

--- a/tensorflow_io/core/python/ops/feather_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/feather_io_tensor_ops.py
@@ -41,7 +41,7 @@ class FeatherIOTensor(io_tensor_ops._TableIOTensor): # pylint: disable=protected
       spec = []
       for column in columns:
         shape, dtype = core_ops.feather_indexable_spec(resource, column)
-        shape = tf.TensorShape(shape)
+        shape = tf.TensorShape(shape.numpy())
         dtype = tf.as_dtype(dtype.numpy())
         spec.append(tf.TensorSpec(shape, dtype, column))
       spec = tuple(spec)

--- a/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
@@ -53,7 +53,7 @@ class HDF5IOTensor(io_tensor_ops._CollectionIOTensor): # pylint: disable=protect
       elements = []
       for column in columns:
         shape, dtype = core_ops.hdf5_indexable_spec(resource, column)
-        shape = tf.TensorShape(shape)
+        shape = tf.TensorShape(shape.numpy())
         dtype = tf.as_dtype(dtype.numpy())
         spec = tf.TensorSpec(shape, dtype, column)
         elements.append(

--- a/tensorflow_io/core/python/ops/json_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/json_io_tensor_ops.py
@@ -44,7 +44,7 @@ class JSONIOTensor(io_tensor_ops._TableIOTensor): # pylint: disable=protected-ac
       spec = []
       for column in columns:
         shape, dtype = core_ops.json_indexable_spec(resource, column)
-        shape = tf.TensorShape(shape)
+        shape = tf.TensorShape(shape.numpy())
         dtype = tf.as_dtype(dtype.numpy())
         spec.append(tf.TensorSpec(shape, dtype, column))
       spec = tuple(spec)

--- a/tensorflow_io/core/python/ops/kafka_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_io_tensor_ops.py
@@ -47,7 +47,8 @@ class KafkaIOTensor(io_tensor_ops.BaseIOTensor): # pylint: disable=protected-acc
           container=scope,
           shared_name="%s/%s" % (subscription, uuid.uuid4().hex))
       shape, dtype = core_ops.kafka_indexable_spec(resource, 0)
-      spec = tf.TensorSpec(tf.TensorShape(shape), tf.as_dtype(dtype.numpy()))
+      spec = tf.TensorSpec(
+          tf.TensorShape(shape.numpy()), tf.as_dtype(dtype.numpy()))
 
       class _Function(object):
         def __init__(self, func, spec):

--- a/tensorflow_io/core/python/ops/prometheus_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/prometheus_io_tensor_ops.py
@@ -42,9 +42,9 @@ class PrometheusIOTensor(io_tensor_ops._SeriesIOTensor): # pylint: disable=prote
           resource, "index")
       value_shape, value_dtype = core_golang_ops.prometheus_indexable_spec(
           resource, "value")
-      spec = tuple([tf.TensorSpec(tf.TensorShape(index_shape),
+      spec = tuple([tf.TensorSpec(tf.TensorShape(index_shape.numpy()),
                                   tf.as_dtype(index_dtype.numpy())),
-                    tf.TensorSpec(tf.TensorShape(value_shape),
+                    tf.TensorSpec(tf.TensorShape(value_shape.numpy()),
                                   tf.as_dtype(value_dtype.numpy()))])
       super(PrometheusIOTensor, self).__init__(
           spec, resource, core_golang_ops.prometheus_indexable_read,

--- a/tests/test_json_eager.py
+++ b/tests/test_json_eager.py
@@ -76,9 +76,9 @@ def test_io_tensor_json_recods_mode():
     v_x = x_test[i]
     v_y = y_test[i]
     for index, x in enumerate(j_x):
-      assert v_x[index] == x
+      assert v_x[index] == x.numpy()
     for index, y in enumerate(j_y):
-      assert v_y[index] == y
+      assert v_y[index] == y.numpy()
     i += 1
   assert i == len(y_test)
 


### PR DESCRIPTION
This PR fixes several 1.15.0 compatibility issue. It works for
both TF 1.15.0 and 2.0.0.

One this PR is merged to master, we will rebase R0.8 branch.

Note the issue was casued by bumping R0.8 from 1.15.0rc0 to 1.15.0rc1

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>