### PR TITLE
Enable SSE4.2 and AVX (not AVX2) for tensorflow-io

### DIFF
--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -57,6 +57,7 @@ bash -x -e tests/test_azure/start_azure.sh
 bash -x -e tests/test_dicom/dicom_samples.sh download
 bash -x -e tests/test_dicom/dicom_samples.sh extract
 
+export BAZEL_CPU_OPTIMIZATION=yes
 bash -x -e .travis/python.release.sh
 
 if [[ $PYTHON_VERSION == "2" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ jobs:
   - stage: build
     name: "Nightly Release Build on Linux"
     script:
+    - export BAZEL_CPU_OPTIMIZATION=yes
     - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
     after_success: bash -x -e .travis/after-success.sh
 

--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -57,6 +57,11 @@ if [[ "${BAZEL_CACHE}" != "" ]]; then
   args+=(--disk_cache=${BAZEL_CACHE})
 fi
 
+# Build with SSE4.2
+if [[ "${BAZEL_CPU_OPTIMIZATION}" == "true" ]]; then
+  args+=(--copt=-msse4.2 --copt=-mavx)
+fi
+
 bazel build \
   "${args[@]}" \
   --noshow_progress \

--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -58,7 +58,7 @@ if [[ "${BAZEL_CACHE}" != "" ]]; then
 fi
 
 # Build with SSE4.2
-if [[ "${BAZEL_CPU_OPTIMIZATION}" == "true" ]]; then
+if [[ "${BAZEL_CPU_OPTIMIZATION}" == "yes" ]]; then
   args+=(--copt=-msse4.2 --copt=-mavx)
 fi
 

--- a/.travis/python.release.sh
+++ b/.travis/python.release.sh
@@ -37,7 +37,7 @@ if [[ $(uname) == "Darwin" ]]; then
   done
   ls wheelhouse/*
 else
-  docker run -i --rm -v $PWD:/v -w /v --net=host -e BAZEL_CACHE=${BAZEL_CACHE} gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.travis/bazel.build.sh $@
+  docker run -i --rm -v $PWD:/v -w /v --net=host -e BAZEL_CACHE=${BAZEL_CACHE} -e BAZEL_CPU_OPTIMIZATION=${BAZEL_CPU_OPTIMIZATION} gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.travis/bazel.build.sh $@
   sudo chown -R $(id -nu):$(id -ng) .
 
   for entry in 2.7 3.5 3.6 3.7; do

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -11,9 +11,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 cc_library(
     name = "cpuinfo",
     srcs = [
+        "kernels/cpu_check.cc",
         "kernels/cpu_info.cc",
         "kernels/cpu_info.h",
-        "kernels/cpu_check.cc",
     ],
     copts = tf_io_copts(),
     linkstatic = True,
@@ -250,7 +250,6 @@ cc_binary(
     copts = tf_io_copts(),
     linkshared = 1,
     deps = [
-        "//tensorflow_io/core:cpuinfo",
         "//tensorflow_io/arrow:arrow_ops",
         "//tensorflow_io/avro:avro_ops",
         "//tensorflow_io/azure:azfs_ops",
@@ -258,6 +257,7 @@ cc_binary(
         "//tensorflow_io/bigtable:bigtable_ops",
         "//tensorflow_io/core:audio_ops",
         "//tensorflow_io/core:core_ops",
+        "//tensorflow_io/core:cpuinfo",
         "//tensorflow_io/core:image_ops",
         "//tensorflow_io/core:mnist_ops",
         "//tensorflow_io/core:pcap_ops",

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -9,6 +9,21 @@ load(
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 cc_library(
+    name = "cpuinfo",
+    srcs = [
+        "kernels/cpu_info.cc",
+        "kernels/cpu_info.h",
+        "kernels/cpu_check.cc",
+    ],
+    copts = tf_io_copts(),
+    linkstatic = True,
+    deps = [
+        "@local_config_tf//:libtensorflow_framework",
+        "@local_config_tf//:tf_header_lib",
+    ],
+)
+
+cc_library(
     name = "sequence_ops",
     srcs = [
         "kernels/sequence_ops.h",
@@ -235,6 +250,7 @@ cc_binary(
     copts = tf_io_copts(),
     linkshared = 1,
     deps = [
+        "//tensorflow_io/core:cpuinfo",
         "//tensorflow_io/arrow:arrow_ops",
         "//tensorflow_io/avro:avro_ops",
         "//tensorflow_io/azure:azfs_ops",

--- a/tensorflow_io/core/kernels/cpu_check.cc
+++ b/tensorflow_io/core/kernels/cpu_check.cc
@@ -1,0 +1,140 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow_io/core/kernels/cpu_info.h"
+#include "tensorflow/core/platform/logging.h"
+
+#include <mutex>
+#include <string>
+#include <iostream>
+
+namespace tensorflow {
+namespace io {
+namespace {
+
+// If the CPU feature isn't present, log a fatal error.
+void CheckFeatureOrDie(CPUFeature feature, const string& feature_name) {
+  if (!TestCPUFeature(feature)) {
+#ifdef __ANDROID__
+    // Some Android emulators seem to indicate they don't support SSE, so to
+    // avoid crashes when testing, switch this to a warning.
+    LOG(WARNING)
+#else
+    LOG(FATAL)
+#endif
+        << "The TensorFlow IO library was compiled to use " << feature_name
+        << " instructions, but these aren't available on your machine,"
+        << " please recompile libraries with supported instructions.";
+  }
+}
+
+// Check if CPU feature is included in the TensorFlow binary.
+void CheckIfFeatureUnused(CPUFeature feature, const string& feature_name,
+                          string& missing_instructions) {
+  if (TestCPUFeature(feature)) {
+    missing_instructions.append(" ");
+    missing_instructions.append(feature_name);
+  }
+}
+
+// Raises an error if the binary has been compiled for a CPU feature (like AVX)
+// that isn't available on the current machine. It also warns of performance
+// loss if there's a feature available that's not being used.
+// Depending on the compiler and initialization order, a SIGILL exception may
+// occur before this code is reached, but this at least offers a chance to give
+// a more meaningful error message.
+class CPUFeatureGuard {
+ public:
+  CPUFeatureGuard() {
+#ifdef __SSE__
+    CheckFeatureOrDie(CPUFeature::SSE, "SSE");
+#endif  // __SSE__
+#ifdef __SSE2__
+    CheckFeatureOrDie(CPUFeature::SSE2, "SSE2");
+#endif  // __SSE2__
+#ifdef __SSE3__
+    CheckFeatureOrDie(CPUFeature::SSE3, "SSE3");
+#endif  // __SSE3__
+#ifdef __SSE4_1__
+    CheckFeatureOrDie(CPUFeature::SSE4_1, "SSE4.1");
+#endif  // __SSE4_1__
+#ifdef __SSE4_2__
+    CheckFeatureOrDie(CPUFeature::SSE4_2, "SSE4.2");
+#endif  // __SSE4_2__
+#ifdef __AVX__
+    CheckFeatureOrDie(CPUFeature::AVX, "AVX");
+#endif  // __AVX__
+#ifdef __AVX2__
+    CheckFeatureOrDie(CPUFeature::AVX2, "AVX2");
+#endif  // __AVX2__
+#ifdef __AVX512F__
+    CheckFeatureOrDie(CPUFeature::AVX512F, "AVX512F");
+#endif  // __AVX512F__
+#ifdef __FMA__
+    CheckFeatureOrDie(CPUFeature::FMA, "FMA");
+#endif  // __FMA__
+  }
+};
+
+class CPUFeatureCheck {
+ public:
+  CPUFeatureCheck() {
+    string missing_instructions;
+#ifndef __SSE__
+    CheckIfFeatureUnused(CPUFeature::SSE, "SSE", missing_instructions);
+#endif  // __SSE__
+#ifndef __SSE2__
+    CheckIfFeatureUnused(CPUFeature::SSE2, "SSE2", missing_instructions);
+#endif  // __SSE2__
+#ifndef __SSE3__
+    CheckIfFeatureUnused(CPUFeature::SSE3, "SSE3", missing_instructions);
+#endif  // __SSE3__
+#ifndef __SSE4_1__
+    CheckIfFeatureUnused(CPUFeature::SSE4_1, "SSE4.1", missing_instructions);
+#endif  // __SSE4_1__
+#ifndef __SSE4_2__
+    CheckIfFeatureUnused(CPUFeature::SSE4_2, "SSE4.2", missing_instructions);
+#endif  // __SSE4_2__
+#ifndef __AVX__
+    CheckIfFeatureUnused(CPUFeature::AVX, "AVX", missing_instructions);
+#endif  // __AVX__
+
+// NOTE: In TensorFlow IO currently on Linux only AVX and earlier are supported
+// This is inline with TensorFlow Core support.
+// We may decide to enable further e.g., AVX2 in TensorFlow IO only in the future.
+#if 0
+#ifndef __AVX2__
+    CheckIfFeatureUnused(CPUFeature::AVX2, "AVX2", missing_instructions);
+#endif  // __AVX2__
+#ifndef __AVX512F__
+    CheckIfFeatureUnused(CPUFeature::AVX512F, "AVX512F", missing_instructions);
+#endif  // __AVX512F__
+#ifndef __FMA__
+    CheckIfFeatureUnused(CPUFeature::FMA, "FMA", missing_instructions);
+#endif  // __FMA__
+#endif
+    if (!missing_instructions.empty()) {
+    LOG(INFO) << "Your CPU supports instructions that this TensorFlow IO "
+              << "binary was not compiled to use:" << missing_instructions;
+    }
+  }
+};
+
+CPUFeatureGuard g_io_cpu_feature_guard_singleton;
+CPUFeatureCheck g_io_cpu_feature_check_singleton;
+
+}  // namespace
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/kernels/cpu_check.cc
+++ b/tensorflow_io/core/kernels/cpu_check.cc
@@ -114,7 +114,6 @@ class CPUFeatureCheck {
 // NOTE: In TensorFlow IO currently on Linux only AVX and earlier are supported
 // This is inline with TensorFlow Core support.
 // We may decide to enable further e.g., AVX2 in TensorFlow IO only in the future.
-#if 0
 #ifndef __AVX2__
     CheckIfFeatureUnused(CPUFeature::AVX2, "AVX2", missing_instructions);
 #endif  // __AVX2__
@@ -124,10 +123,9 @@ class CPUFeatureCheck {
 #ifndef __FMA__
     CheckIfFeatureUnused(CPUFeature::FMA, "FMA", missing_instructions);
 #endif  // __FMA__
-#endif
     if (!missing_instructions.empty()) {
-    LOG(INFO) << "Your CPU supports instructions that this TensorFlow IO "
-              << "binary was not compiled to use:" << missing_instructions;
+      LOG(INFO) << "Your CPU supports instructions that this TensorFlow IO "
+                << "binary was not compiled to use:" << missing_instructions;
     }
   }
 };

--- a/tensorflow_io/core/kernels/cpu_info.cc
+++ b/tensorflow_io/core/kernels/cpu_info.cc
@@ -1,0 +1,371 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow_io/core/kernels/cpu_info.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/platform.h"
+#include "tensorflow/core/platform/types.h"
+#if defined(PLATFORM_IS_X86)
+#include <mutex>  // NOLINT
+#endif
+
+// SIMD extension querying is only available on x86.
+#ifdef PLATFORM_IS_X86
+#ifdef PLATFORM_WINDOWS
+// Visual Studio defines a builtin function for CPUID, so use that if possible.
+#define GETCPUID(a, b, c, d, a_inp, c_inp) \
+  {                                        \
+    int cpu_info[4] = {-1};                \
+    __cpuidex(cpu_info, a_inp, c_inp);     \
+    a = cpu_info[0];                       \
+    b = cpu_info[1];                       \
+    c = cpu_info[2];                       \
+    d = cpu_info[3];                       \
+  }
+#else
+// Otherwise use gcc-format assembler to implement the underlying instructions.
+#define GETCPUID(a, b, c, d, a_inp, c_inp) \
+  asm("mov %%rbx, %%rdi\n"                 \
+      "cpuid\n"                            \
+      "xchg %%rdi, %%rbx\n"                \
+      : "=a"(a), "=D"(b), "=c"(c), "=d"(d) \
+      : "a"(a_inp), "2"(c_inp))
+#endif
+#endif
+
+namespace tensorflow {
+namespace io {
+namespace {
+
+#ifdef PLATFORM_IS_X86
+class CPUIDInfo;
+void InitCPUIDInfo();
+
+CPUIDInfo *cpuid = nullptr;
+
+#ifdef PLATFORM_WINDOWS
+// Visual Studio defines a builtin function, so use that if possible.
+int GetXCR0EAX() { return _xgetbv(0); }
+#else
+int GetXCR0EAX() {
+  int eax, edx;
+  asm("XGETBV" : "=a"(eax), "=d"(edx) : "c"(0));
+  return eax;
+}
+#endif
+
+// Structure for basic CPUID info
+class CPUIDInfo {
+ public:
+  CPUIDInfo()
+      : have_adx_(0),
+        have_aes_(0),
+        have_avx_(0),
+        have_avx2_(0),
+        have_avx512f_(0),
+        have_avx512cd_(0),
+        have_avx512er_(0),
+        have_avx512pf_(0),
+        have_avx512vl_(0),
+        have_avx512bw_(0),
+        have_avx512dq_(0),
+        have_avx512vbmi_(0),
+        have_avx512ifma_(0),
+        have_avx512_4vnniw_(0),
+        have_avx512_4fmaps_(0),
+        have_bmi1_(0),
+        have_bmi2_(0),
+        have_cmov_(0),
+        have_cmpxchg16b_(0),
+        have_cmpxchg8b_(0),
+        have_f16c_(0),
+        have_fma_(0),
+        have_mmx_(0),
+        have_pclmulqdq_(0),
+        have_popcnt_(0),
+        have_prefetchw_(0),
+        have_prefetchwt1_(0),
+        have_rdrand_(0),
+        have_rdseed_(0),
+        have_smap_(0),
+        have_sse_(0),
+        have_sse2_(0),
+        have_sse3_(0),
+        have_sse4_1_(0),
+        have_sse4_2_(0),
+        have_ssse3_(0),
+        have_hypervisor_(0) {}
+
+  static void Initialize() {
+    // Initialize cpuid struct
+    CHECK(cpuid == nullptr) << __func__ << " ran more than once";
+    cpuid = new CPUIDInfo;
+
+    uint32 eax, ebx, ecx, edx;
+
+    // Get vendor string (issue CPUID with eax = 0)
+    GETCPUID(eax, ebx, ecx, edx, 0, 0);
+    cpuid->vendor_str_.append(reinterpret_cast<char *>(&ebx), 4);
+    cpuid->vendor_str_.append(reinterpret_cast<char *>(&edx), 4);
+    cpuid->vendor_str_.append(reinterpret_cast<char *>(&ecx), 4);
+
+    // To get general information and extended features we send eax = 1 and
+    // ecx = 0 to cpuid.  The response is returned in eax, ebx, ecx and edx.
+    // (See Intel 64 and IA-32 Architectures Software Developer's Manual
+    // Volume 2A: Instruction Set Reference, A-M CPUID).
+    GETCPUID(eax, ebx, ecx, edx, 1, 0);
+
+    cpuid->model_num_ = static_cast<int>((eax >> 4) & 0xf);
+    cpuid->family_ = static_cast<int>((eax >> 8) & 0xf);
+
+    cpuid->have_aes_ = (ecx >> 25) & 0x1;
+    cpuid->have_cmov_ = (edx >> 15) & 0x1;
+    cpuid->have_cmpxchg16b_ = (ecx >> 13) & 0x1;
+    cpuid->have_cmpxchg8b_ = (edx >> 8) & 0x1;
+    cpuid->have_mmx_ = (edx >> 23) & 0x1;
+    cpuid->have_pclmulqdq_ = (ecx >> 1) & 0x1;
+    cpuid->have_popcnt_ = (ecx >> 23) & 0x1;
+    cpuid->have_rdrand_ = (ecx >> 30) & 0x1;
+    cpuid->have_sse2_ = (edx >> 26) & 0x1;
+    cpuid->have_sse3_ = ecx & 0x1;
+    cpuid->have_sse4_1_ = (ecx >> 19) & 0x1;
+    cpuid->have_sse4_2_ = (ecx >> 20) & 0x1;
+    cpuid->have_sse_ = (edx >> 25) & 0x1;
+    cpuid->have_ssse3_ = (ecx >> 9) & 0x1;
+    cpuid->have_hypervisor_ = (ecx >> 31) & 1;
+
+    const uint64 xcr0_xmm_mask = 0x2;
+    const uint64 xcr0_ymm_mask = 0x4;
+    const uint64 xcr0_maskreg_mask = 0x20;
+    const uint64 xcr0_zmm0_15_mask = 0x40;
+    const uint64 xcr0_zmm16_31_mask = 0x80;
+
+    const uint64 xcr0_avx_mask = xcr0_xmm_mask | xcr0_ymm_mask;
+    const uint64 xcr0_avx512_mask = xcr0_avx_mask | xcr0_maskreg_mask |
+                                    xcr0_zmm0_15_mask | xcr0_zmm16_31_mask;
+
+    const bool have_avx =
+        // Does the OS support XGETBV instruction use by applications?
+        ((ecx >> 27) & 0x1) &&
+        // Does the OS save/restore XMM and YMM state?
+        ((GetXCR0EAX() & xcr0_avx_mask) == xcr0_avx_mask) &&
+        // Is AVX supported in hardware?
+        ((ecx >> 28) & 0x1);
+
+    const bool have_avx512 =
+        // Does the OS support XGETBV instruction use by applications?
+        ((ecx >> 27) & 0x1) &&
+        // Does the OS save/restore ZMM state?
+        ((GetXCR0EAX() & xcr0_avx512_mask) == xcr0_avx512_mask);
+
+    cpuid->have_avx_ = have_avx;
+    cpuid->have_fma_ = have_avx && ((ecx >> 12) & 0x1);
+    cpuid->have_f16c_ = have_avx && ((ecx >> 29) & 0x1);
+
+    // Get standard level 7 structured extension features (issue CPUID with
+    // eax = 7 and ecx= 0), which is required to check for AVX2 support as
+    // well as other Haswell (and beyond) features.  (See Intel 64 and IA-32
+    // Architectures Software Developer's Manual Volume 2A: Instruction Set
+    // Reference, A-M CPUID).
+    GETCPUID(eax, ebx, ecx, edx, 7, 0);
+
+    cpuid->have_adx_ = (ebx >> 19) & 0x1;
+    cpuid->have_avx2_ = have_avx && ((ebx >> 5) & 0x1);
+    cpuid->have_bmi1_ = (ebx >> 3) & 0x1;
+    cpuid->have_bmi2_ = (ebx >> 8) & 0x1;
+    cpuid->have_prefetchwt1_ = ecx & 0x1;
+    cpuid->have_rdseed_ = (ebx >> 18) & 0x1;
+    cpuid->have_smap_ = (ebx >> 20) & 0x1;
+
+    cpuid->have_avx512f_ = have_avx512 && ((ebx >> 16) & 0x1);
+    cpuid->have_avx512cd_ = have_avx512 && ((ebx >> 28) & 0x1);
+    cpuid->have_avx512er_ = have_avx512 && ((ebx >> 27) & 0x1);
+    cpuid->have_avx512pf_ = have_avx512 && ((ebx >> 26) & 0x1);
+    cpuid->have_avx512vl_ = have_avx512 && ((ebx >> 31) & 0x1);
+    cpuid->have_avx512bw_ = have_avx512 && ((ebx >> 30) & 0x1);
+    cpuid->have_avx512dq_ = have_avx512 && ((ebx >> 17) & 0x1);
+    cpuid->have_avx512vbmi_ = have_avx512 && ((ecx >> 1) & 0x1);
+    cpuid->have_avx512ifma_ = have_avx512 && ((ebx >> 21) & 0x1);
+    cpuid->have_avx512_4vnniw_ = have_avx512 && ((edx >> 2) & 0x1);
+    cpuid->have_avx512_4fmaps_ = have_avx512 && ((edx >> 3) & 0x1);
+  }
+
+  static bool TestFeature(CPUFeature feature) {
+    InitCPUIDInfo();
+    // clang-format off
+    switch (feature) {
+      case ADX:           return cpuid->have_adx_;
+      case AES:           return cpuid->have_aes_;
+      case AVX2:          return cpuid->have_avx2_;
+      case AVX:           return cpuid->have_avx_;
+      case AVX512F:       return cpuid->have_avx512f_;
+      case AVX512CD:      return cpuid->have_avx512cd_;
+      case AVX512PF:      return cpuid->have_avx512pf_;
+      case AVX512ER:      return cpuid->have_avx512er_;
+      case AVX512VL:      return cpuid->have_avx512vl_;
+      case AVX512BW:      return cpuid->have_avx512bw_;
+      case AVX512DQ:      return cpuid->have_avx512dq_;
+      case AVX512VBMI:    return cpuid->have_avx512vbmi_;
+      case AVX512IFMA:    return cpuid->have_avx512ifma_;
+      case AVX512_4VNNIW: return cpuid->have_avx512_4vnniw_;
+      case AVX512_4FMAPS: return cpuid->have_avx512_4fmaps_;
+      case BMI1:          return cpuid->have_bmi1_;
+      case BMI2:          return cpuid->have_bmi2_;
+      case CMOV:          return cpuid->have_cmov_;
+      case CMPXCHG16B:    return cpuid->have_cmpxchg16b_;
+      case CMPXCHG8B:     return cpuid->have_cmpxchg8b_;
+      case F16C:          return cpuid->have_f16c_;
+      case FMA:           return cpuid->have_fma_;
+      case MMX:           return cpuid->have_mmx_;
+      case PCLMULQDQ:     return cpuid->have_pclmulqdq_;
+      case POPCNT:        return cpuid->have_popcnt_;
+      case PREFETCHW:     return cpuid->have_prefetchw_;
+      case PREFETCHWT1:   return cpuid->have_prefetchwt1_;
+      case RDRAND:        return cpuid->have_rdrand_;
+      case RDSEED:        return cpuid->have_rdseed_;
+      case SMAP:          return cpuid->have_smap_;
+      case SSE2:          return cpuid->have_sse2_;
+      case SSE3:          return cpuid->have_sse3_;
+      case SSE4_1:        return cpuid->have_sse4_1_;
+      case SSE4_2:        return cpuid->have_sse4_2_;
+      case SSE:           return cpuid->have_sse_;
+      case SSSE3:         return cpuid->have_ssse3_;
+      case HYPERVISOR:    return cpuid->have_hypervisor_;
+      default:
+        break;
+    }
+    // clang-format on
+    return false;
+  }
+
+  string vendor_str() const { return vendor_str_; }
+  int family() const { return family_; }
+  int model_num() { return model_num_; }
+
+ private:
+  int have_adx_ : 1;
+  int have_aes_ : 1;
+  int have_avx_ : 1;
+  int have_avx2_ : 1;
+  int have_avx512f_ : 1;
+  int have_avx512cd_ : 1;
+  int have_avx512er_ : 1;
+  int have_avx512pf_ : 1;
+  int have_avx512vl_ : 1;
+  int have_avx512bw_ : 1;
+  int have_avx512dq_ : 1;
+  int have_avx512vbmi_ : 1;
+  int have_avx512ifma_ : 1;
+  int have_avx512_4vnniw_ : 1;
+  int have_avx512_4fmaps_ : 1;
+  int have_bmi1_ : 1;
+  int have_bmi2_ : 1;
+  int have_cmov_ : 1;
+  int have_cmpxchg16b_ : 1;
+  int have_cmpxchg8b_ : 1;
+  int have_f16c_ : 1;
+  int have_fma_ : 1;
+  int have_mmx_ : 1;
+  int have_pclmulqdq_ : 1;
+  int have_popcnt_ : 1;
+  int have_prefetchw_ : 1;
+  int have_prefetchwt1_ : 1;
+  int have_rdrand_ : 1;
+  int have_rdseed_ : 1;
+  int have_smap_ : 1;
+  int have_sse_ : 1;
+  int have_sse2_ : 1;
+  int have_sse3_ : 1;
+  int have_sse4_1_ : 1;
+  int have_sse4_2_ : 1;
+  int have_ssse3_ : 1;
+  int have_hypervisor_ : 1;
+  string vendor_str_;
+  int family_;
+  int model_num_;
+};
+
+std::once_flag cpuid_once_flag;
+
+void InitCPUIDInfo() {
+  // This ensures that CPUIDInfo::Initialize() is called exactly
+  // once regardless of how many threads concurrently call us
+  std::call_once(cpuid_once_flag, CPUIDInfo::Initialize);
+}
+
+#endif  // PLATFORM_IS_X86
+
+}  // namespace
+
+bool TestCPUFeature(CPUFeature feature) {
+#ifdef PLATFORM_IS_X86
+  return CPUIDInfo::TestFeature(feature);
+#else
+  return false;
+#endif
+}
+
+std::string CPUVendorIDString() {
+#ifdef PLATFORM_IS_X86
+  InitCPUIDInfo();
+  return cpuid->vendor_str();
+#else
+  return "";
+#endif
+}
+
+int CPUFamily() {
+#ifdef PLATFORM_IS_X86
+  InitCPUIDInfo();
+  return cpuid->family();
+#else
+  return 0;
+#endif
+}
+
+int CPUModelNum() {
+#ifdef PLATFORM_IS_X86
+  InitCPUIDInfo();
+  return cpuid->model_num();
+#else
+  return 0;
+#endif
+}
+
+int CPUIDNumSMT() {
+#ifdef PLATFORM_IS_X86
+  // https://software.intel.com/en-us/articles/intel-64-architecture-processor-topology-enumeration
+  // https://software.intel.com/en-us/articles/intel-sdm (Vol 3A)
+  // Section: Detecting Hardware Multi-threads Support and Topology
+  // Uses CPUID Leaf 11 to enumerate system topology on Intel x86 architectures
+  // Other cases not supported
+  uint32 eax, ebx, ecx, edx;
+  // Check if system supports Leaf 11
+  GETCPUID(eax, ebx, ecx, edx, 0, 0);
+  if (eax >= 11) {
+    // 1) Leaf 11 available? CPUID.(EAX=11, ECX=0):EBX != 0
+    // 2) SMT_Mask_Width = CPUID.(EAX=11, ECX=0):EAX[4:0] if CPUID.(EAX=11,
+    // ECX=0):ECX[15:8] is 1
+    GETCPUID(eax, ebx, ecx, edx, 11, 0);
+    if (ebx != 0 && ((ecx & 0xff00) >> 8) == 1) {
+      return 1 << (eax & 0x1f);  // 2 ^ SMT_Mask_Width
+    }
+  }
+#endif  // PLATFORM_IS_X86
+  return 0;
+}
+
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/kernels/cpu_info.h
+++ b/tensorflow_io/core/kernels/cpu_info.h
@@ -1,0 +1,151 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_IO_PLATFORM_CPU_INFO_H_
+#define TENSORFLOW_IO_PLATFORM_CPU_INFO_H_
+
+// NOTE: This file is from tensorflow repo. We make a copy here.
+
+#include <string>
+
+// TODO(ahentz): This is not strictly required here but, for historical
+// reasons, many people depend on cpu_info.h in order to use kLittleEndian.
+#include "tensorflow/core/platform/byte_order.h"
+
+#if defined(_MSC_VER)
+// included so __cpuidex function is available for GETCPUID on Windows
+#include <intrin.h>
+#endif
+
+namespace tensorflow {
+namespace io {
+
+// Returns an estimate of the number of schedulable CPUs for this
+// process.  Usually, it's constant throughout the lifetime of a
+// process, but it might change if the underlying cluster management
+// software can change it dynamically.  If the underlying call fails, a default
+// value (e.g. `4`) may be returned.
+int NumSchedulableCPUs();
+
+// Returns an estimate for the maximum parallelism for this process.
+// Applications should avoid running more than this number of threads with
+// intensive workloads concurrently to avoid performance degradation and
+// contention.
+// This value is either the number of schedulable CPUs, or a value specific to
+// the underlying cluster management. Applications should assume this value can
+// change throughout the lifetime of the process. This function must not be
+// called during initialization, i.e., before before main() has started.
+int MaxParallelism();
+
+// Returns an estimate for the maximum parallelism for this process on the
+// provided numa node, or any numa node if `numa_node` is kNUMANoAffinity.
+// See MaxParallelism() for more information.
+int MaxParallelism(int numa_node);
+
+// Returns the total number of CPUs on the system.  This number should
+// not change even if the underlying cluster management software may
+// change the number of schedulable CPUs.  Unlike `NumSchedulableCPUs`, if the
+// underlying call fails, an invalid value of -1 will be returned;
+// the user must check for validity.
+static constexpr int kUnknownCPU = -1;
+int NumTotalCPUs();
+
+// Returns the id of the current CPU.  Returns -1 if the current CPU cannot be
+// identified.  If successful, the return value will be in [0, NumTotalCPUs()).
+int GetCurrentCPU();
+
+// Returns an estimate of the number of hyperthreads per physical core
+// on the CPU
+int NumHyperthreadsPerCore();
+
+// Mostly ISA related features that we care about
+enum CPUFeature {
+  // Do not change numeric assignments.
+  MMX = 0,
+  SSE = 1,
+  SSE2 = 2,
+  SSE3 = 3,
+  SSSE3 = 4,
+  SSE4_1 = 5,
+  SSE4_2 = 6,
+  CMOV = 7,
+  CMPXCHG8B = 8,
+  CMPXCHG16B = 9,
+  POPCNT = 10,
+  AES = 11,
+  AVX = 12,
+  RDRAND = 13,
+  AVX2 = 14,
+  FMA = 15,
+  F16C = 16,
+  PCLMULQDQ = 17,
+  RDSEED = 18,
+  ADX = 19,
+  SMAP = 20,
+
+  // Prefetch Vector Data Into Caches with Intent to Write and T1 Hint
+  // http://www.felixcloutier.com/x86/PREFETCHWT1.html.
+  // You probably want PREFETCHW instead.
+  PREFETCHWT1 = 21,
+
+  BMI1 = 22,
+  BMI2 = 23,
+  HYPERVISOR = 25,  // 0 when on a real CPU, 1 on (well-behaved) hypervisor.
+
+  // Prefetch Data into Caches in Anticipation of a Write (3D Now!).
+  // http://www.felixcloutier.com/x86/PREFETCHW.html
+  PREFETCHW = 26,
+
+  // AVX-512: 512-bit vectors (plus masking, etc.) in Knights Landing,
+  // Skylake
+  // Xeon, etc.; each of these entries is a different subset of
+  // instructions,
+  // various combinations of which occur on various CPU types.
+  AVX512F = 27,        // Foundation
+  AVX512CD = 28,       // Conflict detection
+  AVX512ER = 29,       // Exponential and reciprocal
+  AVX512PF = 30,       // Prefetching
+  AVX512VL = 31,       // Shorter vector lengths
+  AVX512BW = 32,       // Byte and word
+  AVX512DQ = 33,       // Dword and qword
+  AVX512VBMI = 34,     // Bit manipulation
+  AVX512IFMA = 35,     // Integer multiply-add
+  AVX512_4VNNIW = 36,  // Integer neural network
+  AVX512_4FMAPS = 37,  // Floating point neural network
+};
+
+// Checks whether the current processor supports one of the features above.
+// Checks CPU registers to return hardware capabilities.
+bool TestCPUFeature(CPUFeature feature);
+
+// Returns CPU Vendor string (i.e. 'GenuineIntel', 'AuthenticAMD', etc.)
+std::string CPUVendorIDString();
+
+// Returns CPU family.
+int CPUFamily();
+
+// Returns CPU model number.
+int CPUModelNum();
+
+// Returns nominal core processor cycles per second of each processor.
+double NominalCPUFrequency();
+
+// Returns num of hyperthreads per physical core
+int CPUIDNumSMT();
+
+}  // namespace io
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_IO_PLATFORM_CPU_INFO_H_


### PR DESCRIPTION
This PR is part of the effort for #612 and #611. Basically we enables SSE4.2 and AVX support by default on Linux.

If machines used does not have the SSE4.2 and AVX support then it will thrown out an error on Linux.

User could still build their own binary with any instruction set.

Note SSE4.2 and AVX are enabled by tensorflow's core library already, so we are basically inline with tensorflow.

Note also that AVX2 are not enabled yet, also inline with tensorflow.

This PR fixes #612.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>