### PR TITLE
Explicitly expose servers and configuration in from_kafka

### DIFF
--- a/tensorflow_io/core/python/ops/io_dataset.py
+++ b/tensorflow_io/core/python/ops/io_dataset.py
@@ -92,6 +92,8 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
                  partition=0,
                  offset=0,
                  tail=-1,
+                 servers=None,
+                 configuration=None,
                  **kwargs):
     """Creates an `IODataset` from kafka server with an offset range.
 
@@ -124,8 +126,7 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
     with tf.name_scope(kwargs.get("name", "IOFromKafka")):
       return kafka_dataset_ops.KafkaIODataset(
           topic, partition=partition, offset=offset, tail=tail,
-          servers=kwargs.get("servers", None),
-          configuration=kwargs.get("configuration", None),
+          servers=servers, configuration=configuration,
           internal=True)
 
   @classmethod

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -116,7 +116,8 @@ def test_kafka_stream_dataset():
     _ = [e.numpy().tolist() for e in dataset]
 
 def test_kafka_io_dataset():
-  dataset = tfio.IODataset.from_kafka("test").batch(2)
+  dataset = tfio.IODataset.from_kafka(
+      "test", configuration=["fetch.min.bytes=2"]).batch(2)
   # repeat multiple times will result in the same result
   for i in range(5):
     assert np.all([


### PR DESCRIPTION
This PR explicitly expose servers and configuration in from_kafka.
This PR fixes #593

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>