### PR TITLE
Implicitly import azure/oss file systems

### DIFF
--- a/tensorflow_io/__init__.py
+++ b/tensorflow_io/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+# tensorflow_io.core.python.ops is implicitly imported (along with file system)
 from tensorflow_io.core.python.ops.io_info import version as __version__
 from tensorflow_io.core.python.ops.io_tensor import IOTensor
 from tensorflow_io.core.python.ops.io_dataset import IODataset, IOStreamDataset

--- a/tensorflow_io/azure/README.md
+++ b/tensorflow_io/azure/README.md
@@ -13,7 +13,7 @@
 ```python
 >>> import os
 >>> import tensorflow as tf
->>> import tensorflow_io.azure
+>>> import tensorflow_io as tfio
 >>>
 >>> os.environ['TF_AZURE_STORAGE_KEY'] = 'my-storage-key'
 >>>

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -163,6 +163,7 @@ cc_binary(
         "//tensorflow_io/kafka:kafka_ops",
         "//tensorflow_io/lmdb:lmdb_ops",
         "//tensorflow_io/mnist:mnist_ops",
+        "//tensorflow_io/oss:oss_ops",
         "//tensorflow_io/parquet:parquet_ops",
         "//tensorflow_io/text:text_ops",
         "@libarchive",

--- a/tensorflow_io/oss/BUILD
+++ b/tensorflow_io/oss/BUILD
@@ -9,15 +9,15 @@ load(
     "tf_io_copts",
 )
 
-cc_binary(
-    name = "python/ops/_oss_ops.so",
+cc_library(
+    name = "oss_ops",
     srcs = [
         "kernels/ossfs/oss_file_system.cc",
         "kernels/ossfs/oss_file_system.h",
         "ops/ossfs_ops.cc",
     ],
     copts = tf_io_copts(),
-    linkshared = 1,
+    linkstatic = True,
     deps = [
         "@aliyun_oss_c_sdk",
         "@local_config_tf//:libtensorflow_framework",

--- a/tensorflow_io/oss/README.md
+++ b/tensorflow_io/oss/README.md
@@ -16,10 +16,10 @@ OSS_BUCKET = your_oss_bucket_name
 In Python code, import the extension `ossfs_op` module to use the extension with `gfile`. The files and directory URI should have `oss://` prefix, followed by an oss bucket name, access_id, access_key, oss_host, then the directory hierarchy.
 
 ```python
-import tensorflow_io.oss
-from tensorflow.python.platform import gfile
+import tensorflow as tf
+import tensorflow_io as tfio
 
-gfile.MkDir('oss://${bucket}\x01id=${access_id}\x02key=${access_key}\x02host=${host}/test_dir')
+tf.io.gfile.mkdir('oss://${bucket}\x01id=${access_id}\x02key=${access_key}\x02host=${host}/test_dir')
 ```
 
 With the extension installed, OSS files can be used with Dataset Ops, etc., in the same fashion as other files.

--- a/tensorflow_io/oss/__init__.py
+++ b/tensorflow_io/oss/__init__.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io.oss.python.ops import ossfs_ops  # pylint: disable=unused-import
+import tensorflow_io.core.python.ops # pylint: disable=unused-import
 
 from tensorflow.python.util.all_util import remove_undocumented
 

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -21,7 +21,7 @@ import os
 
 from tensorflow.python.platform import test
 from tensorflow.python.platform import gfile
-import tensorflow_io.azure  # pylint: disable=unused-import
+import tensorflow_io as tfio  # pylint: disable=unused-import
 
 class AZFSTest(test.TestCase):
   """[summary]

--- a/tests/test_ossfs.py
+++ b/tests/test_ossfs.py
@@ -22,7 +22,7 @@ import unittest
 
 from tensorflow.python.platform import test
 from tensorflow.python.platform import gfile
-from tensorflow_io.oss import ossfs_ops  # pylint: disable=unused-import
+import tensorflow_io as tfio  # pylint: disable=unused-import
 
 get_oss_path = None
 access_id = os.environ.get("OSS_ACCESS_ID")


### PR DESCRIPTION
This PR made several changes so that azure/oss file system could be implicitly registered as long as tensorflow_io is imported:
```
import tensorflow_io as tfio
```

This should help consolidate the API exposure.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>