### PR TITLE
Enable and Fix Arrow tests for TF 1.15.0

### DIFF
--- a/tensorflow_io/arrow/kernels/arrow_stream_client_unix.cc
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client_unix.cc
@@ -121,8 +121,9 @@ arrow::Status ArrowStreamClient::Tell(int64_t* position) const {
 arrow::Status ArrowStreamClient::Read(int64_t nbytes,
                                       int64_t* bytes_read,
                                       void* out) {
-  // TODO: look into why 0 bytes are requested
+  // TODO: 0 bytes requested when message body length == 0
   if (nbytes == 0) {
+    *bytes_read = 0;
     return arrow::Status::OK();
   }
 

--- a/tests/test_arrow_eager.py
+++ b/tests/test_arrow_eager.py
@@ -35,8 +35,6 @@ from tensorflow import dtypes # pylint: disable=wrong-import-position
 from tensorflow import errors # pylint: disable=wrong-import-position
 from tensorflow import test   # pylint: disable=wrong-import-position
 
-pytest.skip(
-    "arrow test is disabled temporarily", allow_module_level=True)
 import tensorflow_io.arrow as arrow_io # pylint: disable=wrong-import-position
 
 if sys.version_info == (3, 4):


### PR DESCRIPTION
This corrects API issues with TF 1.15.0 and fixes a bug in reading ArrowStreamDataset messages causing test failures. Arrow tests are now all enabled.