### PR TITLE
Fix KafkaOutputSequence bug caused by find_first_of

### DIFF
--- a/tensorflow_io/avro/kernels/avro_kernels.cc
+++ b/tensorflow_io/avro/kernels/avro_kernels.cc
@@ -307,7 +307,7 @@ class AvroReadable : public IOReadableInterface {
 
     string schema;
     for (size_t i = 0; i < metadata.size(); i++) {
-      if (metadata[i].find_first_of("schema: ") == 0) {
+      if (metadata[i].find("schema: ") == 0) {
         schema = metadata[i].substr(8);
       }
     }

--- a/tensorflow_io/json/kernels/json_kernels.cc
+++ b/tensorflow_io/json/kernels/json_kernels.cc
@@ -223,7 +223,7 @@ class JSONReadable : public IOReadableInterface {
 
     mode_ = "ndjson";
     for (size_t i = 0; i < metadata.size(); i++) {
-      if (metadata[i].find_first_of("mode: ") == 0) {
+      if (metadata[i].find("mode: ") == 0) {
         mode_ = metadata[i].substr(6);
       }
     }

--- a/tensorflow_io/kafka/kernels/kafka_kernels.cc
+++ b/tensorflow_io/kafka/kernels/kafka_kernels.cc
@@ -80,18 +80,18 @@ class KafkaReadable : public IOReadableInterface {
     eof_ = true;
     timeout_ = 2000;
     for (size_t i = 0; i < metadata.size(); i++) {
-      if (metadata[i].find_first_of("conf.eof") == 0) {
+      if (metadata[i].find("conf.eof") == 0) {
         std::vector<string> parts = str_util::Split(metadata[i], "=");
         if (parts.size() != 2) {
           return errors::InvalidArgument("invalid bounded configuration: ", metadata[i]);
         }
         eof_ = (parts[1] != "0");
-      } else if (metadata[i].find_first_of("conf.timeout") == 0) {
+      } else if (metadata[i].find("conf.timeout") == 0) {
         std::vector<string> parts = str_util::Split(metadata[i], "=");
         if (parts.size() != 2 || !strings::safe_strto64(parts[1], &timeout_)) {
           return errors::InvalidArgument("invalid timeout configuration: ", metadata[i]);
         }
-      } else if (metadata[i].find_first_of("conf.topic.") == 0) {
+      } else if (metadata[i].find("conf.topic.") == 0) {
         std::vector<string> parts = str_util::Split(metadata[i], "=");
         if (parts.size() != 2) {
             return errors::InvalidArgument("invalid topic configuration: ", metadata[i]);
@@ -100,7 +100,7 @@ class KafkaReadable : public IOReadableInterface {
         if (result != RdKafka::Conf::CONF_OK) {
           return errors::Internal("failed to do topic configuration:", metadata[i], "error:", errstr);
         }
-      } else if (metadata[i] != "" && metadata[i].find_first_of("conf.") == string::npos) {
+      } else if (metadata[i] != "" && metadata[i].find("conf.") == string::npos) {
         std::vector<string> parts = str_util::Split(metadata[i], "=");
         if (parts.size() != 2) {
             return errors::InvalidArgument("invalid topic configuration: ", metadata[i]);

--- a/tensorflow_io/kafka/kernels/kafka_sequence.cc
+++ b/tensorflow_io/kafka/kernels/kafka_sequence.cc
@@ -76,7 +76,7 @@ class KafkaOutputSequence : public OutputSequence {
     RdKafka::Conf::ConfResult result = RdKafka::Conf::CONF_UNKNOWN;
 
     for (size_t i = 0; i < metadata.size(); i++) {
-      if (metadata[i].find_first_of("conf.topic.") == 0) {
+      if (metadata[i].find("conf.topic.") == 0) {
         std::vector<string> parts = str_util::Split(metadata[i], "=");
         if (parts.size() != 2) {
             return errors::InvalidArgument("invalid topic configuration: ", metadata[i]);
@@ -85,7 +85,7 @@ class KafkaOutputSequence : public OutputSequence {
         if (result != RdKafka::Conf::CONF_OK) {
           return errors::Internal("failed to do topic configuration:", metadata[i], "error:", errstr);
         }
-      } else if (metadata[i] != "" && metadata[i].find_first_of("conf.") == string::npos) {
+      } else if (metadata[i] != "" && metadata[i].find("conf.") == string::npos) {
         std::vector<string> parts = str_util::Split(metadata[i], "=");
         if (parts.size() != 2) {
             return errors::InvalidArgument("invalid global configuration: ", metadata[i]);

--- a/tensorflow_io/prometheus/kernels/prometheus_kernels.cc
+++ b/tensorflow_io/prometheus/kernels/prometheus_kernels.cc
@@ -91,7 +91,7 @@ class PrometheusReadable : public IOReadableInterface {
 
     string endpoint = "http://localhost:9090";
     for (size_t i = 0; i < metadata.size(); i++) {
-      if (metadata[i].find_first_of("endpoint: ") == 0) {
+      if (metadata[i].find("endpoint: ") == 0) {
         endpoint = metadata[i].substr(8);
       }
     }


### PR DESCRIPTION
This PR fixes KafkaOutputSequence bug caused by find_first_of.
The C++ find_first_of will find the first occurance of any
char, not the sequence. So it really should be find_first_of.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>