### PR TITLE
Add the ability to support pass additional global configurations to KafkaOutput

### DIFF
--- a/tensorflow_io/kafka/ops/kafka_ops.cc
+++ b/tensorflow_io/kafka/ops/kafka_ops.cc
@@ -60,7 +60,7 @@ REGISTER_OP("IO>KafkaReadableRead")
 
 REGISTER_OP("IO>KafkaOutputSequence")
     .Input("topic: string")
-    .Input("servers: string")
+    .Input("metadata: string")
     .Output("sequence: resource")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")

--- a/tensorflow_io/kafka/python/ops/kafka_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_ops.py
@@ -23,12 +23,15 @@ from tensorflow_io.core.python.ops import core_ops
 class KafkaOutputSequence(object):
   """KafkaOutputSequence"""
 
-  def __init__(self, topic, servers="localhost"):
+  def __init__(self, topic, servers="localhost", configuration=None):
     """Create a `KafkaOutputSequence`.
     """
     self._topic = topic
+    metadata = [e for e in configuration or []]
+    if servers is not None:
+      metadata.append("bootstrap.servers=%s" % servers)
     self._resource = core_ops.io_kafka_output_sequence(
-        topic=topic, servers=servers)
+        topic=topic, metadata=metadata)
 
   def setitem(self, index, item):
     core_ops.io_kafka_output_sequence_set_item(self._resource, index, item)

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -37,9 +37,6 @@ def test_kafka_io_tensor():
       ("D" + str(i)).encode() for i in range(10)])
   assert len(kafka) == 10
 
-@pytest.mark.skipif(
-    not (hasattr(tf, "version") and
-         tf.version.VERSION.startswith("2.0.")), reason=None)
 def test_kafka_output_sequence():
   """Test case based on fashion mnist tutorial"""
   fashion_mnist = tf.keras.datasets.fashion_mnist


### PR DESCRIPTION
This PR adds the ability to support pass additional global configurations to KafkaOutput
so that it is possible to fine tune Kafka producer (e.g, ssl, etc if possible)

This PR fixes #584.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>