### PR TITLE
Update decode_tiff_info to allow float data support

### DIFF
--- a/tensorflow_io/core/python/ops/tiff_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/tiff_io_tensor_ops.py
@@ -33,10 +33,14 @@ class TIFFIOTensor(io_tensor_ops._CollectionIOTensor): # pylint: disable=protect
     with tf.name_scope("TIFFIOTensor"):
       # TIFF can fit into memory so load TIFF first
       data = tf.io.read_file(filename)
-      info = core_ops.io_decode_tiff_info(data)
+      shapes, dtypes = core_ops.io_decode_tiff_info(data)
+      # NOTE: While shapes returned correctly handles 3 or 4 channels
+      # we can only handle RGBA so fix shape as 4 for now,
+      # until decode_tiff is updated.
       spec = tuple([
           tf.TensorSpec(tf.TensorShape(
-              e.numpy().tolist() + [4]), tf.uint8) for e in info])
+              shape.tolist()[0:2] + [4]), dtype) for (
+                  shape, dtype) in zip(shapes.numpy(), dtypes.numpy())])
       columns = [i for i, _ in enumerate(spec)]
       elements = [
           io_tensor_ops.TensorIOTensor(

--- a/tensorflow_io/image/kernels/image_tiff_kernels.cc
+++ b/tensorflow_io/image/kernels/image_tiff_kernels.cc
@@ -28,25 +28,76 @@ class DecodeTIFFInfoOp : public OpKernel {
   void Compute(OpKernelContext* context) override {
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
-
     std::istringstream input_stream(input_tensor->scalar<string>()(), std::ios_base::in | std::ios_base::binary);
 
     std::unique_ptr<TIFF, void(*)(TIFF*)> tiff(TIFFStreamOpen("memory", &input_stream), [](TIFF* p) { if (p != nullptr) { TIFFClose(p); } });
     OP_REQUIRES(context, (tiff.get() != nullptr), errors::InvalidArgument("unable to open TIFF from memory"));
 
-    std::vector<std::pair<int64, int64>> shape;
+    std::vector<TensorShape> shape;
+    std::vector<DataType> dtype;
     do {
       unsigned int height, width;
       TIFFGetField(tiff.get(), TIFFTAG_IMAGELENGTH, &height);
       TIFFGetField(tiff.get(), TIFFTAG_IMAGEWIDTH, &width);
-      shape.push_back(std::pair<int64, int64>(static_cast<int64>(height), static_cast<int64>(width)));
+
+      unsigned short channels;
+      TIFFGetField(tiff.get(), TIFFTAG_SAMPLESPERPIXEL, &channels);
+
+      shape.push_back(TensorShape({static_cast<int64>(height), static_cast<int64>(width), static_cast<int64>(channels)}));
+
+      unsigned short format, bits;
+      if (!TIFFGetField(tiff.get(), TIFFTAG_SAMPLEFORMAT, &format)) {
+        // If format is not defined, then we assume format is SAMPLEFORMAT_UINT
+	format = SAMPLEFORMAT_UINT;
+      }
+      TIFFGetField(tiff.get(), TIFFTAG_BITSPERSAMPLE, &bits);
+      DataType pixel_dtype;
+      switch (format)
+      {
+      case SAMPLEFORMAT_UINT:
+        switch (bits)
+	{
+        case 8:
+          pixel_dtype = DT_UINT8;
+          break;
+        default:
+          OP_REQUIRES(context, false, errors::InvalidArgument("unsupported bits ", bits, " for uint"));
+	}
+	break;
+      case SAMPLEFORMAT_INT:
+        switch (bits)
+	{
+        default:
+          OP_REQUIRES(context, false, errors::InvalidArgument("unsupported bits ", bits, " for int"));
+	}
+	break;
+      case SAMPLEFORMAT_IEEEFP:
+        switch (bits)
+	{
+        case 16:
+          pixel_dtype = DT_HALF;
+          break;
+        default:
+          OP_REQUIRES(context, false, errors::InvalidArgument("unsupported bits ", bits, " for fp"));
+	}
+	break;
+      default:
+        OP_REQUIRES(context, false, errors::InvalidArgument("unsupported format ", format));
+      }
+      dtype.push_back(pixel_dtype);
     } while (TIFFReadDirectory(tiff.get()));
 
     Tensor* shape_tensor = nullptr;
-    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({static_cast<int64>(shape.size()), 2}), &shape_tensor));
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({static_cast<int64>(shape.size()), 3}), &shape_tensor));
     for (size_t i = 0; i < shape.size(); i++) {
-      shape_tensor->flat<int64>()(i * 2) = shape[i].first;
-      shape_tensor->flat<int64>()(i * 2 + 1) = shape[i].second;
+      shape_tensor->flat<int64>()(i * 3) = shape[i].dim_size(0);
+      shape_tensor->flat<int64>()(i * 3 + 1) = shape[i].dim_size(1);
+      shape_tensor->flat<int64>()(i * 3 + 2) = shape[i].dim_size(2);
+    }
+    Tensor* dtype_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(1, TensorShape({static_cast<int64>(dtype.size())}), &dtype_tensor));
+    for (size_t i = 0; i < dtype.size(); i++) {
+      dtype_tensor->flat<int64>()(i) = dtype[i];
     }
   }
 };

--- a/tensorflow_io/image/ops/image_ops.cc
+++ b/tensorflow_io/image/ops/image_ops.cc
@@ -22,10 +22,12 @@ namespace tensorflow {
 REGISTER_OP("IO>DecodeTiffInfo")
   .Input("input: string")
   .Output("shape: int64")
+  .Output("dtype: int64")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
     shape_inference::ShapeHandle unused;
     TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &unused));
     c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
+    c->set_output(1, c->MakeShape({c->UnknownDim()}));
     return Status::OK();
   });
 


### PR DESCRIPTION
In #534 we disscussed the native data support for tiff formats.
In order to extract the native data type we first have to
correctly identify the data type (as opposed always do the RGBA 32 conversion
in existing code).

This PR checks additional tiff field so that different data types could be
probed.

This PR is related to #534.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>