### PR TITLE
Check for existence of attribute _grpc_server

### DIFF
--- a/tensorflow_io/grpc/python/ops/grpc_ops.py
+++ b/tensorflow_io/grpc/python/ops/grpc_ops.py
@@ -56,7 +56,7 @@ class GRPCDataset(data.Dataset):
     return dataset
 
   def __del__(self):
-    if self._grpc_server is not None:
+    if hasattr(self, '_grpc_server') and self._grpc_server is not None:
       self._grpc_server.stop()
 
   def _inputs(self):


### PR DESCRIPTION
Without this check, the `__del__` method fails with:

```
Exception ignored in: <bound method GRPCDataset.__del__ of <GRPCDataset shapes: (2,), types: tf.int16>>
Traceback (most recent call last):
  File .../lib/python3.6/site-packages/tensorflow_io/grpc/python/ops/grpc_ops.py, line 59, in __del__
    if self._grpc_server is not None:
AttributeError: 'GRPCDataset' object has no attribute '_grpc_server'
```
when instantiating GRPCDataset with the normal constructor instead of from_numpy.