### PR TITLE
Add `linkstatic = True` to grpc to remove the unneed .so build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -245,6 +245,8 @@ if datapath is not None:
       for filename in [
           f for f in filenames if fnmatch.fnmatch(
               f, "*.so") or fnmatch.fnmatch(f, "*.py")]:
+        if filename.endswith("_proto.so"):
+          continue
         src = os.path.join(rootname, filename)
         dst = os.path.join(
             rootpath,

--- a/setup.py
+++ b/setup.py
@@ -245,6 +245,18 @@ if datapath is not None:
       for filename in [
           f for f in filenames if fnmatch.fnmatch(
               f, "*.so") or fnmatch.fnmatch(f, "*.py")]:
+        # NOTE:
+        # cc_grpc_library will generate a lib<name>_cc_grpc.so
+        # proto_library will generate a lib<name>_proto.so
+        # both .so files are not needed in final wheel.
+        # The cc_grpc_library only need to pass `linkstatic = True`
+        # to the underlying native.cc_library. It is not exposed
+        # but we applied a patch (see third_party/grpc.patch) so
+        # cc_grpc_library is covered and lib<name>_cc_grpc.so will
+        # not be generated.
+        # proto_library is a native library in bazel which we could
+        # not patch easily.
+        # For that reason we skip lib<name>_proto.so here:
         if filename.endswith("_proto.so"):
           continue
         src = os.path.join(rootname, filename)

--- a/third_party/grpc.patch
+++ b/third_party/grpc.patch
@@ -1,6 +1,16 @@
+diff -Naur a/bazel/cc_grpc_library.bzl b/bazel/cc_grpc_library.bzl
+--- a/bazel/cc_grpc_library.bzl	2019-10-24 18:22:38.817788818 +0000
++++ b/bazel/cc_grpc_library.bzl	2019-10-24 18:23:25.991293690 +0000
+@@ -101,5 +101,6 @@
+             deps = deps +
+                    extra_deps +
+                    ["@com_github_grpc_grpc//:grpc++_codegen_proto"],
++            linkstatic = True,
+             **kwargs
+         )
 diff -Naur a/bazel/python_rules.bzl b/bazel/python_rules.bzl
---- a/bazel/python_rules.bzl	2019-09-06 22:12:25.994442366 +0000
-+++ b/bazel/python_rules.bzl	2019-09-06 22:13:05.638367699 +0000
+--- a/bazel/python_rules.bzl	2019-10-24 18:22:38.817788818 +0000
++++ b/bazel/python_rules.bzl	2019-10-24 18:25:31.128668957 +0000
 @@ -175,7 +175,7 @@
          srcs = [
              ":{}".format(codegen_grpc_target),


### PR DESCRIPTION
grpc has been built into libtensorflow_io.so and the libendpoint_cc_grpc.so
is not needed for wheel to run. This also causes the issue in #489.

This PR adds `linkstatic = True,` to skip the building of libendpoint_cc_grpc.so

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>