### PR TITLE
Update Bazel version to 1.0.0

### DIFF
--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -20,7 +20,7 @@ if [[ "$#" -gt 0 ]]; then
     export TENSORFLOW_INSTALL="${1}"
 fi
 
-export BAZEL_VERSION=0.29.0 BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
+export BAZEL_VERSION=1.0.0 BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
 curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
 bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
 bazel version

--- a/tools/dev/Dockerfile
+++ b/tools/dev/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     ffmpeg \
     dnsutils
 
-ARG BAZEL_VERSION=0.29.0
+ARG BAZEL_VERSION=1.0.0
 ARG BAZEL_OS=linux
 
 RUN curl -sL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh -o bazel-install.sh && \


### PR DESCRIPTION
Bazel 1.0.0 has been released. This PR updates Bazel version to 1.0.0

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>