### PR TITLE
Disable python 3.7.4 on macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
   - stage: build
     name: "Nightly Release Build on Linux"
     script:
-    - echo bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -74,8 +74,8 @@ jobs:
     os: osx
     osx_image: xcode9.3
     script:
-    - echo bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -83,8 +83,8 @@ jobs:
     os: osx
     osx_image: xcode9.3
     script:
-    - echo bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -92,17 +92,8 @@ jobs:
     os: osx
     osx_image: xcode9.3
     script:
-    - echo bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - echo bash -x -e .travis/wheel.test.sh
-    after_success: bash -x -e .travis/after-success.sh
-
-  - stage: build
-    name: "Nightly Release Build on macOS 3.7.4"
-    os: osx
-    osx_image: xcode9.3
-    script:
     - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
 notifications:

--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -63,23 +63,7 @@ bazel build \
   --noshow_loading_progress \
   --verbose_failures \
   --test_output=errors \
-  -- //tensorflow_io/arrow:arrow_ops \
-     //tensorflow_io/audio:audio_ops \
-     //tensorflow_io/avro:avro_ops \
-     //tensorflow_io/azure:azfs_ops \
-     //tensorflow_io/bigquery:bigquery_ops \
-     //tensorflow_io/core:core_ops \
-     //tensorflow_io/dicom:dicom_ops \
-     //tensorflow_io/gcs:gcs_config_ops \
-     //tensorflow_io/genome:genome_ops \
-     //tensorflow_io/grpc:grpc_ops \
-     //tensorflow_io/hdf5:hdf5_ops \
-     //tensorflow_io/ignite:ignite_ops \
-     //tensorflow_io/image:image_ops \
-     //tensorflow_io/json:json_ops \
-     //tensorflow_io/kafka:kafka_ops \
-     //tensorflow_io/kinesis:kinesis_ops \
-     //tensorflow_io/libsvm:libsvm_ops
+  -- //tensorflow_io/...
 
 rm -rf build && mkdir -p build
 


### PR DESCRIPTION
Too many issues on Travis CI so disable 3.7.4 for now.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>