### PR TITLE
Add graph mode support for audio IOTensor and IODataset

### DIFF
--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -35,7 +35,7 @@ REGISTER_OP("IO>WAVReadableSpec")
   .Output("dtype: int64")
   .Output("rate: int32")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
-    c->set_output(0, c->MakeShape({c->UnknownDim()}));
+    c->set_output(0, c->MakeShape({2}));
     c->set_output(1, c->MakeShape({}));
     c->set_output(2, c->Scalar());
      return Status::OK();
@@ -46,14 +46,9 @@ REGISTER_OP("IO>WAVReadableRead")
   .Input("start: int64")
   .Input("stop: int64")
   .Output("value: dtype")
-  .Attr("shape: shape")
   .Attr("dtype: type")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
-    PartialTensorShape shape;
-    TF_RETURN_IF_ERROR(c->GetAttr("shape", &shape));
-    shape_inference::ShapeHandle entry;
-    TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(shape, &entry));
-    c->set_output(0, entry);
+    c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
     return Status::OK();
    });
 

--- a/tensorflow_io/core/python/api/v0/__init__.py
+++ b/tensorflow_io/core/python/api/v0/__init__.py
@@ -16,6 +16,6 @@
 
 # tensorflow_io.core.python.ops is implicitly imported (along with file system)
 from tensorflow_io.core.python.ops.io_tensor import IOTensor
-from tensorflow_io.core.python.ops.io_dataset import IODataset, IOStreamDataset
+from tensorflow_io.core.python.ops.io_dataset import IODataset
 
 from tensorflow_io.core.python.api.v0 import image

--- a/tensorflow_io/core/python/ops/audio_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/audio_io_tensor_ops.py
@@ -17,33 +17,91 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import uuid
-
 import tensorflow as tf
 from tensorflow_io.core.python.ops import io_tensor_ops
 from tensorflow_io.core.python.ops import core_ops
 
-class _AudioIOTensorFunction(object):
-  """_AudioIOTensorFunction"""
-  def __init__(self, function, resource, shape, dtype):
-    self._function = function
-    self._resource = resource
-    self._length = shape[0]
-    self._shape = tf.TensorShape([None]).concatenate(shape[1:])
-    self._dtype = dtype
-  def __call__(self, start, stop):
-    start, stop, _ = slice(start, stop).indices(self._length)
-    if start >= self._length:
-      raise IndexError("index %s is out of range" % slice(start, stop))
-    return self._function(
-        self._resource,
-        start=start, stop=stop,
-        shape=self._shape, dtype=self._dtype)
-  @property
-  def length(self):
-    return self._length
+class AudioGraphIOTensor(object):
+  """AudioGraphIOTensor"""
 
