### PR TITLE
Add encode_avro support

### DIFF
--- a/tensorflow_io/kafka/__init__.py
+++ b/tensorflow_io/kafka/__init__.py
@@ -18,6 +18,7 @@
 @@KafkaDataset
 @@write_kafka
 @@decode_avro
+@@encode_avro
 """
 
 from __future__ import absolute_import
@@ -28,6 +29,7 @@ from tensorflow_io.kafka.python.ops.kafka_ops import KafkaOutputSequence
 from tensorflow_io.kafka.python.ops.kafka_dataset_ops import KafkaDataset
 from tensorflow_io.kafka.python.ops.kafka_dataset_ops import write_kafka
 from tensorflow_io.kafka.python.ops.kafka_dataset_ops import decode_avro
+from tensorflow_io.kafka.python.ops.kafka_dataset_ops import encode_avro
 
 from tensorflow.python.util.all_util import remove_undocumented
 

--- a/tensorflow_io/kafka/kernels/kafka_kernels.cc
+++ b/tensorflow_io/kafka/kernels/kafka_kernels.cc
@@ -367,7 +367,16 @@ class DecodeAvroOp : public OpKernel {
           value[i]->flat<double>()(entry_index) = field.value<double>();
           break;
         case avro::AVRO_STRING:
-          value[i]->flat<string>()(entry_index) = field.value<string>();
+          {
+            // make a concrete explicit copy as otherwise avro may override the underlying buffer.
+            const string& field_value = field.value<string>();
+            string v;
+            if (field_value.size() > 0) {
+              v.resize(field_value.size());
+              memcpy(&v[0], &field_value[0], field_value.size());
+            }
+            value[i]->flat<string>()(entry_index) = v;
+          }
           break;
         case avro::AVRO_BYTES:
           {
@@ -404,9 +413,98 @@ private:
   string schema_;
 };
 
+class EncodeAvroOp : public OpKernel {
+ public:
+  explicit EncodeAvroOp(OpKernelConstruction* context) : OpKernel(context) {
+   OP_REQUIRES_OK(context, context->GetAttr("schema", &schema_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    // Make sure input have the same elements;
+    for (int64 i = 1; i < context->num_inputs(); i++) {
+      OP_REQUIRES(
+          context, (context->input(0).NumElements() == context->input(i).NumElements()),
+          errors::InvalidArgument("number of elements different: input 0 (", context->input(0).NumElements(), ") vs. input ", i, " (", context->input(i).NumElements(), ")"));
+    }
+
+    avro::ValidSchema avro_schema;
+    std::istringstream ss(schema_);
+    string error;
+    OP_REQUIRES(context, (avro::compileJsonSchema(ss, avro_schema, error)), errors::Unimplemented("Avro schema error: ", error));
+
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, context->input(0).shape(), &output_tensor));
+
+    for (int64 entry_index = 0; entry_index < context->input(0).NumElements(); entry_index++) {
+      std::ostringstream ss;
+      std::unique_ptr<avro::OutputStream> out = avro::ostreamOutputStream(ss);
+
+      avro::GenericDatum datum(avro_schema);
+      avro::GenericRecord& record = datum.value<avro::GenericRecord>();
+      for (int i = 0; i < avro_schema.root()->names(); i++) {
+        switch (record.fieldAt(i).type())
+        {
+        case avro::AVRO_BOOL:
+          record.setFieldAt(i, avro::GenericDatum(context->input(i).flat<bool>()(entry_index)));
+          break;
+        case avro::AVRO_INT:
+          record.setFieldAt(i, avro::GenericDatum(static_cast<int32_t>(context->input(i).flat<int32>()(entry_index))));
+          break;
+        case avro::AVRO_LONG:
+          record.setFieldAt(i, avro::GenericDatum(static_cast<int64_t>(context->input(i).flat<int64>()(entry_index))));
+          break;
+        case avro::AVRO_FLOAT:
+          record.setFieldAt(i, avro::GenericDatum(context->input(i).flat<float>()(entry_index)));
+          break;
+        case avro::AVRO_DOUBLE:
+          record.setFieldAt(i, avro::GenericDatum(context->input(i).flat<double>()(entry_index)));
+          break;
+        case avro::AVRO_STRING:
+          {
+            // make a concrete explicit copy as otherwise avro may override the underlying buffer??
+            // happens in decode (not verified in encode yet).
+            const string& v = context->input(i).flat<string>()(entry_index);
+            string field_value;
+            field_value.resize(v.size());
+            if (field_value.size() > 0) {
+              memcpy(&field_value[0], &v[0], field_value.size());
+            }
+            record.setFieldAt(i, avro::GenericDatum(field_value));
+          }
+          break;
+        case avro::AVRO_BYTES:
+          {
+            const string& v = context->input(i).flat<string>()(entry_index);
+            std::vector<uint8_t> field_value;
+            field_value.resize(v.size());
+            if (field_value.size() > 0) {
+              memcpy(&field_value[0], &v[0], field_value.size());
+            }
+            record.setFieldAt(i, avro::GenericDatum(field_value));
+          }
+          break;
+        case avro::AVRO_FIXED:
+        case avro::AVRO_ENUM:
+        default:
+          OP_REQUIRES(context, false, errors::InvalidArgument("unsupported data type: ", record.fieldAt(i).type()));
+        }
+      }
+      avro::EncoderPtr e = avro::binaryEncoder();
+      e->init(*out);
+      avro::encode(*e, datum);
+      out->flush();
+      output_tensor->flat<string>()(entry_index) = ss.str();
+    }
+  }
+private:
+  string schema_;
+};
+
 
 REGISTER_KERNEL_BUILDER(Name("IO>DecodeAvro").Device(DEVICE_CPU),
                         DecodeAvroOp);
+REGISTER_KERNEL_BUILDER(Name("IO>EncodeAvro").Device(DEVICE_CPU),
+                        EncodeAvroOp);
 
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/kafka/ops/kafka_ops.cc
+++ b/tensorflow_io/kafka/ops/kafka_ops.cc
@@ -19,6 +19,16 @@ limitations under the License.
 
 namespace tensorflow {
 
+REGISTER_OP("IO>EncodeAvro")
+  .Input("input: dtype")
+  .Output("string: string")
+  .Attr("schema: string")
+  .Attr("dtype: list({float,double,int32,int64,string})")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->input(0));
+    return Status::OK();
+   });
+
 REGISTER_OP("IO>DecodeAvro")
   .Input("input: string")
   .Output("value: dtype")

--- a/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
@@ -25,6 +25,7 @@ from tensorflow.compat.v1 import data
 from tensorflow_io.core.python.ops import core_ops
 
 decode_avro = core_ops.io_decode_avro
+encode_avro = core_ops.io_encode_avro
 
 warnings.warn(
     "implementation of existing tensorflow_io.kafka.KafkaDataset is "

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -125,3 +125,16 @@ def test_kafka_io_dataset():
     assert np.all([
         e.numpy().tolist() for e in dataset] == np.asarray([
             ("D" + str(i)).encode() for i in range(10)]).reshape((5, 2)))
+
+def test_avro_encode_decode():
+  """test_avro_encode_decode"""
+  schema = ('{"type":"record","name":"myrecord","fields":'
+            '[{"name":"f1","type":"string"},{"name":"f2","type":"long"}]}"')
+  value = [('value1', 1), ('value2', 2), ('value3', 3)]
+  f1 = tf.cast([v[0] for v in value], tf.string)
+  f2 = tf.cast([v[1] for v in value], tf.int64)
+  message = kafka_io.encode_avro([f1, f2], schema=schema)
+  entries = kafka_io.decode_avro(
+      message, schema=schema, dtype=[tf.string, tf.int64])
+  assert np.all(entries[1].numpy() == f2.numpy())
+  assert np.all(entries[0].numpy() == f1.numpy())


### PR DESCRIPTION
In tensorflow-io, the decode_avro has been added so
that it is possible to process kafka stream for kafka schema registry (read).

There is no encode_avro yet which is needed if we want to support writing
serialized (avro) message to kafka stream.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>