### PR TITLE
Initial tensorflow-io subsite page setup

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -1,0 +1,38 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+upper_tabs:
+  # Tabs left of dropdown menu
+  - include: /_upper_tabs_left.yaml
+  - include: /api_docs/_upper_tabs_api.yaml
+  # Dropdown menu
+  - name: Resources
+    path: /resources
+    is_default: true
+    menu:
+      - include: /resources/_menu_toc.yaml
+    lower_tabs:
+      # Subsite tabs
+      other:
+        - name: tutorials
+          contents:
+            - title: Image Ops
+              path: /io/tutorials/image_ops
+        - name: API
+          skip_translation: true
+          contents:
+            - include: /io/api_docs/python/_toc.yaml
+
+  - include: /_upper_tabs_right.yaml

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -1,0 +1,73 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+project_path: /io/_project.yaml
+description: <!--no description-->
+landing_page:
+  custom_css_path: /site-assets/css/style.css
+  rows:
+    - heading: TensorFlow I/O provides useful extra Dataset, streaming, and file system extensions maintained by TensorFlow SIG-IO
+      items:
+        - classname: devsite-landing-row-50
+          description: >
+            TensorFlow I/O is a collection of file systems and file formats
+            that are not available in TensorFlow's built-in support.
+          code_block: |
+            <pre class = "prettyprint">
+            import tensorflow as tf
+            import tensorflow_io.mnist as mnist_io
+
+            # Read MNIST into tf.data.Dataset
+            d_train = mnist_io.MNISTDataset(
+              'train-images-idx3-ubyte.gz',
+              'train-labels-idx1-ubyte.gz',
+              batch=1)
+
+            # By default image data is uint8 so conver to float32.
+            d_train = d_train.map(lambda x, y: (tf.image.convert_image_dtype(x, tf.float32), y))
+
+            model = tf.keras.models.Sequential([
+              tf.keras.layers.Flatten(input_shape=(28, 28)),
+              tf.keras.layers.Dense(512, activation=tf.nn.relu),
+              tf.keras.layers.Dropout(0.2),
+              tf.keras.layers.Dense(10, activation=tf.nn.softmax)
+            ])
+            model.compile(optimizer='adam',
+                          loss='sparse_categorical_crossentropy',
+                          metrics=['accuracy'])
+
+            model.fit(d_train, epochs=5, steps_per_epoch=10000)
+
+            </pre>
+            {% dynamic if request.tld != 'cn' %}
+            {% dynamic endif %}
+    - classname: devsite-landing-row-cards
+      items:
+        - heading: "Introducing TensorFlow I/O"
+          image_path: /resources/images/tf-logo-card-16x9.png
+          path: https://medium.com/tensorflow/introducing-tensorflow-addons-6131a50a3dcf
+          buttons:
+            - label: "TensorFlow with Apache Arrow Datasets"
+              path: https://medium.com/tensorflow/tensorflow-with-apache-arrow-datasets-cdbcfe80a59f
+            - label: "How to build a custom Dataset for Tensorflow"
+              path: https://towardsdatascience.com/how-to-build-a-custom-dataset-for-tensorflow-1fe3967544d8
+            - label: "TensorFlow on Apache Ignite"
+              path: https://medium.com/tensorflow/tensorflow-on-apache-ignite-99f1fc60efeb
+        - heading: "TensorFlow I/O on GitHub"
+          image_path: /resources/images/github-card-16x9.png
+          path: https://github.com/tensorflow/io
+          buttons:
+            - label: "View on GitHub"
+              path: https://github.com/tensorflow/io

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 # ==============================================================================
+book_path: /io/_book.yaml
 project_path: /io/_project.yaml
 description: <!--no description-->
 landing_page:
@@ -52,6 +53,7 @@ landing_page:
 
             </pre>
             {% dynamic if request.tld != 'cn' %}
+            <a class="colab-button" target="_blank" href="https://colab.research.google.com/github/tensorflow/io/blob/master/docs/tutorials/quick.ipynb">Run in a <span>Notebook</span></a>
             {% dynamic endif %}
     - classname: devsite-landing-row-cards
       items:

--- a/docs/_project.yaml
+++ b/docs/_project.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+name: TensorFlow I/O
+breadcrumb_name: I/O
+home_url: /io/
+parent_project_metadata_path: /_project.yaml
+description: >
+  "TensorFlow I/O provides useful extra Dataset, streaming, and file system extensions maintained by TensorFlow SIG-IO"
+use_site_branding: true
+hide_from_products_list: true
+content_license: cc-apache
+include: /_project_included.yaml

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,21 @@
+# TensorFlow I/O Tutorials
+
+TensorFlow I/O welcomes and highly encourages tutorial contributions.
+
+
+## How To Contribute
+
+I/O tutorials are created using [Google Colab](https://colab.research.google.com/) 
+and the jupyter notebooks are saved to this directory in the repository. To do 
+this, follow the below steps:
+
+1. Create a new branch on your fork of TensorFlow I/O
+2. Goto [Google Colab](https://colab.research.google.com/) and start a new 
+notebook using addons example template:
+[docs/tutorials/template.ipynb](template.ipynb)
+3. Edit the the links for the "View source on GitHub" and "Run in Google Colab" 
+URL boxes so that they match the name of your new example notebook
+4. Follow the guidelines of the template
+5. "Save a copy in Github" and select your new branch. The notebook should be 
+named `subpackage_submodule`
+6. Submit the branch as a PR on the TF-I/O [Github](https://github.com/tensorflow/io)


### PR DESCRIPTION
This PR is the initial tensorflow-io subsite page setup

Source of some of the yams is from Addons PR: https://github.com/tensorflow/addons/pull/486

/cc @terrytangyuan @BryanCutler @dmitrievanthony @ivelin 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>