-class AudioIOTensor(io_tensor_ops.BaseIOTensor): # pylint: disable=protected-access
+  #=============================================================================
+  # Constructor (private)
+  #=============================================================================
+  def __init__(self,
+               resource,
+               shape, dtype, rate,
+               internal=False):
+    with tf.name_scope("AudioGraphIOTensor"):
+      assert internal
+      self._resource = resource
+      self._shape = shape
+      self._dtype = dtype
+      self._rate = rate
+      super(AudioGraphIOTensor, self).__init__()
+
+  #=============================================================================
+  # Accessors
+  #=============================================================================
+
+  @property
+  def shape(self):
+    """Returns the `TensorShape` that represents the shape of the tensor."""
+    return self._shape
+
+  @property
+  def dtype(self):
+    """Returns the `dtype` of elements in the tensor."""
+    return self._dtype
+
+  #=============================================================================
+  # String Encoding
+  #=============================================================================
+  def __repr__(self):
+    meta = "".join([", %s=%s" % (
+        k, repr(v.__get__(self))) for k, v in self.__class__.__dict__.items(
+            ) if isinstance(v, _IOTensorMeta)])
+    return "<%s: shape=%s, dtype=%s%s>" % (
+        self.__class__.__name__, self.shape, self.dtype, meta)
+
+  #=============================================================================
+  # Tensor Type Conversions
+  #=============================================================================
+
+  def to_tensor(self):
+    """Converts this `IOTensor` into a `tf.Tensor`.
+
+    Args:
+      name: A name prefix for the returned tensors (optional).
+
+    Returns:
+      A `Tensor` with value obtained from this `IOTensor`.
+    """
+    return core_ops.io_wav_readable_read(
+        self._resource, 0, -1, dtype=self._dtype)
+
+  #=============================================================================
+  # Indexing
+  #=============================================================================
+  def __getitem__(self, key):
+    """Returns the specified piece of this IOTensor."""
+    if isinstance(key, slice):
+      return core_ops.io_wav_readable_read(
+          self._resource, key.start, key.stop, dtype=self._dtype)
+    item = core_ops.io_wav_readable_read(
+        self._resource, key, key + 1, dtype=self._dtype)
+    if tf.shape(item)[0] == 0:
+      raise IndexError("index %s is out of range" % key)
+    return item[0]
+
+  #=============================================================================
+  # Accessors
+  #=============================================================================
+  @io_tensor_ops._IOTensorMeta # pylint: disable=protected-access
+  def rate(self):
+    """The sample `rate` of the audio stream"""
+    return self._rate
+
+class AudioIOTensor(AudioGraphIOTensor):
   """AudioIOTensor
 
   An `AudioIOTensor` is an `IOTensor` backed by audio files such as WAV
@@ -59,26 +117,10 @@ class AudioIOTensor(io_tensor_ops.BaseIOTensor): # pylint: disable=protected-acc
   def __init__(self,
                filename,
                internal=False):
-    with tf.name_scope("FromAudio") as scope:
-      resource = core_ops.io_wav_readable_init(
-          filename,
-          container=scope,
-          shared_name="%s/%s" % (filename, uuid.uuid4().hex))
+    with tf.name_scope("FromAudio"):
+      resource = core_ops.io_wav_readable_init(filename)
       shape, dtype, rate = core_ops.io_wav_readable_spec(resource)
-      shape = tf.TensorShape(shape.numpy())
+      shape = tf.TensorShape(shape)
       dtype = tf.as_dtype(dtype.numpy())
-      spec = tf.TensorSpec(shape, dtype)
-      function = _AudioIOTensorFunction(
-          core_ops.io_wav_readable_read, resource, shape, dtype)
-      self._rate = rate.numpy()
       super(AudioIOTensor, self).__init__(
-          spec, function, internal=internal)
-
-  #=============================================================================
-  # Accessors
-  #=============================================================================
-
-  @io_tensor_ops._IOTensorMeta # pylint: disable=protected-access
-  def rate(self):
-    """The sample `rate` of the audio stream"""
-    return self._rate
+          resource, shape, dtype, rate, internal=internal)

--- a/tensorflow_io/core/python/ops/audio_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/audio_io_tensor_ops.py
@@ -80,7 +80,7 @@ class AudioGraphIOTensor(object):
         self._resource, 0, -1, dtype=self._dtype)
 
   #=============================================================================
-  # Indexing
+  # Indexing and slicing
   #=============================================================================
   def __getitem__(self, key):
     """Returns the specified piece of this IOTensor."""
@@ -92,6 +92,10 @@ class AudioGraphIOTensor(object):
     if tf.shape(item)[0] == 0:
       raise IndexError("index %s is out of range" % key)
     return item[0]
+
+  def __len__(self):
+    """Returns the total number of items of this IOTensor."""
+    return self._shape[0]
 
   #=============================================================================
   # Accessors

--- a/tensorflow_io/core/python/ops/io_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/io_dataset_ops.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""_IODataset and _IOStreamDataset"""
+"""_IODataset and _StreamIODataset"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -21,15 +21,15 @@ import sys
 
 import tensorflow as tf
 
-class _IOStreamDataset(tf.compat.v2.data.Dataset):
-  """_IOStreamDataset"""
+class _StreamIODataset(tf.compat.v2.data.Dataset):
+  """_StreamIODataset"""
 
   def __init__(self, function, internal=True, **kwargs):
     if not internal:
-      raise ValueError("IOStreamDataset constructor is private; please use one "
+      raise ValueError("StreamIODataset constructor is private; please use one "
                        "of the factory methods instead (e.g., "
                        "IODataset.from_kafka())")
-    with tf.name_scope("IOStreamDataset"):
+    with tf.name_scope("StreamIODataset"):
       capacity = kwargs.get("capacity", 4096)
       dataset = tf.compat.v2.data.Dataset.range(0, sys.maxsize, capacity)
       dataset = dataset.map(lambda index: function(index, index+capacity))
@@ -40,7 +40,7 @@ class _IOStreamDataset(tf.compat.v2.data.Dataset):
 
       self._function = function
       self._dataset = dataset
-      super(_IOStreamDataset, self).__init__(
+      super(_StreamIODataset, self).__init__(
           self._dataset._variant_tensor) # pylint: disable=protected-access
 
   def _inputs(self):
@@ -50,7 +50,7 @@ class _IOStreamDataset(tf.compat.v2.data.Dataset):
   def element_spec(self):
     return self._dataset.element_spec
 
-class _IODataset(_IOStreamDataset):
+class _IODataset(_StreamIODataset):
   """_IODataset"""
 
   def __init__(self, function, internal=False, **kwargs):

--- a/tensorflow_io/core/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_dataset_ops.py
@@ -55,8 +55,8 @@ class KafkaIODataset(io_dataset_ops._IODataset): # pylint: disable=protected-acc
       super(KafkaIODataset, self).__init__(
           _KafkaIODatasetFunction(resource), internal=internal)
 
-class KafkaIOStreamDataset(io_dataset_ops._IOStreamDataset): # pylint: disable=protected-access
-  """KafkaIOStreamDataset"""
+class KafkaStreamIODataset(io_dataset_ops._StreamIODataset): # pylint: disable=protected-access
+  """KafkaStreamIODataset"""
 
   def __init__(self,
                topic,
@@ -65,8 +65,8 @@ class KafkaIOStreamDataset(io_dataset_ops._IOStreamDataset): # pylint: disable=p
                servers,
                configuration,
                internal=True):
-    """KafkaIOStreamDataset."""
-    with tf.name_scope("KafkaIOStreamDataset") as scope:
+    """KafkaStreamIODataset."""
+    with tf.name_scope("KafkaStreamIODataset") as scope:
       subscription = "%s:%d:%d" % (topic, partition, offset)
       metadata = [e for e in configuration or []]
       if servers is not None:
@@ -76,5 +76,5 @@ class KafkaIOStreamDataset(io_dataset_ops._IOStreamDataset): # pylint: disable=p
           container=scope,
           shared_name="%s/%s" % (subscription, uuid.uuid4().hex))
 
-      super(KafkaIOStreamDataset, self).__init__(
+      super(KafkaStreamIODataset, self).__init__(
           _KafkaIODatasetFunction(resource), internal=internal)

--- a/tests/test_audio_eager.py
+++ b/tests/test_audio_eager.py
@@ -21,9 +21,7 @@ import os
 import numpy as np
 
 import tensorflow as tf
-if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
-  tf.compat.v1.enable_eager_execution()
-import tensorflow_io as tfio # pylint: disable=wrong-import-position
+import tensorflow_io as tfio
 
 audio_path = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -33,11 +31,11 @@ def test_from_tensor():
   """test_from_tensor"""
   audio_data = tfio.IOTensor.from_audio(audio_path)
   numpy_data = audio_data.to_tensor().numpy()
-
   new_tensor = tfio.IOTensor.from_tensor(numpy_data)
   # The behavior of from_audio and from_tesnor should match
   for i, audio_value in enumerate(audio_data):
     assert new_tensor[i].numpy() == audio_value.numpy()
+
 def test_audio_dataset():
   """Test Audio Dataset"""
   with open(audio_path, 'rb') as f:
@@ -82,3 +80,69 @@ def test_audio_dataset():
   assert samples.shape == [22050, 2]
   assert samples.rate == 44100
   assert np.all(samples.to_tensor().numpy() == expected)
+
+def test_dataset_with_io_tensor():
+  """test_from_tensor"""
+  audio_v = tf.audio.decode_wav(tf.io.read_file(audio_path))
+  f = lambda x: float(x) / (1 << 15)
+
+  filename_dataset = tf.data.Dataset.from_tensor_slices(
+      [audio_path, audio_path])
+  position_dataset = tf.data.Dataset.from_tensor_slices(
+      [tf.constant(1000, tf.int64), tf.constant(2000, tf.int64)])
+
+  dataset = tf.data.Dataset.zip((filename_dataset, position_dataset))
+
+  # Note: @tf.function is actually not needed, as tf.data.Dataset
+  # will automatically wrap the `func` into a graph anyway.
+  # The following is purely for explanation purposes.
+  # Return: audio chunk from position:position+100, and the rate.
+  @tf.function
+  def func(filename, position):
+    audio = tfio.IOTensor.graph(tf.int16).from_audio(filename)
+    return audio[position:position+100], audio.rate
+
+  dataset = dataset.map(func)
+
+  item = 0
+  for (data, rate) in dataset:
+    assert rate == audio_v.sample_rate
+    assert data.shape == (100, 1)
+    position = 1000 if item == 0 else 2000
+    for i in range(100):
+      assert audio_v.audio[position + i].numpy() == f(data[i].numpy())
+    item += 1
+
+def test_dataset_with_io_dataset():
+  """test_dataset_with_io_dataset"""
+  audio_v = tf.audio.decode_wav(tf.io.read_file(audio_path))
+  f = lambda x: float(x) / (1 << 15)
+
+  filename_dataset = tf.data.Dataset.from_tensor_slices(
+      [audio_path, audio_path])
+  position_dataset = tf.data.Dataset.from_tensor_slices(
+      [tf.constant(1000, tf.int64), tf.constant(2000, tf.int64)])
+
+  dataset = tf.data.Dataset.zip((filename_dataset, position_dataset))
+
+  # Note: @tf.function is actually not needed, as tf.data.Dataset
+  # will automatically wrap the `func` into a graph anyway.
+  # The following is purely for explanation purposes.
+  # Return: an embedded dataset (in an outer dataset) for position:position+100
+  @tf.function
+  def func(filename, position):
+    audio_dataset = tfio.IODataset.graph(tf.int16).from_audio(filename)
+    return audio_dataset.skip(position).take(100)
+
+  dataset = dataset.map(func)
+
+  item = 0
+  # Notice audio_dataset in dataset:
+  for audio_dataset in dataset:
+    position = 1000 if item == 0 else 2000
+    i = 0
+    for value in audio_dataset:
+      assert audio_v.audio[position + i].numpy() == f(value.numpy())
+      i += 1
+    assert i == 100
+    item += 1

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -23,8 +23,6 @@ import pytest
 import numpy as np
 
 import tensorflow as tf
-if not (hasattr(tf, "version") and tf.version.VERSION.startswith("2.")):
-  tf.compat.v1.enable_eager_execution()
 import tensorflow_io as tfio # pylint: disable=wrong-import-position
 from tensorflow_io.kafka.python.ops import kafka_ops # pylint: disable=wrong-import-position
 import tensorflow_io.kafka as kafka_io # pylint: disable=wrong-import-position
@@ -110,7 +108,7 @@ def test_avro_kafka_dataset():
   np.all(entries == [('value1', 1), ('value2', 2), ('value3', 3)])
 
 def test_kafka_stream_dataset():
-  dataset = tfio.IOStreamDataset.from_kafka("test").batch(2)
+  dataset = tfio.IODataset.stream().from_kafka("test").batch(2)
   assert np.all([
       e.numpy().tolist() for e in dataset] == np.asarray([
           ("D" + str(i)).encode() for i in range(10)]).reshape((5, 2)))


### PR DESCRIPTION
This PR tries to address the issue in #581 where IOTensor
from audio (WAV) file does not support graph mode, thus
could not be wired up inside tf.data.Dataset.map() function.

There were several reasons:
1) Initially tf.data was designed as a pipeline in graph mode
   with efficiency as the goal.
2) It was not possible to random access with tf.data as
   tf.data always iterate from beginning to end.
3) It was not possible to get meta data as graph mode essentially
   is a one-shot operation and all of the information about shape
   and dtype has to be defined exactly before hand.

Some of the goals of tensorflow/io were to address 2) and 3).
While addressing 3), IOTensor utilize eager mode to obtain the metadata
in one run, then run the graph.

This reduces user knobs and there is no need to specify Tensor
shape and dtype for any operations.

However, since it utilize eager mode, it is not possible to use IOTensor
inside a tf.data.Dataset's `map` function, because `map` will wrap the
function (or lambda) as a subgraph with autograph.

This PR tries to address the issue by avoid eager mode in IOTensor.

However, by nature of graph, at the minimium the dtype of the Tensor
has to be specified for the output node. There is no real way to
get around (other than infered or casted).

The solution in this PR, is to introduce the graph mode and requiring
user to provide the dtype. With dtype in place, this PR also did some
additional plumbing so that AudioGraphIOTensor and AudioGraphIODataset
could be used in graph mode, thus they could be used in combination
with tf.data.Dataset's map function (and tf.data pipeline).

The loss is the need to provide dtype before hand. But user still have
the option of not providing dtype and use AudioIOTensor and AudioIODataset
in eager mode.

Below is the usage of IOTensor with audio in graph mode (in combination with tf.data.Dataset):
```python
import tensorflow as tf
import tensorflow_io as tfio

filename_dataset = tf.data.Dataset.from_tensor_slices(
    [audio_path, audio_path])
position_dataset = tf.data.Dataset.from_tensor_slices(
    [tf.constant(1000, tf.int64), tf.constant(2000, tf.int64)])

dataset = tf.data.Dataset.zip((filename_dataset, position_dataset))

# Note: @tf.function is actually not needed, as tf.data.Dataset
# will automatically wrap the `func` into a graph anyway.
# The following is purely for explanation purposes.
# Return: audio chunk from position:position+100, and the rate.
@tf.function
def func(filename, position):
  audio = tfio.IOTensor.graph(tf.int16).from_audio(filename)
  return audio[position:position+100], audio.rate

dataset = dataset.map(func)

for (data, rate) in dataset:
  print(data, rate)

```


Below is the usage of IODataset with audio in graph mode (in combination with tf.data.Dataset), essentially a `dataset inside an outer scope dataset`:
```python
import tensorflow as tf
import tensorflow_io as tfio

filename_dataset = tf.data.Dataset.from_tensor_slices(
    [audio_path, audio_path])
position_dataset = tf.data.Dataset.from_tensor_slices(
    [tf.constant(1000, tf.int64), tf.constant(2000, tf.int64)])

dataset = tf.data.Dataset.zip((filename_dataset, position_dataset))

# Note: @tf.function is actually not needed, as tf.data.Dataset
# will automatically wrap the `func` into a graph anyway.
# The following is purely for explanation purposes.
# Return: an embedded dataset (in an outer dataset) for position:position+100
@tf.function
def func(filename, position):
  audio_dataset = tfio.IODataset.graph(tf.int16).from_audio(filename)
  return audio_dataset.skip(position).take(100)

dataset = dataset.map(func)

# Notice audio_dataset in dataset:
for audio_dataset in dataset:
  for value in audio_dataset:
    print(value)
```

This PR fixes #581.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>