### PR TITLE
Add decode_tiff and decode_tiff_info

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -158,6 +158,7 @@ cc_binary(
         "//tensorflow_io/genome:genome_ops",
         "//tensorflow_io/hdf5:hdf5_ops",
         "//tensorflow_io/ignite:ignite_ops",
+        "//tensorflow_io/image:image_ops",
         "//tensorflow_io/json:json_ops",
         "//tensorflow_io/kafka:kafka_ops",
         "//tensorflow_io/lmdb:lmdb_ops",

--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -30,6 +30,7 @@ from tensorflow_io.core.python.ops import csv_io_tensor_ops
 from tensorflow_io.core.python.ops import avro_io_tensor_ops
 from tensorflow_io.core.python.ops import ffmpeg_io_tensor_ops
 from tensorflow_io.core.python.ops import parquet_io_tensor_ops
+from tensorflow_io.core.python.ops import tiff_io_tensor_ops
 
 class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
   """IOTensor
@@ -440,3 +441,22 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
     """
     with tf.name_scope(kwargs.get("name", "IOFromParquet")):
       return parquet_io_tensor_ops.ParquetIOTensor(filename, internal=True)
+
+  @classmethod
+  def from_tiff(cls,
+                filename,
+                **kwargs):
+    """Creates an `IOTensor` from a tiff file.
+
+    Note tiff file may consists of multiple images with different shapes.
+
+    Args:
+      filename: A string, the filename of a tiff file.
+      name: A name prefix for the IOTensor (optional).
+
+    Returns:
+      A `IOTensor`.
+
+    """
+    with tf.name_scope(kwargs.get("name", "IOFromTIFF")):
+      return tiff_io_tensor_ops.TIFFIOTensor(filename, internal=True)

--- a/tensorflow_io/core/python/ops/tiff_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/tiff_io_tensor_ops.py
@@ -1,0 +1,47 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""TIFFIOTensor"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import io_tensor_ops
+from tensorflow_io.core.python.ops import core_ops
+
+class TIFFIOTensor(io_tensor_ops._CollectionIOTensor): # pylint: disable=protected-access
+  """TIFFIOTensor"""
+
+  #=============================================================================
+  # Constructor (private)
+  #=============================================================================
+  def __init__(self,
+               filename,
+               internal=False):
+    with tf.name_scope("TIFFIOTensor"):
+      # TIFF can fit into memory so load TIFF first
+      data = tf.io.read_file(filename)
+      info = core_ops.decode_tiff_info(data)
+      spec = tuple([
+          tf.TensorSpec(tf.TensorShape(
+              e.numpy().tolist() + [4]), tf.uint8) for e in info])
+      columns = [i for i, _ in enumerate(spec)]
+      elements = [
+          io_tensor_ops.TensorIOTensor(
+              core_ops.decode_tiff(data, i),
+              internal=internal) for i in columns]
+      super(TIFFIOTensor, self).__init__(
+          spec, columns, elements,
+          internal=internal)

--- a/tensorflow_io/image/BUILD
+++ b/tensorflow_io/image/BUILD
@@ -7,27 +7,28 @@ load(
     "tf_io_copts",
 )
 
-cc_binary(
-    name = "python/ops/_image_ops.so",
+cc_library(
+    name = "image_ops",
     srcs = [
         "kernels/font_opensans_regular.h",
         "kernels/gif_dataset_ops.cc",
         "kernels/image_kernels.cc",
+        "kernels/image_tiff_kernels.cc",
         "kernels/tiff_dataset_ops.cc",
         "kernels/webp_dataset_ops.cc",
         "ops/dataset_ops.cc",
+        "ops/image_ops.cc",
     ],
     copts = tf_io_copts(),
     includes = [
         ".",
     ],
-    linkshared = 1,
+    linkstatic = True,
     deps = [
+        "//tensorflow_io/core:dataset_ops",
         "@freetype",
         "@giflib",
         "@libtiff",
         "@libwebp",
-        "@local_config_tf//:libtensorflow_framework",
-        "@local_config_tf//:tf_header_lib",
     ],
 )

--- a/tensorflow_io/image/kernels/image_tiff_kernels.cc
+++ b/tensorflow_io/image/kernels/image_tiff_kernels.cc
@@ -1,0 +1,93 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include <tiffio.h>
+#include <tiffio.hxx>
+
+namespace tensorflow {
+namespace data {
+namespace {
+class DecodeTIFFInfoOp : public OpKernel {
+ public:
+  explicit DecodeTIFFInfoOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    std::istringstream input_stream(input_tensor->scalar<string>()(), std::ios_base::in | std::ios_base::binary);
+
+    std::unique_ptr<TIFF, void(*)(TIFF*)> tiff(TIFFStreamOpen("memory", &input_stream), [](TIFF* p) { if (p != nullptr) { TIFFClose(p); } });
+    OP_REQUIRES(context, (tiff.get() != nullptr), errors::InvalidArgument("unable to open TIFF from memory"));
+
+    std::vector<std::pair<int64, int64>> shape;
+    do {
+      unsigned int height, width;
+      TIFFGetField(tiff.get(), TIFFTAG_IMAGELENGTH, &height);
+      TIFFGetField(tiff.get(), TIFFTAG_IMAGEWIDTH, &width);
+      shape.push_back(std::pair<int64, int64>(static_cast<int64>(height), static_cast<int64>(width)));
+    } while (TIFFReadDirectory(tiff.get()));
+
+    Tensor* shape_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({static_cast<int64>(shape.size()), 2}), &shape_tensor));
+    for (size_t i = 0; i < shape.size(); i++) {
+      shape_tensor->flat<int64>()(i * 2) = shape[i].first;
+      shape_tensor->flat<int64>()(i * 2 + 1) = shape[i].second;
+    }
+  }
+};
+class DecodeTIFFOp : public OpKernel {
+ public:
+  explicit DecodeTIFFOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    const Tensor* index_tensor;
+    OP_REQUIRES_OK(context, context->input("index", &index_tensor));
+
+    std::istringstream input_stream(input_tensor->scalar<string>()(), std::ios_base::in | std::ios_base::binary);
+
+    std::unique_ptr<TIFF, void(*)(TIFF*)> tiff(TIFFStreamOpen("memory", &input_stream), [](TIFF* p) { if (p != nullptr) { TIFFClose(p); } });
+    OP_REQUIRES(context, (tiff.get() != nullptr), errors::InvalidArgument("unable to open TIFF from memory"));
+
+
+    int status = TIFFSetDirectory(tiff.get(), index_tensor->scalar<int64>()());
+    OP_REQUIRES(context, (status), errors::InvalidArgument("unable to set TIFF directory to ", index_tensor->scalar<int64>()()));
+    unsigned int height, width;
+    TIFFGetField(tiff.get(), TIFFTAG_IMAGELENGTH, &height);
+    TIFFGetField(tiff.get(), TIFFTAG_IMAGEWIDTH, &width);
+
+    Tensor* image_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({static_cast<int64>(height), static_cast<int64>(width), channels_}), &image_tensor));
+
+    uint32* raster = reinterpret_cast<uint32*>(image_tensor->flat<uint8>().data());
+    OP_REQUIRES(context, (TIFFReadRGBAImageOriented(tiff.get(), width, height, raster, ORIENTATION_TOPLEFT, 0)),errors::InvalidArgument("unable to read directory: ", index_tensor->scalar<int64>()()));
+  }
+
+ private:
+  // TODO (yongtang): Set channels_ = 4 for now.
+  static const int channels_ = 4;
+};
+REGISTER_KERNEL_BUILDER(Name("DecodeTiffInfo").Device(DEVICE_CPU),
+                        DecodeTIFFInfoOp);
+REGISTER_KERNEL_BUILDER(Name("DecodeTiff").Device(DEVICE_CPU),
+                        DecodeTIFFOp);
+
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow_io/image/ops/image_ops.cc
+++ b/tensorflow_io/image/ops/image_ops.cc
@@ -1,0 +1,45 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+
+REGISTER_OP("DecodeTiffInfo")
+  .Input("input: string")
+  .Output("shape: int64")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    shape_inference::ShapeHandle unused;
+    TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &unused));
+    c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
+    return Status::OK();
+  });
+
+REGISTER_OP("DecodeTiff")
+  .Input("input: string")
+  .Input("index: int64")
+  .Output("image: uint8")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    shape_inference::ShapeHandle unused;
+    TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &unused));
+    TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &unused));
+    c->set_output(0, c->MakeShape({
+        c->UnknownDim(), c->UnknownDim(), c->UnknownDim()}));
+    return Status::OK();
+  });
+
+}  // namespace tensorflow

