### PR TITLE
Add AVRO_NULL support for decode_avro

### DIFF
--- a/tensorflow_io/kafka/kernels/kafka_kernels.cc
+++ b/tensorflow_io/kafka/kernels/kafka_kernels.cc
@@ -351,6 +351,30 @@ class DecodeAvroOp : public OpKernel {
       for (int i = 0; i < avro_schema.root()->names(); i++) {
         const avro::GenericDatum& field = record.fieldAt(i);
         switch(field.type()) {
+        case avro::AVRO_NULL:
+          switch(context->expected_output_dtype(i)) {
+          case DT_BOOL:
+            value[i]->flat<bool>()(entry_index) = false;
+            break;
+          case DT_INT32:
+            value[i]->flat<int32>()(entry_index) = 0;
+            break;
+          case DT_INT64:
+            value[i]->flat<int64>()(entry_index) = 0;
+            break;
+          case DT_FLOAT:
+            value[i]->flat<float>()(entry_index) = 0.0;
+            break;
+          case DT_DOUBLE:
+            value[i]->flat<double>()(entry_index) = 0.0;
+            break;
+          case DT_STRING:
+            value[i]->flat<string>()(entry_index) = "";
+            break;
+          default:
+            OP_REQUIRES(context, false, errors::InvalidArgument("unsupported data type against AVRO_NULL: ", field.type()));
+          }
+          break;
         case avro::AVRO_BOOL:
           value[i]->flat<bool>()(entry_index) = field.value<bool>();
           break;

--- a/tests/test_kafka/kafka_test.sh
+++ b/tests/test_kafka/kafka_test.sh
@@ -40,7 +40,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
     sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
     sudo confluent-$VERSION/bin/kafka-console-producer --topic test --broker-list 127.0.0.1:9092 < confluent-$VERSION/test
     sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic avro-test
-    echo -e "{\"f1\":\"value1\",\"f2\":1,\"f3\":null}\n{\"f1\":\"value2\",\"f2\":2,\"f3\":\"2\"}\n{\"f1\":\"value3\",\"f2\":3,\"f3\":null}" > confluent-$VERSION/avro-test
+    echo -e "{\"f1\":\"value1\",\"f2\":1,\"f3\":null}\n{\"f1\":\"value2\",\"f2\":2,\"f3\":{\"string\":\"2\"}}\n{\"f1\":\"value3\",\"f2\":3,\"f3\":null}" > confluent-$VERSION/avro-test
     sudo confluent-$VERSION/bin/kafka-avro-console-producer --broker-list localhost:9092 --topic avro-test --property value.schema="{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"long\"},{\"name\":\"f3\",\"type\":[\"null\",\"string\"],\"default\":null}]}" < confluent-$VERSION/avro-test
     echo Everything started
     exit 0
@@ -88,7 +88,7 @@ if [ "$action" == "start" ]; then
     echo Create avro test topic
     docker exec -i $container-kafka bash -c '/usr/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic avro-test'
     echo Create avro test message
-    docker exec -i $container-schema-registry bash -c 'echo -e "{\"f1\":\"value1\",\"f2\":1,\"f3\":null}\n{\"f1\":\"value2\",\"f2\":2,\"f3\":\"2\"}\n{\"f1\":\"value3\",\"f2\":3,\"f3\":null}" > /avro-test'
+    docker exec -i $container-schema-registry bash -c 'echo -e "{\"f1\":\"value1\",\"f2\":1,\"f3\":null}\n{\"f1\":\"value2\",\"f2\":2,\"f3\":{\"string\":\"2\"}}\n{\"f1\":\"value3\",\"f2\":3,\"f3\":null}" > /avro-test'
     echo Produce avro test message
     docker exec -i $container-schema-registry bash -c "/usr/bin/kafka-avro-console-producer --broker-list localhost:9092 --topic avro-test --property value.schema='{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"long\"},{\"name\":\"f3\",\"type\":[\"null\",\"string\"],\"default\":null}]}' </avro-test"
     echo Container $container started successfully

--- a/tests/test_kafka/kafka_test.sh
+++ b/tests/test_kafka/kafka_test.sh
@@ -40,8 +40,8 @@ if [[ "$(uname)" == "Darwin" ]]; then
     sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
     sudo confluent-$VERSION/bin/kafka-console-producer --topic test --broker-list 127.0.0.1:9092 < confluent-$VERSION/test
     sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic avro-test
-    echo -e "{\"f1\":\"value1\",\"f2\":1}\n{\"f1\":\"value2\",\"f2\":2}\n{\"f1\":\"value3\",\"f2\":3}" > confluent-$VERSION/avro-test
-    sudo confluent-$VERSION/bin/kafka-avro-console-producer --broker-list localhost:9092 --topic avro-test --property value.schema="{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"long\"}]}" < confluent-$VERSION/avro-test
+    echo -e "{\"f1\":\"value1\",\"f2\":1,\"f3\":null}\n{\"f1\":\"value2\",\"f2\":2,\"f3\":\"2\"}\n{\"f1\":\"value3\",\"f2\":3,\"f3\":null}" > confluent-$VERSION/avro-test
+    sudo confluent-$VERSION/bin/kafka-avro-console-producer --broker-list localhost:9092 --topic avro-test --property value.schema="{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"long\"},{\"name\":\"f3\",\"type\":[\"null\",\"string\"],\"default\":null}]}" < confluent-$VERSION/avro-test
     echo Everything started
     exit 0
 fi
@@ -88,9 +88,9 @@ if [ "$action" == "start" ]; then
     echo Create avro test topic
     docker exec -i $container-kafka bash -c '/usr/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic avro-test'
     echo Create avro test message
-    docker exec -i $container-schema-registry bash -c 'echo -e "{\"f1\":\"value1\",\"f2\":1}\n{\"f1\":\"value2\",\"f2\":2}\n{\"f1\":\"value3\",\"f2\":3}" > /avro-test'
+    docker exec -i $container-schema-registry bash -c 'echo -e "{\"f1\":\"value1\",\"f2\":1,\"f3\":null}\n{\"f1\":\"value2\",\"f2\":2,\"f3\":\"2\"}\n{\"f1\":\"value3\",\"f2\":3,\"f3\":null}" > /avro-test'
     echo Produce avro test message
-    docker exec -i $container-schema-registry bash -c "/usr/bin/kafka-avro-console-producer --broker-list localhost:9092 --topic avro-test --property value.schema='{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"long\"}]}' </avro-test"
+    docker exec -i $container-schema-registry bash -c "/usr/bin/kafka-avro-console-producer --broker-list localhost:9092 --topic avro-test --property value.schema='{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"long\"},{\"name\":\"f3\",\"type\":[\"null\",\"string\"],\"default\":null}]}' </avro-test"
     echo Container $container started successfully
 elif [ "$action" == "stop" ]; then
     docker rm -f $container-zookeeper

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -93,8 +93,11 @@ def test_kafka_output_sequence():
 
 def test_avro_kafka_dataset():
   """test_avro_kafka_dataset"""
-  schema = ('{"type":"record","name":"myrecord","fields":'
-            '[{"name":"f1","type":"string"},{"name":"f2","type":"long"}]}"')
+  schema = ('{"type":"record","name":"myrecord","fields":['
+            '{"name":"f1","type":"string"},'
+            '{"name":"f2","type":"long"},'
+            '{"name":"f3","type":["null","string"],"default":null}'
+            ']}"')
   dataset = kafka_io.KafkaDataset(
       ["avro-test:0"], group="avro-test", eof=True)
   # remove kafka framing
@@ -102,8 +105,8 @@ def test_avro_kafka_dataset():
   # deserialize avro
   dataset = dataset.map(
       lambda e: kafka_io.decode_avro(
-          e, schema=schema, dtype=[tf.string, tf.int64]))
-  entries = [(f1.numpy(), f2.numpy()) for (f1, f2) in dataset]
+          e, schema=schema, dtype=[tf.string, tf.int64, tf.string]))
+  entries = [(f1.numpy(), f2.numpy(), f3.numpy()) for (f1, f2, f3) in dataset]
   np.all(entries == [('value1', 1), ('value2', 2), ('value3', 3)])
 
 def test_kafka_stream_dataset():


### PR DESCRIPTION
In decode_avro, AVRO_NULL was not supported and that may
cause the issue of `unsupported data type: 7`

This PR adds AVRO_NULL support. Note if AVRO_NULL is added
then default value of the data type is taken.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>