### PR TITLE
Expose __version__ in tensorflow_io

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,12 +180,24 @@ setup(
 )
 """
 
-package = 'tensorflow>=2.0.0,<2.1.0'
-version = '0.9.0'
-project = 'tensorflow-io'
+# read package and version from:
+# tensorflow_io/core/python/ops/io_info.py
+with open("tensorflow_io/core/python/ops/io_info.py") as f:
+  entries = [e.strip() for e in f.readlines() if not e.startswith("#")]
+  assert sum(e.startswith("package = ") for e in entries) == 1
+  assert sum(e.startswith("version = ") for e in entries) == 1
+  package = list([
+      e[10:] for e in entries if e.startswith("package = ")])[0].strip("'")
+  version = list([
+      e[10:] for e in entries if e.startswith("version = ")])[0].strip("'")
+  assert package != ""
+  assert version != ""
+
 if '--package-version' in sys.argv:
   print(package)
   sys.exit(0)
+
+project = 'tensorflow-io'
 
 # Note: import setuptools later to avoid unnecessary dependency
 from setuptools import sandbox # pylint: disable=wrong-import-position
@@ -196,6 +208,10 @@ if '--nightly' in sys.argv:
   project = 'tensorflow-io-nightly'
   sys.argv.remove('--nightly')
   sys.argv.pop(nightly_idx)
+
+print("setup.py - project = '{}'".format(project))
+print("setup.py - package = '{}'".format(package))
+print("setup.py - version = '{}'".format(version))
 
 rootpath = tempfile.mkdtemp()
 print("setup.py - create {} and copy tensorflow_io".format(rootpath))

--- a/tensorflow_io/core/python/ops/io_info.py
+++ b/tensorflow_io/core/python/ops/io_info.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""tensorflow-io"""
+"""version_info"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io.core.python.ops.io_info import version as __version__
-from tensorflow_io.core.python.ops.io_tensor import IOTensor
-from tensorflow_io.core.python.ops.io_dataset import IODataset, IOStreamDataset
+package = 'tensorflow>=2.0.0,<2.1.0'
+version = '0.9.0'

--- a/tests/test_version_eager.py
+++ b/tests/test_version_eager.py
@@ -1,0 +1,33 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for version string"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
+  tf.compat.v1.enable_eager_execution()
+import tensorflow_io as tfio # pylint: disable=wrong-import-position
+from tensorflow_io.core.python.ops import io_info # pylint: disable=wrong-import-position
+
+def test_version():
+  """test_version"""
+  assert tfio.__version__ == io_info.version
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
This PR exposes __version__ in tensorflow_io, as was discussed
in #482. The single source of truth is located in
tensorflow_io/core/python/ops/io_info.py

so that any change only happens in one place.

A test case has been added as well to guarantee the correctness of the __version__
string for package release.

This PR fixes #482.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>