--- a/tensorflow_io/image/python/ops/image_dataset_ops.py
+++ b/tensorflow_io/image/python/ops/image_dataset_ops.py
@@ -17,11 +17,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 import tensorflow as tf
 from tensorflow import dtypes
 from tensorflow.compat.v1 import data
-from tensorflow_io.core.python.ops import _load_library
-image_ops = _load_library('_image_ops.so')
+from tensorflow_io.core.python.ops import core_ops
+
+warnings.warn(
+    "Image Dataset (WebP/GIF/TIFF are deprecated and "
+    "may be removed in the next release, please use "
+    "image ops such as decode_webp for future usage",
+    DeprecationWarning)
 
 
 class WebPDataset(data.Dataset):
@@ -40,7 +47,7 @@ class WebPDataset(data.Dataset):
     return []
 
   def _as_variant_tensor(self):
-    return image_ops.web_p_dataset(self._filenames)
+    return core_ops.web_p_dataset(self._filenames)
 
   @property
   def output_classes(self):
@@ -70,7 +77,7 @@ class TIFFDataset(data.Dataset):
     return []
 
   def _as_variant_tensor(self):
-    return image_ops.tiff_dataset(self._filenames)
+    return core_ops.tiff_dataset(self._filenames)
 
   @property
   def output_classes(self):
