### PR TITLE
Remove unnecessary log on IGFS when import tensorflow_io module

### DIFF
--- a/tensorflow_io/ignite/kernels/igfs/igfs.cc
+++ b/tensorflow_io/ignite/kernels/igfs/igfs.cc
@@ -65,8 +65,7 @@ IGFS::IGFS()
         }
       }()),
       fs_name_(GetEnvOrElse("IGFS_FS_NAME", "default_fs")) {
-  LOG(INFO) << "IGFS created [host=" << host_ << ", port=" << port_
-            << ", fs_name=" << fs_name_ << "]";
+
 }
 
 IGFS::~IGFS() {


### PR DESCRIPTION
The following log appeared when just importing `tensorflow_io` module:
```
>>> import tensorflow_io as tfio
2019-10-15 15:35:12.262088: I tensorflow_io/ignite/kernels/igfs/igfs.cc:68] IGFS created [host=localhost, port=10500, fs_name=default_fs]
```