### PR TITLE
HTTP file system support

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -64,6 +64,7 @@ cc_library(
     name = "core_ops",
     srcs = [
         "kernels/archive_kernels.cc",
+        "kernels/http_kernels.cc",
         "ops/core_ops.cc",
     ],
     copts = tf_io_copts(),
@@ -73,6 +74,7 @@ cc_library(
     linkstatic = True,
     deps = [
         ":dataset_ops",
+        "@curl",
     ],
 )
 

--- a/tensorflow_io/core/kernels/http_kernels.cc
+++ b/tensorflow_io/core/kernels/http_kernels.cc
@@ -1,0 +1,134 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/file_system.h"
+#include "tensorflow/core/platform/cloud/curl_http_request.h"
+
+namespace tensorflow {
+
+class HTTPRandomAccessFile : public RandomAccessFile {
+ public:
+  HTTPRandomAccessFile(const std::string& uri, HttpRequest::Factory* http_request_factory)
+   : uri_(uri)
+   , http_request_factory_(http_request_factory) {}
+
+  Status Read(uint64 offset, size_t n, StringPiece* result,
+              char* scratch) const override {
+    // If n == 0, then return Status::OK()
+    // otherwise, if bytes_read < n then return OutofRange
+    if (n == 0) {
+      *result = StringPiece("", 0);
+      return Status::OK();
+    }
+    std::unique_ptr<HttpRequest> request(http_request_factory_->Create());
+    request->SetUri(uri_);
+    request->SetRange(offset, offset + n - 1);
+    request->SetResultBufferDirect(scratch, n);
+    TF_RETURN_IF_ERROR(request->Send());
+    size_t bytes_read = request->GetResultBufferDirectBytesTransferred();
+    *result = StringPiece(scratch, bytes_read);
+    if (bytes_read < n) {
+      return errors::OutOfRange("EOF reached");
+    }
+    return Status::OK();
+  }
+
+ private:
+  string uri_;
+  HttpRequest::Factory* http_request_factory_;
+};
+
+class HTTPFileSystem : public FileSystem {
+ public:
+  HTTPFileSystem() {
+    http_request_factory_ = std::make_shared<CurlHttpRequest::Factory>();
+  }
+  Status NewRandomAccessFile(
+      const string& fname, std::unique_ptr<RandomAccessFile>* result) override {
+    result->reset(new HTTPRandomAccessFile(fname, http_request_factory_.get()));
+    return Status::OK();
+  };
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result) override {
+    return errors::Unimplemented("NewWritableFile");
+  }
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result) override {
+    return errors::Unimplemented("NewAppendableFile");
+  }
+  Status NewReadOnlyMemoryRegionFromFile(
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result) override {
+    return errors::Unimplemented("NewReadOnlyMemoryRegionFromFile");
+  }
+  Status FileExists(const string& fname) override {
+    return errors::Unimplemented("FileExists");
+  }
+  Status GetChildren(const string& dir,
+                     std::vector<string>* result) override {
+    return errors::Unimplemented("GetChildren");
+  }
+  Status GetMatchingPaths(const string& pattern,
+                          std::vector<string>* results) override {
+    return errors::Unimplemented("GetMatchingPaths");
+  }
+  Status Stat(const string& fname, FileStatistics* stat) override {
+    std::unique_ptr<HttpRequest> request(http_request_factory_->Create());
+    request->SetUri(fname);
+    TF_RETURN_IF_ERROR(request->Send());
+    string length_string = request->GetResponseHeader("Content-Length");
+    if (length_string == "") {
+      return errors::InvalidArgument("unable to check the Content-Length of the url: ", fname);
+    }
+    int64 length = 0;
+    if (!strings::safe_strto64(length_string, &length)) {
+      return errors::InvalidArgument("unable to parse the Content-Length of the url: ", fname, " [", length_string, "]");
+    }
+
+    string last_modified_string = request->GetResponseHeader("Last-Modified");
+
+    FileStatistics fs;
+    fs.length = length;
+    fs.mtime_nsec = 0;
+    *stat = std::move(fs);
+
+    return Status::OK();
+  }
+  Status DeleteFile(const string& fname) override {
+    return errors::Unimplemented("DeleteFile");
+  }
+  Status CreateDir(const string& dirname) override {
+    return errors::Unimplemented("CreateDir");
+  }
+  Status DeleteDir(const string& dirname) override {
+    return errors::Unimplemented("DeleteDir");
+  }
+  Status GetFileSize(const string& fname, uint64* file_size) override {
+    FileStatistics stat;
+    TF_RETURN_IF_ERROR(Stat(fname, &stat));
+    *file_size = stat.length;
+    return Status::OK();
+  }
+  Status RenameFile(const string& src, const string& target) override {
+    return errors::Unimplemented("RenameFile");
+  }
+ private:
+  mutex mu_;
+  std::shared_ptr<HttpRequest::Factory> http_request_factory_;
+};
+
+REGISTER_FILE_SYSTEM("http", HTTPFileSystem);
+
+}  // namespace tensorflow

--- a/tests/test_http/LICENSE-2.0.txt
+++ b/tests/test_http/LICENSE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/test_http_eager.py
+++ b/tests/test_http_eager.py
@@ -1,0 +1,54 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for HTTP file system"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import tensorflow as tf
+import tensorflow_io as tfio # pylint: disable=unused-import
+
+def test_http_file_system():
+  """Test case for http file system"""
+  local_path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_http", "LICENSE-2.0.txt")
+  with open(local_path) as f:
+    lines = [line for line in f]
+  local = "".join(lines)
+
+  filename = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+  remote = tf.io.read_file(filename)
+
+  assert remote == local
+
+  dataset = tf.data.TextLineDataset(filename)
+  i = 0
+  for d in dataset:
+    assert d == lines[i].rstrip()
+    i += 1
+  assert i == len(lines)
+
+  remote = tf.io.gfile.GFile(filename)
+  assert remote.size() == len(local)
+  offset_start = list(range(0, len(local), 100))
+  offset_stop = offset_start[1:] + [len(local)]
+  for (start, stop) in zip(offset_start, offset_stop):
+    assert remote.read(100) == local[start:stop]
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
This PR is an initial effort to have HTTP file system, as was mentioned in #137.

This PR added two functions, Read and GetFileSize, which should be enough
for most RandomAccess file related  operations.

NOTE:
1) GetFileSize replies on "Content-Length" header. If this header is not available, then file system fails.
2) Read relies on "Range" header. If this header is not supported, then file system fails.

We could build up additional functionalities and fine tuning later.

This PR fixes #137.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>