### PR TITLE
Add ffmpeg_io.decode_video to decode video frames from memory

### DIFF
--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -73,3 +73,4 @@ video_dataset = _ffmpeg_ops.video_dataset
 ffmpeg_iterable_init = _ffmpeg_ops.ffmpeg_iterable_init
 ffmpeg_iterable_spec = _ffmpeg_ops.ffmpeg_iterable_spec
 ffmpeg_iterable_next = _ffmpeg_ops.ffmpeg_iterable_next
+ffmpeg_decode_video = _ffmpeg_ops.ffmpeg_decode_video

--- a/tensorflow_io/ffmpeg/__init__.py
+++ b/tensorflow_io/ffmpeg/__init__.py
@@ -16,6 +16,7 @@
 
 @@AudioDataset
 @@VideoDataset
+@@decode_video
 """
 
 from __future__ import absolute_import
@@ -24,12 +25,14 @@ from __future__ import print_function
 
 from tensorflow_io.ffmpeg.python.ops.ffmpeg_ops import AudioDataset
 from tensorflow_io.ffmpeg.python.ops.ffmpeg_ops import VideoDataset
+from tensorflow_io.ffmpeg.python.ops.ffmpeg_ops import decode_video
 
 from tensorflow.python.util.all_util import remove_undocumented
 
 _allowed_symbols = [
     "AudioDataset",
     "VideoDataset",
+    "decode_video",
 ]
 
 remove_undocumented(__name__, allowed_exception_list=_allowed_symbols)

--- a/tensorflow_io/ffmpeg/ops/ffmpeg_ops.cc
+++ b/tensorflow_io/ffmpeg/ops/ffmpeg_ops.cc
@@ -107,4 +107,13 @@ REGISTER_OP("FfmpegIterableNext")
     c->set_output(0, entry);
     return Status::OK();
   });
+
+REGISTER_OP("FfmpegDecodeVideo")
+  .Input("input: string")
+  .Input("index: int64")
+  .Output("value: uint8")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim(), c->UnknownDim(), 3}));
+    return Status::OK();
+  });
 }  // namespace tensorflow

--- a/tensorflow_io/ffmpeg/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/ffmpeg/python/ops/ffmpeg_ops.py
@@ -24,6 +24,8 @@ import tensorflow as tf
 from tensorflow_io.core.python.ops import data_ops
 from tensorflow_io.core.python.ops import ffmpeg_ops
 
+decode_video = ffmpeg_ops.ffmpeg_decode_video
+
 class VideoDataset(data_ops.Dataset):
   """A Video File Dataset that reads the video file."""
 

--- a/tests/test_ffmpeg_eager.py
+++ b/tests/test_ffmpeg_eager.py
@@ -116,3 +116,10 @@ def _test_ffmpeg_io_tensor_mkv():
   assert video('v:0').dtype == tf.uint8
   assert len(video('v:0')) == 166
   assert video('v:0').to_tensor().shape == [166, 320, 560, 3]
+
+def test_ffmpeg_decode_video():
+  """test_ffmpeg_decode_video"""
+  content = tf.io.read_file(video_path)
+  video = ffmpeg_io.decode_video(content, 0)
+  assert video.shape == [166, 320, 560, 3]
+  assert video.dtype == tf.uint8


### PR DESCRIPTION
This PR add the ability to decode videeo frames from memory (read from a video file)
```python
import tensorflow_io.ffmpeg as ffmpeg_io
content = tf.io.read_file(video_path)
video = ffmpeg_io.decode_video(content, 0) # 0 is the video stream index, video/audio/subtitle all starts with 0 separately
```
This PR fixes #455 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>