### PR TITLE
[WIP] Expose tfio.experimental.image.decode_tiff

### DIFF
--- a/tensorflow_io/core/python/ops/experimental/__init__.py
+++ b/tensorflow_io/core/python/ops/experimental/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""tensorflow-io"""
+"""experimental"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io.core.python.ops.io_info import version as __version__
-from tensorflow_io.core.python.ops.io_tensor import IOTensor
-from tensorflow_io.core.python.ops.io_dataset import IODataset, IOStreamDataset
-from tensorflow_io.core.python.ops import experimental
+from tensorflow_io.core.python.ops.experimental import image

--- a/tensorflow_io/core/python/ops/experimental/image.py
+++ b/tensorflow_io/core/python/ops/experimental/image.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""tensorflow-io"""
+"""experimental.image"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io.core.python.ops.io_info import version as __version__
-from tensorflow_io.core.python.ops.io_tensor import IOTensor
-from tensorflow_io.core.python.ops.io_dataset import IODataset, IOStreamDataset
-from tensorflow_io.core.python.ops import experimental
+from tensorflow_io.core.python.ops import core_ops
+
+def decode_tiff(contents, index=0, name=None):
+  """
+  Decode a TIFF-encoded image to a uint8 tensor.
+
+  Args:
+    contents: A `Tensor` of type `string`. 0-D.  The TIFF-encoded image.
+    index: A `Tensor` of type int64. 0-D. The 0-based index of the frame
+      inside TIFF-encoded image.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `uint8` and shape of `[height, width, 4]` (RGBA).
+  """
+  return core_ops.decode_tiff(contents, index, name=name)

--- a/tests/test_image_eager.py
+++ b/tests/test_image_eager.py
@@ -57,6 +57,37 @@ def test_tiff_io_tensor():
   for i in tiff.keys:
     assert np.all(images[i].numpy() == tiff(i).to_tensor().numpy())
 
+def test_decode_tiff():
+  """Test case for tfio.experimental.image.decode_tiff"""
+  width = 560
+  height = 320
+  channels = 4
+
+  images = []
+  for filename in [
+      "small-00.png",
+      "small-01.png",
+      "small-02.png",
+      "small-03.png",
+      "small-04.png"]:
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     "test_image",
+                     filename), 'rb') as f:
+      png_contents = f.read()
+    image_v = tf.image.decode_png(png_contents, channels=channels)
+    assert image_v.shape == [height, width, channels]
+    images.append(image_v)
+
+  filename = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)), "test_image", "small.tiff")
+  filename = "file://" + filename
+
+  for i in range(5):
+    tiff = tfio.experimental.image.decode_tiff(
+        tf.io.read_file(filename), index=i)
+    assert np.all(images[i].numpy() == tiff.numpy())
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This is part of the effort to rethink about namespace management
in tensorflow-io, as was discussed in 537 and RFC tensorflow/community/135

This is the first op introduced, we could move more to tfio.experimental.

There are several reasons for having a tfio.experimental namespace:
1) Some API are not stable enough or we are not sure what is the best way to expose it.
2) Some API has been implemented but not generic enough, e.g, we process image as uint8 though we  know 16 bit or higher format is possible.

This PR is to start tfio.experimental with decode_tiff for sveral reasons:
1) TIFF could have multiple frames with different shapes, that adds complexity
2) TIFF could have higher resolution than uint8, currently it is not handled yet (See 534).

As such decode_tiff could be a candidate of tfio.experimental. In the future once
implementation is complete and solde we could promote and remove `experimental`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>