### PR TITLE
Remove deprecated WAVDataset

### DIFF
--- a/tensorflow_io/audio/__init__.py
+++ b/tensorflow_io/audio/__init__.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 # ==============================================================================
 """Audio Dataset.
-
-@@WAVDataset
 """
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-from tensorflow_io.audio.python.ops.audio_ops import WAVDataset
 
 from tensorflow.python.util.all_util import remove_undocumented
 


### PR DESCRIPTION
WAVDataset has been replaced with tfio.IODataset.from_audio
so this PR removes it. (as otherwise it causes one error in #489).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>