### PR TITLE
Use balanced sharding strategy in bigquery read session.

### DIFF
--- a/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
+++ b/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
@@ -149,6 +149,7 @@ class BigQueryReadSessionOp : public OpKernel {
     createReadSessionRequest.mutable_read_options()->set_row_restriction(
         row_restriction_);                                        
     createReadSessionRequest.set_requested_streams(requested_streams_);
+    createReadSessionRequest.set_sharding_strategy(apiv1beta1::ShardingStrategy::BALANCED);
     createReadSessionRequest.set_format(apiv1beta1::DataFormat::AVRO);
     VLOG(3) << "createReadSessionRequest: "
             << createReadSessionRequest.DebugString();


### PR DESCRIPTION
We use sharding to provide a way of shuffling the read order. With liquid sharding, a single stream can read all data which wouldn't be shuffled.