@@ -99,7 +106,7 @@ class GIFDataset(data.Dataset):
     return []
 
   def _as_variant_tensor(self):
-    return image_ops.gif_dataset(self._filenames)
+    return core_ops.gif_dataset(self._filenames)
 
   @property
   def output_classes(self):
@@ -124,7 +131,7 @@ def decode_webp(contents, name=None):
   Returns:
     A `Tensor` of type `uint8` and shape of `[height, width, 4]` (RGBA).
   """
-  return image_ops.decode_web_p(contents, name=name)
+  return core_ops.decode_web_p(contents, name=name)
 
 def draw_bounding_boxes(images, boxes, texts=None, colors=None, name=None):
   """
@@ -144,5 +151,5 @@ def draw_bounding_boxes(images, boxes, texts=None, colors=None, name=None):
     texts = []
   if colors is None:
     colors = [[]]
-  return image_ops.draw_bounding_boxes_v3(
+  return core_ops.draw_bounding_boxes_v3(
       images, boxes, colors, texts, name=name)

--- a/tests/test_image_eager.py
+++ b/tests/test_image_eager.py
@@ -1,0 +1,62 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for ImageIOTensor."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import numpy as np
+
+import tensorflow as tf
+if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
+  tf.compat.v1.enable_eager_execution()
+import tensorflow_io as tfio # pylint: disable=wrong-import-position
+
+
+def test_tiff_io_tensor():
+  """Test case for TIFFImageIOTensor"""
+  width = 560
+  height = 320
+  channels = 4
+
+  images = []
+  for filename in [
+      "small-00.png",
+      "small-01.png",
+      "small-02.png",
+      "small-03.png",
+      "small-04.png"]:
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     "test_image",
+                     filename), 'rb') as f:
+      png_contents = f.read()
+    image_v = tf.image.decode_png(png_contents, channels=channels)
+    assert image_v.shape == [height, width, channels]
+    images.append(image_v)
+
+  filename = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)), "test_image", "small.tiff")
+  filename = "file://" + filename
+
+  tiff = tfio.IOTensor.from_tiff(filename)
+  assert tiff.keys == list(range(5))
+  for i in tiff.keys:
+    assert np.all(images[i] == tiff(i).to_tensor())
+
+
+if __name__ == "__main__":
+  test.main()

--- a/third_party/libtiff.BUILD
+++ b/third_party/libtiff.BUILD
@@ -14,12 +14,15 @@ cc_library(
         exclude = [
             "libtiff/tif_win32.c",
         ],
-    ),
+    ) + [
+        "libtiff/tif_stream.cxx",
+    ],
     hdrs = glob([
         "libtiff/*.h",
     ]) + [
         "libtiff/tif_config.h",
         "libtiff/tiffconf.h",
+        "libtiff/tiffio.hxx",
     ],
     defines = [],
     includes = [


### PR DESCRIPTION
This PR adds native kernel ops of decode_tiff and decode_tiff_info
to replace the previous implementation of TIFFDataset.

The reasons to prefer native kernel ops for images are
1) Images are normally one item per file. Iteration does not make a lot of sense
2) Images fit into memory which means there is no need to "partially" load a slice like other data
   formats that may store huge data (e.g., Parquet).

Note tiff may have multiple frames with different shapes. This PR
introduce the `index` input to allow reading one frame at a time.

This PR also wraps TIFF into a TIFFIOTensor to allow easy access.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>