### PR TITLE
Support graph mode  dataset usage of IODataset.graph(tf.uint8).from_ffmpeg

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -207,6 +207,7 @@ cc_library(
     name = "ffmpeg_3.4_ops",
     srcs = [
         "kernels/ffmpeg_kernels.cc",
+        "kernels/ffmpeg_kernels_deprecated.cc",
         "ops/ffmpeg_ops.cc",
     ],
     copts = tf_io_copts(),
@@ -221,6 +222,7 @@ cc_library(
     name = "ffmpeg_2.8_ops",
     srcs = [
         "kernels/ffmpeg_kernels.cc",
+        "kernels/ffmpeg_kernels_deprecated.cc",
         "ops/ffmpeg_ops.cc",
     ],
     copts = tf_io_copts(),

--- a/tensorflow_io/core/kernels/ffmpeg_kernels.cc
+++ b/tensorflow_io/core/kernels/ffmpeg_kernels.cc
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow_io/core/kernels/io_interface.h"
 #include "tensorflow_io/core/kernels/io_stream.h"
 #include  <deque>
@@ -30,54 +29,26 @@ extern "C" {
 
 namespace tensorflow {
 namespace data {
+void FFmpegInit();
+namespace {
 
-static mutex mu(LINKER_INITIALIZED);
-static unsigned count(0);
-void FFmpegReaderInit() {
-  mutex_lock lock(mu);
-  count++;
-  if (count == 1) {
-    // Set log level if needed
-    static const struct { const char *name; int level; } log_levels[] = {
-        { "quiet"  , AV_LOG_QUIET   },
-        { "panic"  , AV_LOG_PANIC   },
-        { "fatal"  , AV_LOG_FATAL   },
-        { "error"  , AV_LOG_ERROR   },
-        { "warning", AV_LOG_WARNING },
-        { "info"   , AV_LOG_INFO    },
-        { "verbose", AV_LOG_VERBOSE },
-        { "debug"  , AV_LOG_DEBUG   },
-        // { "trace"  , AV_LOG_TRACE   },
-    };
-    const char* log_level_name = getenv("FFMPEG_LOG_LEVEL");
-    if (log_level_name != nullptr) {
-      string log_level = log_level_name;
-      for (size_t i = 0; i < sizeof(log_levels)/sizeof(log_levels[0]); i++) {
-        if (log_level == log_levels[i].name) {
-          LOG(INFO) << "FFmpeg log level: " << log_level;
-          av_log_set_level(log_levels[i].level);
-          break;
-        }
-      }
-    }
-
-    // Register all formats and codecs
-    av_register_all();
-  }
-}
-
-class FFmpegReadStream {
+class FFmpegStream {
  public:
-  FFmpegReadStream(const string& filename, SizedRandomAccessFile* file, uint64 file_size)
+  FFmpegStream(const string& filename, SizedRandomAccessFile* file, uint64 file_size)
   : filename_(filename)
   , file_(file)
   , file_size_(file_size)
   , offset_(0)
   , format_context_(nullptr, [](AVFormatContext* p) { if (p != nullptr) { avformat_close_input(&p); av_free(p); } })
   , io_context_(nullptr, [](AVIOContext* p) { if (p != nullptr) { av_free(p); } })
-  , stream_index_(-1) { }
-  ~FFmpegReadStream() {}
-
+  , stream_index_(-1)
+  , codec_context_(nullptr)
+  , codec_context_scope_(nullptr, [](AVCodecContext* p) { if (p != nullptr) { avcodec_free_context(&p); }})
+  , nb_frames_(-1)
+  , packet_scope_(nullptr, [](AVPacket* p) { if (p != nullptr) { av_packet_unref(p); }})
+  { }
+  ~FFmpegStream() {}
+/*
   int64 Streams() {
     return format_context_.get()->nb_streams;
   }
@@ -89,25 +60,41 @@ class FFmpegReadStream {
 #endif
     return media_type;
   }
-  virtual Status Open(int64 stream_index) {
+*/
+  virtual Status Open(int64 media, int64 index) {
     offset_ = 0;
     AVFormatContext *format_context; 
     if ((format_context = avformat_alloc_context()) != NULL) {
       AVIOContext *io_context;
-      if ((io_context = avio_alloc_context(NULL, 0, 0, this, FFmpegReadStream::ReadPacket, NULL, FFmpegReadStream::Seek)) != NULL) {
+      if ((io_context = avio_alloc_context(NULL, 0, 0, this, FFmpegStream::ReadPacket, NULL, FFmpegStream::Seek)) != NULL) {
         format_context->pb = io_context;
         if (avformat_open_input(&format_context, filename_.c_str(), NULL, NULL) >= 0) {
           if (avformat_find_stream_info(format_context, NULL) >= 0) {
+            stream_index_ = -1;
+
             // No plan to read any other stream frame
+            int64 media_index = 0;
             for (int64 i = 0; i < format_context->nb_streams; i++) {
-              if (stream_index != i) {
+#if LIBAVCODEC_VERSION_MAJOR > 56
+              int media_type = format_context->streams[i]->codecpar->codec_type;
+#else
+              int media_type = format_context->streams[i]->codec->codec_type;
+#endif
+              if (media_type == media) {
+                if (media_index == index) {
+                  stream_index_ = i;
+                }
+                media_index++;
+              }
+              if (stream_index_ != i) {
                 format_context->streams[i]->discard = AVDISCARD_ALL;
               }
             }
-            stream_index_ = stream_index;
-            io_context_.reset(io_context);
-            format_context_.reset(format_context);
-            return Status::OK();
+            if (stream_index_ >= 0) {
+              io_context_.reset(io_context);
+              format_context_.reset(format_context);
+              return Status::OK();
+            }
           }
         }
         av_free(io_context);
@@ -115,10 +102,47 @@ class FFmpegReadStream {
       av_free(format_context);
     }
     return errors::InvalidArgument("unable to open file: ", filename_);
-   }
+  }
+  Status OpenCodec() {
+    int64 stream_index = stream_index_;
+
+#if LIBAVCODEC_VERSION_MAJOR > 56
+    int codec_id = format_context_->streams[stream_index]->codecpar->codec_id;
+#else
+    int codec_id = format_context_->streams[stream_index]->codec->codec_id;
+#endif
+    // Find decoder for the stream
+    AVCodec *codec = avcodec_find_decoder((enum AVCodecID)codec_id);
+    if (codec == NULL) {
+      return errors::InvalidArgument("unable to find codec id: ", codec_id);
+    }
+    codec_ = codec->name;
+#if LIBAVCODEC_VERSION_MAJOR > 56
+    codec_context_ = avcodec_alloc_context3(codec);
+    if (codec_context_ == nullptr) {
+      return errors::InvalidArgument("unable to allocate codec context");
+    }
+    codec_context_scope_.reset(codec_context_);
+    // Copy codec parameters from input stream to output codec context
+    if (avcodec_parameters_to_context(codec_context_, format_context_->streams[stream_index]->codecpar) < 0) {
+      return errors::Internal("could not copy codec parameters from input stream to output codec context");
+    }
+#else
+    codec_context_ = format_context_->streams[stream_index]->codec;
+#endif
+    // TODO (yongtang): avcodec_open2 is not thread-safe
+    AVDictionary *opts = NULL;
+    if (avcodec_open2(codec_context_, codec, &opts) < 0) {
+      return errors::Internal("could not open codec");
+    }
+
+    nb_frames_ = format_context_->streams[stream_index]->nb_frames;
+
+    return Status::OK();
+  }
 
   static int ReadPacket(void *opaque, uint8_t *buf, int buf_size) {
-    FFmpegReadStream *r = (FFmpegReadStream *)opaque;
+    FFmpegStream *r = (FFmpegStream *)opaque;
     StringPiece result;
     Status status = r->file_->Read(r->offset_, buf_size, &result, (char *)buf);
     if (!(status.ok() || errors::IsOutOfRange(status))) {
@@ -129,7 +153,7 @@ class FFmpegReadStream {
   }
 
   static int64_t Seek(void *opaque, int64_t offset, int whence) {
-    FFmpegReadStream *r = (FFmpegReadStream *)opaque;
+    FFmpegStream *r = (FFmpegStream *)opaque;
     switch (whence)
     {
     case SEEK_SET:
@@ -166,81 +190,121 @@ class FFmpegReadStream {
   std::unique_ptr<AVFormatContext, void(*)(AVFormatContext*)> format_context_;
   std::unique_ptr<AVIOContext, void(*)(AVIOContext*)> io_context_;
   int64 stream_index_;
+  string codec_;
+  AVCodecContext* codec_context_;
+  std::unique_ptr<AVCodecContext, void(*)(AVCodecContext*)> codec_context_scope_;
+  int64 nb_frames_;
+  AVPacket packet_;
+  std::unique_ptr<AVPacket, void(*)(AVPacket*)> packet_scope_;
+  std::deque<std::unique_ptr<AVFrame, void(*)(AVFrame*)>> frames_;
 };
-class FFmpegReadStreamMeta : public FFmpegReadStream {
+
+class FFmpegAudioStream : public FFmpegStream {
  public:
-  FFmpegReadStreamMeta(const string& filename, SizedRandomAccessFile* file, uint64 file_size, int64 media_type)
-  : FFmpegReadStream(filename, file, file_size)
-  , media_type_(media_type)
-  , record_index_(0)
-  , nb_frames_(-1)
+  FFmpegAudioStream(const string&filename, SizedRandomAccessFile* file, uint64 file_size)
+  : FFmpegStream(filename, file, file_size)
   , dtype_(DT_INVALID)
-  , packet_scope_(nullptr, [](AVPacket* p) { if (p != nullptr) { av_packet_unref(p); }})
-  , codec_context_scope_(nullptr, [](AVCodecContext* p) { if (p != nullptr) { avcodec_free_context(&p); }})
-  , initialized_(false) {}
+  , channels_(-1)
+  , rate_(-1) {}
+  virtual ~FFmpegAudioStream() {}
 
-  virtual ~FFmpegReadStreamMeta() {}
+  Status OpenAudio(int64 index) {
+    TF_RETURN_IF_ERROR(Open(AVMEDIA_TYPE_AUDIO, index));
+    TF_RETURN_IF_ERROR(OpenCodec());
 
-  virtual Status Open(int64 stream_index) override {
-    record_index_ = 0;
-    initialized_ = false;
-    TF_RETURN_IF_ERROR(FFmpegReadStream::Open(stream_index));
-    if (StreamType(stream_index) != media_type_) {
-      return errors::Internal("type mismatch: ", StreamType(stream_index), " vs. ", media_type_);
-    }
+    int64 stream_index = stream_index_;
 #if LIBAVCODEC_VERSION_MAJOR > 56
-    int codec_id = format_context_->streams[stream_index]->codecpar->codec_id;
+    int format = format_context_->streams[stream_index]->codecpar->format;
+    channels_ = format_context_->streams[stream_index]->codecpar->channels;
+    rate_ = format_context_->streams[stream_index]->codecpar->sample_rate;
 #else
-    int codec_id = format_context_->streams[stream_index]->codec->codec_id;
+    int format = format_context_->streams[stream_index]->codec->sample_fmt;
+    channels_ = format_context_->streams[stream_index]->codec->channels;
+    rate_ = format_context_->streams[stream_index]->codec->sample_rate;
 #endif
-    // Find decoder for the stream
-    AVCodec *codec = avcodec_find_decoder((enum AVCodecID)codec_id);
-    if (codec == NULL) {
-      return errors::InvalidArgument("unable to find codec id: ", codec_id);
-    }
-    codec_ = codec->name;
-#if LIBAVCODEC_VERSION_MAJOR > 56
-    codec_context_ = avcodec_alloc_context3(codec);
-    if (codec_context_ == nullptr) {
-      return errors::InvalidArgument("unable to allocate codec context");
-    }
-    codec_context_scope_.reset(codec_context_);
-    // Copy codec parameters from input stream to output codec context
-    if (avcodec_parameters_to_context(codec_context_, format_context_->streams[stream_index]->codecpar) < 0) {
-      return errors::Internal("could not copy codec parameters from input stream to output codec context");
-    }
-#else
-    codec_context_ = format_context_->streams[stream_index]->codec;
-#endif
-    // TODO (yongtang): avcodec_open2 is not thread-safe
-    AVDictionary *opts = NULL;
-    if (avcodec_open2(codec_context_, codec, &opts) < 0) {
-      return errors::Internal("could not open codec");
-    }
+    switch (format)
+    {
+    case AV_SAMPLE_FMT_U8:          ///< unsigned 8 bits
+      dtype_ = DT_UINT8;
+      break;
+    case AV_SAMPLE_FMT_S16:         ///< signed 16 bits
+      dtype_ = DT_INT16;
+      break;
+    case AV_SAMPLE_FMT_S32:         ///< signed 32 bits
+      dtype_ = DT_INT32;
+      break;
+    case AV_SAMPLE_FMT_FLT:         ///< float
+      dtype_ = DT_FLOAT;
+      break;
+    case AV_SAMPLE_FMT_DBL:         ///< double
+      dtype_ = DT_DOUBLE;
+      break;
 
-    nb_frames_ = format_context_->streams[stream_index]->nb_frames;
-
-    return Status::OK();
-  }
-  Status InitializeDecoder() {
-    // Initialize the decoders
-
-    samples_index_ = 0;
-    // Read first frame if possible
+    case AV_SAMPLE_FMT_U8P:         ///< unsigned 8 bits, planar
+    case AV_SAMPLE_FMT_S16P:        ///< signed 16 bits, planar
+    case AV_SAMPLE_FMT_S32P:        ///< signed 32 bits, planar
+    case AV_SAMPLE_FMT_FLTP:        ///< float, planar
+    case AV_SAMPLE_FMT_DBLP:        ///< double, planar
+    // case AV_SAMPLE_FMT_S64:         ///< signed 64 bits
+    // case AV_SAMPLE_FMT_S64P:        ///< signed 64 bits, planar
+    default:
+      return errors::InvalidArgument("invalid audio (", index, ") format: ", format);
+    }
+    int64 datasize = av_get_bytes_per_sample(codec_context_->sample_fmt);
+    if (datasize != DataTypeSize(dtype_)) {
+      return errors::InvalidArgument("failed to calculate data size");
+    }
+     // Initialize the decoders
+    // Read first packet if possible
     av_init_packet(&packet_);
     packet_.data = NULL;
     packet_.size = 0;
-    // TODO: reference after first?
+
+    int ret = av_read_frame(format_context_.get(), &packet_);
+
+    // reference after first
     packet_scope_.reset(&packet_);
+    while (packet_.stream_index != stream_index_) {
+      ret = av_read_frame(format_context_.get(), &packet_);
+      if (ret < 0) {
+        return errors::InvalidArgument("no frame available");
+      }
+    }
+    int got_frame;
+    while (packet_.size > 0) {
+      TF_RETURN_IF_ERROR(DecodeFrame(&got_frame));
+    }
 
     return Status::OK();
   }
-  int64 Type() { return media_type_; }
-  int64 RecordIndex() { return record_index_; }
-  int64 Frames() { return nb_frames_; }
-  string Codec() { return codec_; }
-  PartialTensorShape Shape() { return shape_; }
-  DataType DType() { return dtype_; }
+  Status Peek(int64* samples) {
+    *samples = 0;
+    TF_RETURN_IF_ERROR(DecodePacket());
+    for (size_t i = 0; i < frames_.size(); i++) {
+      (*samples) += frames_[i]->nb_samples;
+    }
+    return Status::OK();
+  }
+  Status Read(Tensor *value) {
+    int64 datasize = DataTypeSize(dtype_);
+
+    char *base;
+    switch (dtype_) {
+    case DT_INT16:
+      base = ((char *)(value->flat<int16>().data()));
+      break;
+    default:
+      return errors::InvalidArgument("data type not supported: ", DataTypeString(dtype_));
+    }
+    // Note: only one channel supported so far
+    for (size_t i = 0; i < frames_.size(); i++) {
+      memcpy(base, (char *)(frames_[i]->extended_data[0]), datasize * frames_[i]->nb_samples);
+      base += datasize * frames_[i]->nb_samples;
+    }
+    frames_.clear();
+    return Status::OK();
+  }
+
   Status DecodePacket() {
     if (packet_scope_.get() == nullptr) {
       return errors::OutOfRange("EOF reached");
@@ -265,241 +329,16 @@ class FFmpegReadStreamMeta : public FFmpegReadStream {
       TF_RETURN_IF_ERROR(DecodeFrame(&got_frame));
     } while (got_frame);
     packet_scope_.reset(nullptr);
-    
-    return Status::OK();
-  }
-  virtual Status DecodeFrame(int* got_frame) = 0;
-  virtual Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) = 0;
-  virtual Status Read(int64 record_to_read, int64* record_read, Tensor* value) {
-    if (!initialized_) {
-      TF_RETURN_IF_ERROR(InitializeDecoder());
-      TF_RETURN_IF_ERROR(DecodePacket());
-      initialized_ = true;
-    }
-    *record_read = 0;
-    Status status;
-    do {
-      TF_RETURN_IF_ERROR(ReadDecoded(record_to_read, record_read, value));
-      if ((*record_read) >= record_to_read) {
-        record_index_ += (*record_read);
-        return Status::OK();
-      }
-      status = DecodePacket();
-    } while (status.ok());
-    TF_RETURN_IF_ERROR(ReadDecoded(record_to_read, record_read, value));
-    record_index_ += (*record_read);
-    return Status::OK();
-  }
- protected:
-  int64 media_type_;
-  int64 record_index_;
-  int64 nb_frames_;
-  PartialTensorShape shape_;
-  DataType dtype_;
-  string codec_;
-  AVPacket packet_;
-  std::unique_ptr<AVPacket, void(*)(AVPacket*)> packet_scope_;
-  AVCodecContext* codec_context_;
-  std::unique_ptr<AVCodecContext, void(*)(AVCodecContext*)> codec_context_scope_;
-  std::deque<std::unique_ptr<AVFrame, void(*)(AVFrame*)>> frames_;
-  bool initialized_ = false;
-  int got_frame_;
-  int64 samples_index_;
-};
-class FFmpegVideoReadStreamMeta : public FFmpegReadStreamMeta {
- public:
-  FFmpegVideoReadStreamMeta(const string&filename, SizedRandomAccessFile* file, uint64 file_size)
-  : FFmpegReadStreamMeta(filename, file, file_size, AVMEDIA_TYPE_VIDEO)
-  , height_(-1)
-  , width_(-1)
-  , num_bytes_(-1)
-  , sws_context_(nullptr, [](SwsContext* p) { if (p != nullptr) { sws_freeContext(p); }}) {}
-  virtual ~FFmpegVideoReadStreamMeta() {}
-  virtual Status Open(int64 stream_index) override {
-    TF_RETURN_IF_ERROR(FFmpegReadStreamMeta::Open(stream_index));
-
-    height_ = codec_context_->height;
-    width_ = codec_context_->width;
-    num_bytes_ = av_image_get_buffer_size(AV_PIX_FMT_RGB24, codec_context_->width, codec_context_->height, 1);
-
-    SwsContext* sws_context = sws_getContext(codec_context_->width, codec_context_->height, codec_context_->pix_fmt, codec_context_->width, codec_context_->height, AV_PIX_FMT_RGB24, 0, NULL, NULL, NULL);
-    if (!sws_context) {
-      return errors::Internal("could not allocate sws context");
-    }
-    sws_context_.reset(sws_context);
-
-    shape_ = PartialTensorShape({-1, height_, width_, 3});
-    dtype_ = DT_UINT8;
-    return Status::OK();
-  }
-  Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) override {
-    while ((*record_read) < record_to_read) {
-      if (frames_.empty()) {
-        return Status::OK();
-      }
-      int64 offset = (*record_read) * height_ * width_ * 3;
-      memcpy(reinterpret_cast<char*>(&value->flat<uint8>().data()[offset]), reinterpret_cast<char*>(frames_buffer_.front().get()), num_bytes_ * sizeof(uint8_t));
-      frames_.pop_front();
-      frames_buffer_.pop_front();
-      (*record_read)++;
-    }
-    return Status::OK();
-  }
-  Status DecodeFrame(int *got_frame) override {
-    std::unique_ptr<AVFrame, void(*)(AVFrame*)> frame(av_frame_alloc(), [](AVFrame* p) { if (p != nullptr) { av_frame_free(&p); } });
-    int decoded = avcodec_decode_video2(codec_context_, frame.get(), got_frame, &packet_);
-    if (decoded < 0) {
-      return errors::InvalidArgument("error decoding video frame (", decoded, ")");
-    }
-    decoded = FFMIN(decoded, packet_.size);      
-    packet_.data += decoded;
-    packet_.size -= decoded;
-    if (*got_frame) {
-      std::unique_ptr<AVFrame, void(*)(AVFrame*)> frame_rgb(av_frame_alloc(), [](AVFrame* p) { if (p != nullptr) { av_frame_free(&p); } });
-      std::unique_ptr<uint8_t, void(*)(uint8_t*)> buffer_rgb((uint8_t*)av_malloc(num_bytes_ * sizeof(uint8_t)), [](uint8_t* p) { if (p != nullptr) { av_free(p); } });
-      avpicture_fill((AVPicture *)frame_rgb.get(), buffer_rgb.get(), AV_PIX_FMT_RGB24, codec_context_->width, codec_context_->height);
-      sws_scale(sws_context_.get(), frame->data, frame->linesize, 0, codec_context_->height, frame_rgb->data, frame_rgb->linesize);
-
-      frames_.push_back(std::move(frame_rgb));
-      frames_buffer_.push_back(std::move(buffer_rgb));
-    }
-    return Status::OK();
-  }
-  virtual Status Peek(int64* record_to_read) {
-    if (!initialized_) {
-      TF_RETURN_IF_ERROR(InitializeDecoder());
-      TF_RETURN_IF_ERROR(DecodePacket());
-      initialized_ = true;
-    }
-    Status status;
-    do {
-      status = DecodePacket();
-    } while (status.ok());
-    *record_to_read = frames_.size();
-    return Status::OK();
-  }
-  
-  int64 Height() { return height_; }
-  int64 Width() { return width_; }
-
- private:
-  int64 height_;
-  int64 width_;
-  int64 num_bytes_;
-  std::deque<std::unique_ptr<uint8_t, void(*)(uint8_t*)>> frames_buffer_;
-  std::unique_ptr<SwsContext, void(*)(SwsContext*)> sws_context_;
-};
-
-class FFmpegAudioReadStreamMeta : public FFmpegReadStreamMeta {
- public:
-  FFmpegAudioReadStreamMeta(const string&filename, SizedRandomAccessFile* file, uint64 file_size)
-  : FFmpegReadStreamMeta(filename, file, file_size, AVMEDIA_TYPE_AUDIO)
-  , channels_(-1)
-  , rate_(-1) {}
-  virtual ~FFmpegAudioReadStreamMeta() {}
-
-  virtual Status Open(int64 stream_index) override {
-    TF_RETURN_IF_ERROR(FFmpegReadStreamMeta::Open(stream_index));
-#if LIBAVCODEC_VERSION_MAJOR > 56
-    int format = format_context_->streams[stream_index]->codecpar->format;
-    channels_ = format_context_->streams[stream_index]->codecpar->channels;
-    rate_ = format_context_->streams[stream_index]->codecpar->sample_rate;
-#else
-    int format = format_context_->streams[stream_index]->codec->sample_fmt;
-    channels_ = format_context_->streams[stream_index]->codec->channels;
-    rate_ = format_context_->streams[stream_index]->codec->sample_rate;
-#endif
-    shape_ = PartialTensorShape({-1, channels_});
-    switch (format)
-    {
-    case AV_SAMPLE_FMT_U8:          ///< unsigned 8 bits
-      dtype_ = DT_UINT8;
-      break;
-    case AV_SAMPLE_FMT_S16:         ///< signed 16 bits
-      dtype_ = DT_INT16;
-      break;
-    case AV_SAMPLE_FMT_S32:         ///< signed 32 bits
-      dtype_ = DT_INT32;
-      break;
-    case AV_SAMPLE_FMT_FLT:         ///< float
-      dtype_ = DT_FLOAT;
-      break;
-    case AV_SAMPLE_FMT_DBL:         ///< double
-      dtype_ = DT_DOUBLE;
-      break;
-
-    case AV_SAMPLE_FMT_U8P:         ///< unsigned 8 bits, planar
-      dtype_ = DT_UINT8;
-      break;
-    case AV_SAMPLE_FMT_S16P:        ///< signed 16 bits, planar
-      dtype_ = DT_INT16;
-      break;
-    case AV_SAMPLE_FMT_S32P:        ///< signed 32 bits, planar
-      dtype_ = DT_INT32;
-      break;
-    case AV_SAMPLE_FMT_FLTP:        ///< float, planar
-      dtype_ = DT_FLOAT;
-      break;
-    case AV_SAMPLE_FMT_DBLP:        ///< double, planar
-      dtype_ = DT_DOUBLE;
-      break;
-    // case AV_SAMPLE_FMT_S64:         ///< signed 64 bits
-    // case AV_SAMPLE_FMT_S64P:        ///< signed 64 bits, planar
-    default:
-      return errors::InvalidArgument("invalid audio (", stream_index, ") format: ", format);
-    }
 
     return Status::OK();
   }
-  Status ReadDecodedRecord(int64 record_to_read, int64* record_read, Tensor* value) {
-    int64 datasize = av_get_bytes_per_sample(codec_context_->sample_fmt);
-    if (datasize != DataTypeSize(dtype_)) {
-      return errors::InvalidArgument("failed to calculate data size");
-    }
-    char *base;
-    switch (dtype_) {
-    case DT_INT16:
-      base = ((char *)(value->flat<int16>().data()));
-      break;
-    default:
-      return errors::InvalidArgument("data type not supported: ", DataTypeString(dtype_));
-    }
-    while (samples_index_ < frames_.front()->nb_samples) {
-      for (int64 channel = 0; channel < codec_context_->channels; channel++) {
-        char *data = base + datasize * ((*record_read) * codec_context_->channels + channel);
-        char *copy = ((char *)(frames_.front()->data[channel])) + datasize * samples_index_;
-        memcpy(data, copy, datasize);
-      }
-      (*record_read)++;
-      samples_index_++;
-      if ((*record_read) >= record_to_read) {
-        return Status::OK();
-      }
-    }
-    return Status::OK();
-  }
-  Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) override {
-    while ((*record_read) < record_to_read) {
-      if (frames_.empty()) {
-        return Status::OK();
-      }
-      if (samples_index_ < frames_.front()->nb_samples) {
-        TF_RETURN_IF_ERROR(ReadDecodedRecord(record_to_read, record_read, value));
-      }
-      if (!frames_.empty() && samples_index_ >= frames_.front()->nb_samples) {
-        frames_.pop_front();
-        samples_index_ = 0;
-      }
-    }
-    return Status::OK();
-  }
-  Status DecodeFrame(int* got_frame) override {
+  Status DecodeFrame(int* got_frame) {
     std::unique_ptr<AVFrame, void(*)(AVFrame*)> frame(av_frame_alloc(), [](AVFrame* p) { if (p != nullptr) { av_frame_free(&p); } });
     int decoded = avcodec_decode_audio4(codec_context_, frame.get(), got_frame, &packet_);
     if (decoded < 0) {
       return errors::InvalidArgument("error decoding audio frame (", decoded, ")");
     }
-    decoded = FFMIN(decoded, packet_.size);      
+    decoded = FFMIN(decoded, packet_.size);
     packet_.data += decoded;
     packet_.size -= decoded;
     if (*got_frame) {
@@ -507,247 +346,132 @@ class FFmpegAudioReadStreamMeta : public FFmpegReadStreamMeta {
     }
     return Status::OK();
   }
-  int64 Channels() { return channels_; }
-  int64 Rate() { return rate_; }
+  DataType dtype() { return dtype_; }
+  int64 channels() { return channels_; }
+  int64 rate() { return rate_; }
  private:
+  DataType dtype_;
   int64 channels_;
   int64 rate_;
 };
 
-class FFmpegSubtitleReadStreamMeta : public FFmpegReadStreamMeta {
+class FFmpegAudioReadableResource : public ResourceBase {
  public:
-  FFmpegSubtitleReadStreamMeta(const string&filename, SizedRandomAccessFile* file, uint64 file_size)
-  : FFmpegReadStreamMeta(filename, file, file_size, AVMEDIA_TYPE_SUBTITLE) {}
-  virtual ~FFmpegSubtitleReadStreamMeta() {}
-  virtual Status Open(int64 stream_index) override {
-    TF_RETURN_IF_ERROR(FFmpegReadStreamMeta::Open(stream_index));
-    shape_ = PartialTensorShape({-1});
-    dtype_ = DT_STRING;
-    return Status::OK();
-  }
- private:
-  Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) override {
-    while ((*record_read) < record_to_read) {
-      if (subtitles_.empty()) {
-        return Status::OK();
-      }
-      value->flat<string>()((*record_read)) = subtitles_.front();
-      subtitles_.pop_front();
-      (*record_read)++;
-    }
-    return Status::OK();
-  }
-  Status DecodeFrame(int* got_frame) override {
-    AVSubtitle subtitle;
-    int decoded = avcodec_decode_subtitle2(codec_context_, &subtitle, got_frame, &packet_);
-    if (decoded < 0) {
-      return errors::InvalidArgument("error decoding subtitle frame (", decoded, ")");
-    }
-    decoded = FFMIN(decoded, packet_.size);
-    packet_.data += decoded;
-    packet_.size -= decoded;
-    if (*got_frame) {
-      // We expect one rect
-      if (subtitle.num_rects != 1) {
-        return errors::InvalidArgument("number of rects has to be 1, received: ", subtitle.num_rects);
-      }
-      switch (subtitle.rects[0]->type)
-      {
-      case SUBTITLE_ASS:
-        if (!strncmp(subtitle.rects[0]->ass, "Dialogue: ", 10)) {
-          string buffer = string(subtitle.rects[0]->ass);
-          // find after 9th ","
-          size_t position = 0;
-          for (int64 i = 0; i < 9; i++) {
-            position = buffer.find(",", position);
-            if (position == string::npos) {
-              return errors::InvalidArgument("invalid libass format: ", buffer);
-            }
-            position++;
-          }
-          subtitles_.push_back(buffer.substr(position));
-        } else {
-          subtitles_.push_back(string(subtitle.rects[0]->ass));
-        }
-        break;
-      case SUBTITLE_TEXT:
-        subtitles_.push_back(string(subtitle.rects[0]->text));
-        break;
-      default:
-        return errors::InvalidArgument("unsupported subtitle type: ", subtitle.rects[0]->type);
-      }
-    }
-    return Status::OK();
-  }
-  std::deque<string> subtitles_;
-};
-class FFmpegReadable : public IOReadableInterface {
- public:
-  FFmpegReadable(Env* env)
-  : env_(env) {}
+  FFmpegAudioReadableResource(Env* env) : env_(env) {}
+  ~FFmpegAudioReadableResource() {}
 
-  ~FFmpegReadable() {}
-  Status Init(const std::vector<string>& input, const std::vector<string>& metadata, const void* memory_data, const int64 memory_size) override {
-    if (input.size() > 1) {
-      return errors::InvalidArgument("more than 1 filename is not supported");
-    }
-    const string& filename = input[0];
-    file_.reset(new SizedRandomAccessFile(env_, filename, memory_data, memory_size));
-    TF_RETURN_IF_ERROR(env_->GetFileSize(filename, &file_size_));
-    ffmpeg_file_.reset(new FFmpegReadStream(filename, file_.get(), file_size_));
+  Status Init(const string& input, const int64 index) {
+    filename_ = input;
+    audio_index_ = index;
+    file_.reset(new SizedRandomAccessFile(env_, filename_, nullptr, 0));
+    TF_RETURN_IF_ERROR(env_->GetFileSize(filename_, &file_size_));
+    FFmpegInit();
 
-    FFmpegReaderInit();
-    TF_RETURN_IF_ERROR(ffmpeg_file_->Open(-1));
+    ffmpeg_audio_stream_.reset(new FFmpegAudioStream(filename_, file_.get(), file_size_));
 
-    int64 audio_index = 0, video_index = 0, subtitle_index = 0;
-    for (int64 i = 0; i < ffmpeg_file_->Streams(); i++) {
-      switch(ffmpeg_file_->StreamType(i)) {
-      case AVMEDIA_TYPE_VIDEO:
-        columns_meta_.push_back(std::unique_ptr<FFmpegReadStreamMeta>(new FFmpegVideoReadStreamMeta(filename, file_.get(), file_size_)));
-        TF_RETURN_IF_ERROR(columns_meta_[i]->Open(i));
-        shapes_.push_back(columns_meta_[i]->Shape());
-        dtypes_.push_back(columns_meta_[i]->DType());
-        columns_.push_back(absl::StrCat("v:", video_index));
-        columns_index_[columns_.back()] = i;
-        video_index++;
-        break;    
-      case AVMEDIA_TYPE_AUDIO:
-        columns_meta_.push_back(std::unique_ptr<FFmpegReadStreamMeta>(new FFmpegAudioReadStreamMeta(filename, file_.get(), file_size_)));
-        TF_RETURN_IF_ERROR(columns_meta_[i]->Open(i));
-        shapes_.push_back(columns_meta_[i]->Shape());
-        dtypes_.push_back(columns_meta_[i]->DType());
-        columns_.push_back(absl::StrCat("a:", audio_index));
-        columns_index_[columns_.back()] = i;
-        audio_index++;
-        break;
-      case AVMEDIA_TYPE_SUBTITLE:
-        columns_meta_.push_back(std::unique_ptr<FFmpegReadStreamMeta>(new FFmpegSubtitleReadStreamMeta(filename, file_.get(), file_size_)));
-        TF_RETURN_IF_ERROR(columns_meta_[i]->Open(i));
-        shapes_.push_back(columns_meta_[i]->Shape());
-        dtypes_.push_back(columns_meta_[i]->DType());
-        columns_.push_back(absl::StrCat("s:", subtitle_index));
-        columns_index_[columns_.back()] = i;
-        subtitle_index++;
-        break;
-      default:
-        return errors::InvalidArgument("invalid steam (", i, ") type: ", ffmpeg_file_->StreamType(i));
-      }
-    }
+    TF_RETURN_IF_ERROR(ffmpeg_audio_stream_->OpenAudio(audio_index_));
+
+    sample_index_ = 0;
+
     return Status::OK();
   }
-  Status Components(std::vector<string>* components) override {
-    components->clear();
-    for (size_t i = 0; i < columns_.size(); i++) {
-      components->push_back(columns_[i]);
+  Status Seek(const int64 index) {
+    if (index != 0) {
+      return errors::InvalidArgument("seek only support 0");
     }
+    ffmpeg_audio_stream_.reset(new FFmpegAudioStream(filename_, file_.get(), file_size_));
+
+    TF_RETURN_IF_ERROR(ffmpeg_audio_stream_->OpenAudio(audio_index_));
+    sample_index_ = 0;
     return Status::OK();
   }
-  Status Spec(const string& component, PartialTensorShape* shape, DataType* dtype, bool label) override {
-    if (columns_index_.find(component) == columns_index_.end()) {
-      return errors::InvalidArgument("component ", component, " is invalid");
-    }
-    int64 column_index = columns_index_[component];
-    *shape = shapes_[column_index];
-    *dtype = dtypes_[column_index];
+  Status Peek(TensorShape* shape) {
+    int64 samples = 0;
+    Status status = ffmpeg_audio_stream_->Peek(&samples);
+    *shape = TensorShape({samples, ffmpeg_audio_stream_->channels()});
     return Status::OK();
   }
-
-  Status Extra(const string& component, std::vector<Tensor>* extra) override {
-    if (columns_index_.find(component) == columns_index_.end()) {
-      return errors::InvalidArgument("component ", component, " is invalid");
-    }
-    int64 column_index = columns_index_[component];
-    // Expose a sample `rate`
-    FFmpegAudioReadStreamMeta *meta = dynamic_cast<FFmpegAudioReadStreamMeta *>(columns_meta_[column_index].get());
-    Tensor rate(DT_INT64, TensorShape({}));
-    rate.scalar<int64>()() = (meta != nullptr) ? meta->Rate() : 0;
-    extra->push_back(rate);
-    return Status::OK();
+  Status Read(Tensor* value) {
+    return ffmpeg_audio_stream_->Read(value);
   }
-
-  Status Read(const int64 start, const int64 stop, const string& component, int64* record_read, Tensor* value, Tensor* label) override {
-    *record_read = 0;
-    if (columns_index_.find(component) == columns_index_.end()) {
-      return errors::InvalidArgument("component ", component, " is invalid");
-    }
-    int64 column_index = columns_index_[component];
-    if (start != columns_meta_[column_index]->RecordIndex()) {
-      // If we reach to the end, then just 0
-      if (start > columns_meta_[column_index]->RecordIndex()) {
-        return Status::OK();
-      }
-      if (start != 0) {
-        return errors::InvalidArgument("ffmepg dataset could not seek to a random location");
-      }
-      // Else we will recreate the meta.
-      TF_RETURN_IF_ERROR(columns_meta_[column_index]->Open(column_index));
-    }
-    return columns_meta_[column_index]->Read(stop - start, record_read, value);
-  }
-
   string DebugString() const override {
-    mutex_lock l(mu_);
-    return strings::StrCat("FFmpegReadable");
+    return "FFmpegAudioReadableResource";
   }
  private:
   mutable mutex mu_;
   Env* env_ GUARDED_BY(mu_);
+  string filename_ GUARDED_BY(mu_);
+  int64 audio_index_ GUARDED_BY(mu_);
   std::unique_ptr<SizedRandomAccessFile> file_ GUARDED_BY(mu_);
   uint64 file_size_ GUARDED_BY(mu_);
-  std::unique_ptr<FFmpegReadStream> ffmpeg_file_ GUARDED_BY(mu_);
-
-  std::vector<DataType> dtypes_;
-  std::vector<PartialTensorShape> shapes_;
-  std::vector<string> columns_;
-  std::unordered_map<string, int64> columns_index_;
-  std::vector<std::unique_ptr<FFmpegReadStreamMeta>> columns_meta_;
+  std::unique_ptr<FFmpegAudioStream> ffmpeg_audio_stream_ GUARDED_BY(mu_);
+  int64 sample_index_ GUARDED_BY(mu_);
 };
 
-REGISTER_KERNEL_BUILDER(Name("IO>FfmpegReadableInit").Device(DEVICE_CPU),
-                        IOInterfaceInitOp<FFmpegReadable>);
-REGISTER_KERNEL_BUILDER(Name("IO>FfmpegReadableSpec").Device(DEVICE_CPU),
-                        IOInterfaceSpecOp<FFmpegReadable>);
-REGISTER_KERNEL_BUILDER(Name("IO>FfmpegReadableRead").Device(DEVICE_CPU),
-                        IOReadableReadOp<FFmpegReadable>);
-
-class FFmpegDecodeVideoOp : public OpKernel {
+class FFmpegAudioReadableInitOp : public ResourceOpKernel<FFmpegAudioReadableResource> {
  public:
-  explicit FFmpegDecodeVideoOp(OpKernelConstruction* context) : OpKernel(context) {
+  explicit FFmpegAudioReadableInitOp(OpKernelConstruction* context)
+      : ResourceOpKernel<FFmpegAudioReadableResource>(context) {
     env_ = context->env();
   }
-
+ private:
   void Compute(OpKernelContext* context) override {
+    ResourceOpKernel<FFmpegAudioReadableResource>::Compute(context);
+
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
 
     const Tensor* index_tensor;
     OP_REQUIRES_OK(context, context->input("index", &index_tensor));
 
-    const string& input = input_tensor->scalar<string>()();
-    SizedRandomAccessFile file(env_, "memory", input.data(), input.size());
-
-    FFmpegReaderInit();
-
-    FFmpegVideoReadStreamMeta video_meta("memory", &file, input.size());
-    OP_REQUIRES_OK(context, video_meta.Open(index_tensor->scalar<int64>()()));
-    int64 record_to_read = 0;
-    OP_REQUIRES_OK(context, video_meta.Peek(&record_to_read));
-
-    Tensor* video_tensor = nullptr;
-    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({record_to_read, video_meta.Height(), video_meta.Width(), channels_}), &video_tensor));
-
-    int64 record_read = 0;
-    OP_REQUIRES_OK(context, video_meta.Read(record_to_read, &record_read, video_tensor));
-    OP_REQUIRES(context, (record_read == record_to_read), errors::InvalidArgument("unable to read expected frames ", record_to_read, " vs. ", record_read));
+    OP_REQUIRES_OK(context, resource_->Init(input_tensor->scalar<string>()(), index_tensor->scalar<int64>()()));
+  }
+  Status CreateResource(FFmpegAudioReadableResource** resource)
+      EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+    *resource = new FFmpegAudioReadableResource(env_);
+    return Status::OK();
   }
  private:
   mutable mutex mu_;
   Env* env_ GUARDED_BY(mu_);
-  static const int64 channels_ = 3;
 };
 
-REGISTER_KERNEL_BUILDER(Name("IO>FfmpegDecodeVideo").Device(DEVICE_CPU),
-                        FFmpegDecodeVideoOp);
 
+class FFmpegAudioReadableNextOp : public OpKernel {
+ public:
+  explicit FFmpegAudioReadableNextOp(OpKernelConstruction* context) : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    FFmpegAudioReadableResource* resource;
+    OP_REQUIRES_OK(context, GetResourceFromContext(context, "input", &resource));
+    core::ScopedUnref unref(resource);
+
+    const Tensor* reset_tensor;
+    OP_REQUIRES_OK(context, context->input("reset", &reset_tensor));
+    bool reset = reset_tensor->scalar<bool>()();
+    if (reset) {
+      OP_REQUIRES_OK(context, resource->Seek(0));
+    }
+
+    TensorShape value_shape;
+    OP_REQUIRES_OK(context, resource->Peek(&value_shape));
+    Tensor* value_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, value_shape, &value_tensor));
+    if (value_shape.dim_size(0) > 0) {
+      OP_REQUIRES_OK(context, resource->Read(value_tensor));
+    }
+  }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
+REGISTER_KERNEL_BUILDER(Name("IO>FfmpegAudioReadableInit").Device(DEVICE_CPU),
+                        FFmpegAudioReadableInitOp);
+REGISTER_KERNEL_BUILDER(Name("IO>FfmpegAudioReadableNext").Device(DEVICE_CPU),
+                        FFmpegAudioReadableNextOp);
+
+}  // namespace
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/core/kernels/ffmpeg_kernels_deprecated.cc
+++ b/tensorflow_io/core/kernels/ffmpeg_kernels_deprecated.cc
@@ -1,0 +1,753 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow_io/core/kernels/io_interface.h"
+#include "tensorflow_io/core/kernels/io_stream.h"
+#include  <deque>
+
+extern "C" {
+
+#include "libavcodec/avcodec.h"
+#include "libavformat/avformat.h"
+#include "libavutil/imgutils.h"
+#include "libswscale/swscale.h"
+#include <dlfcn.h>
+
+}
+
+namespace tensorflow {
+namespace data {
+
+static mutex mu(LINKER_INITIALIZED);
+static unsigned count(0);
+void FFmpegInit() {
+  mutex_lock lock(mu);
+  count++;
+  if (count == 1) {
+    // Set log level if needed
+    static const struct { const char *name; int level; } log_levels[] = {
+        { "quiet"  , AV_LOG_QUIET   },
+        { "panic"  , AV_LOG_PANIC   },
+        { "fatal"  , AV_LOG_FATAL   },
+        { "error"  , AV_LOG_ERROR   },
+        { "warning", AV_LOG_WARNING },
+        { "info"   , AV_LOG_INFO    },
+        { "verbose", AV_LOG_VERBOSE },
+        { "debug"  , AV_LOG_DEBUG   },
+        // { "trace"  , AV_LOG_TRACE   },
+    };
+    const char* log_level_name = getenv("FFMPEG_LOG_LEVEL");
+    if (log_level_name != nullptr) {
+      string log_level = log_level_name;
+      for (size_t i = 0; i < sizeof(log_levels)/sizeof(log_levels[0]); i++) {
+        if (log_level == log_levels[i].name) {
+          LOG(INFO) << "FFmpeg log level: " << log_level;
+          av_log_set_level(log_levels[i].level);
+          break;
+        }
+      }
+    }
+
+    // Register all formats and codecs
+    av_register_all();
+  }
+}
+
+class FFmpegReadStream {
+ public:
+  FFmpegReadStream(const string& filename, SizedRandomAccessFile* file, uint64 file_size)
+  : filename_(filename)
+  , file_(file)
+  , file_size_(file_size)
+  , offset_(0)
+  , format_context_(nullptr, [](AVFormatContext* p) { if (p != nullptr) { avformat_close_input(&p); av_free(p); } })
+  , io_context_(nullptr, [](AVIOContext* p) { if (p != nullptr) { av_free(p); } })
+  , stream_index_(-1) { }
+  ~FFmpegReadStream() {}
+
+  int64 Streams() {
+    return format_context_.get()->nb_streams;
+  }
+  int64 StreamType(int64 stream_index) {
+#if LIBAVCODEC_VERSION_MAJOR > 56
+    int media_type = format_context_->streams[stream_index]->codecpar->codec_type;
+#else
+    int media_type = format_context_->streams[stream_index]->codec->codec_type;
+#endif
+    return media_type;
+  }
+  virtual Status Open(int64 stream_index) {
+    offset_ = 0;
+    AVFormatContext *format_context; 
+    if ((format_context = avformat_alloc_context()) != NULL) {
+      AVIOContext *io_context;
+      if ((io_context = avio_alloc_context(NULL, 0, 0, this, FFmpegReadStream::ReadPacket, NULL, FFmpegReadStream::Seek)) != NULL) {
+        format_context->pb = io_context;
+        if (avformat_open_input(&format_context, filename_.c_str(), NULL, NULL) >= 0) {
+          if (avformat_find_stream_info(format_context, NULL) >= 0) {
+            // No plan to read any other stream frame
+            for (int64 i = 0; i < format_context->nb_streams; i++) {
+              if (stream_index != i) {
+                format_context->streams[i]->discard = AVDISCARD_ALL;
+              }
+            }
+            stream_index_ = stream_index;
+            io_context_.reset(io_context);
+            format_context_.reset(format_context);
+            return Status::OK();
+          }
+        }
+        av_free(io_context);
+      }
+      av_free(format_context);
+    }
+    return errors::InvalidArgument("unable to open file: ", filename_);
+   }
+
+  static int ReadPacket(void *opaque, uint8_t *buf, int buf_size) {
+    FFmpegReadStream *r = (FFmpegReadStream *)opaque;
+    StringPiece result;
+    Status status = r->file_->Read(r->offset_, buf_size, &result, (char *)buf);
+    if (!(status.ok() || errors::IsOutOfRange(status))) {
+      return -1;
+    }
+    r->offset_ += result.size();
+    return result.size();
+  }
+
+  static int64_t Seek(void *opaque, int64_t offset, int whence) {
+    FFmpegReadStream *r = (FFmpegReadStream *)opaque;
+    switch (whence)
+    {
+    case SEEK_SET:
+      if (offset > r->file_size_) {
+        return -1;
+      }
+      r->offset_ = offset;
+      return r->offset_;
+    case SEEK_CUR:
+      if (r->offset_ + offset > r->file_size_) {
+        return -1;
+      }
+      r->offset_ += offset;
+      return r->offset_;
+    case SEEK_END:
+      if (offset > r->file_size_) {
+        return -1;
+      }
+      r->offset_ = r->file_size_ - offset;
+      return r->offset_;
+    case AVSEEK_SIZE:
+      return r->file_size_;
+    default:
+      break;
+    }
+    return -1;
+  }
+
+ public:
+  string filename_;
+  SizedRandomAccessFile *file_ = nullptr;
+  uint64 file_size_ = 0;
+  uint64 offset_ = 0;
+  std::unique_ptr<AVFormatContext, void(*)(AVFormatContext*)> format_context_;
+  std::unique_ptr<AVIOContext, void(*)(AVIOContext*)> io_context_;
+  int64 stream_index_;
+};
+class FFmpegReadStreamMeta : public FFmpegReadStream {
+ public:
+  FFmpegReadStreamMeta(const string& filename, SizedRandomAccessFile* file, uint64 file_size, int64 media_type)
+  : FFmpegReadStream(filename, file, file_size)
+  , media_type_(media_type)
+  , record_index_(0)
+  , nb_frames_(-1)
+  , dtype_(DT_INVALID)
+  , packet_scope_(nullptr, [](AVPacket* p) { if (p != nullptr) { av_packet_unref(p); }})
+  , codec_context_scope_(nullptr, [](AVCodecContext* p) { if (p != nullptr) { avcodec_free_context(&p); }})
+  , initialized_(false) {}
+
+  virtual ~FFmpegReadStreamMeta() {}
+
+  virtual Status Open(int64 stream_index) override {
+    record_index_ = 0;
+    initialized_ = false;
+    TF_RETURN_IF_ERROR(FFmpegReadStream::Open(stream_index));
+    if (StreamType(stream_index) != media_type_) {
+      return errors::Internal("type mismatch: ", StreamType(stream_index), " vs. ", media_type_);
+    }
+#if LIBAVCODEC_VERSION_MAJOR > 56
+    int codec_id = format_context_->streams[stream_index]->codecpar->codec_id;
+#else
+    int codec_id = format_context_->streams[stream_index]->codec->codec_id;
+#endif
+    // Find decoder for the stream
+    AVCodec *codec = avcodec_find_decoder((enum AVCodecID)codec_id);
+    if (codec == NULL) {
+      return errors::InvalidArgument("unable to find codec id: ", codec_id);
+    }
+    codec_ = codec->name;
+#if LIBAVCODEC_VERSION_MAJOR > 56
+    codec_context_ = avcodec_alloc_context3(codec);
+    if (codec_context_ == nullptr) {
+      return errors::InvalidArgument("unable to allocate codec context");
+    }
+    codec_context_scope_.reset(codec_context_);
+    // Copy codec parameters from input stream to output codec context
+    if (avcodec_parameters_to_context(codec_context_, format_context_->streams[stream_index]->codecpar) < 0) {
+      return errors::Internal("could not copy codec parameters from input stream to output codec context");
+    }
+#else
+    codec_context_ = format_context_->streams[stream_index]->codec;
+#endif
+    // TODO (yongtang): avcodec_open2 is not thread-safe
+    AVDictionary *opts = NULL;
+    if (avcodec_open2(codec_context_, codec, &opts) < 0) {
+      return errors::Internal("could not open codec");
+    }
+
+    nb_frames_ = format_context_->streams[stream_index]->nb_frames;
+
+    return Status::OK();
+  }
+  Status InitializeDecoder() {
+    // Initialize the decoders
+
+    samples_index_ = 0;
+    // Read first frame if possible
+    av_init_packet(&packet_);
+    packet_.data = NULL;
+    packet_.size = 0;
+    // TODO: reference after first?
+    packet_scope_.reset(&packet_);
+
+    return Status::OK();
+  }
+  int64 Type() { return media_type_; }
+  int64 RecordIndex() { return record_index_; }
+  int64 Frames() { return nb_frames_; }
+  string Codec() { return codec_; }
+  PartialTensorShape Shape() { return shape_; }
+  DataType DType() { return dtype_; }
+  Status DecodePacket() {
+    if (packet_scope_.get() == nullptr) {
+      return errors::OutOfRange("EOF reached");
+    }
+    int ret;
+    do {
+      ret = av_read_frame(format_context_.get(), &packet_);
+      if (ret < 0) {
+        break;
+      }
+    } while (packet_.stream_index != stream_index_);
+    int got_frame;
+    // decode
+    if (ret >= 0) {
+      while (packet_.size > 0) {
+        TF_RETURN_IF_ERROR(DecodeFrame(&got_frame));
+      }
+      return Status::OK();
+    }
+    // final cache clean up
+    do {
+      TF_RETURN_IF_ERROR(DecodeFrame(&got_frame));
+    } while (got_frame);
+    packet_scope_.reset(nullptr);
+    
+    return Status::OK();
+  }
+  virtual Status DecodeFrame(int* got_frame) = 0;
+  virtual Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) = 0;
+  virtual Status Read(int64 record_to_read, int64* record_read, Tensor* value) {
+    if (!initialized_) {
+      TF_RETURN_IF_ERROR(InitializeDecoder());
+      TF_RETURN_IF_ERROR(DecodePacket());
+      initialized_ = true;
+    }
+    *record_read = 0;
+    Status status;
+    do {
+      TF_RETURN_IF_ERROR(ReadDecoded(record_to_read, record_read, value));
+      if ((*record_read) >= record_to_read) {
+        record_index_ += (*record_read);
+        return Status::OK();
+      }
+      status = DecodePacket();
+    } while (status.ok());
+    TF_RETURN_IF_ERROR(ReadDecoded(record_to_read, record_read, value));
+    record_index_ += (*record_read);
+    return Status::OK();
+  }
+ protected:
+  int64 media_type_;
+  int64 record_index_;
+  int64 nb_frames_;
+  PartialTensorShape shape_;
+  DataType dtype_;
+  string codec_;
+  AVPacket packet_;
+  std::unique_ptr<AVPacket, void(*)(AVPacket*)> packet_scope_;
+  AVCodecContext* codec_context_;
+  std::unique_ptr<AVCodecContext, void(*)(AVCodecContext*)> codec_context_scope_;
+  std::deque<std::unique_ptr<AVFrame, void(*)(AVFrame*)>> frames_;
+  bool initialized_ = false;
+  int got_frame_;
+  int64 samples_index_;
+};
+class FFmpegVideoReadStreamMeta : public FFmpegReadStreamMeta {
+ public:
+  FFmpegVideoReadStreamMeta(const string&filename, SizedRandomAccessFile* file, uint64 file_size)
+  : FFmpegReadStreamMeta(filename, file, file_size, AVMEDIA_TYPE_VIDEO)
+  , height_(-1)
+  , width_(-1)
+  , num_bytes_(-1)
+  , sws_context_(nullptr, [](SwsContext* p) { if (p != nullptr) { sws_freeContext(p); }}) {}
+  virtual ~FFmpegVideoReadStreamMeta() {}
+  virtual Status Open(int64 stream_index) override {
+    TF_RETURN_IF_ERROR(FFmpegReadStreamMeta::Open(stream_index));
+
+    height_ = codec_context_->height;
+    width_ = codec_context_->width;
+    num_bytes_ = av_image_get_buffer_size(AV_PIX_FMT_RGB24, codec_context_->width, codec_context_->height, 1);
+
+    SwsContext* sws_context = sws_getContext(codec_context_->width, codec_context_->height, codec_context_->pix_fmt, codec_context_->width, codec_context_->height, AV_PIX_FMT_RGB24, 0, NULL, NULL, NULL);
+    if (!sws_context) {
+      return errors::Internal("could not allocate sws context");
+    }
+    sws_context_.reset(sws_context);
+
+    shape_ = PartialTensorShape({-1, height_, width_, 3});
+    dtype_ = DT_UINT8;
+    return Status::OK();
+  }
+  Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) override {
+    while ((*record_read) < record_to_read) {
+      if (frames_.empty()) {
+        return Status::OK();
+      }
+      int64 offset = (*record_read) * height_ * width_ * 3;
+      memcpy(reinterpret_cast<char*>(&value->flat<uint8>().data()[offset]), reinterpret_cast<char*>(frames_buffer_.front().get()), num_bytes_ * sizeof(uint8_t));
+      frames_.pop_front();
+      frames_buffer_.pop_front();
+      (*record_read)++;
+    }
+    return Status::OK();
+  }
+  Status DecodeFrame(int *got_frame) override {
+    std::unique_ptr<AVFrame, void(*)(AVFrame*)> frame(av_frame_alloc(), [](AVFrame* p) { if (p != nullptr) { av_frame_free(&p); } });
+    int decoded = avcodec_decode_video2(codec_context_, frame.get(), got_frame, &packet_);
+    if (decoded < 0) {
+      return errors::InvalidArgument("error decoding video frame (", decoded, ")");
+    }
+    decoded = FFMIN(decoded, packet_.size);      
+    packet_.data += decoded;
+    packet_.size -= decoded;
+    if (*got_frame) {
+      std::unique_ptr<AVFrame, void(*)(AVFrame*)> frame_rgb(av_frame_alloc(), [](AVFrame* p) { if (p != nullptr) { av_frame_free(&p); } });
+      std::unique_ptr<uint8_t, void(*)(uint8_t*)> buffer_rgb((uint8_t*)av_malloc(num_bytes_ * sizeof(uint8_t)), [](uint8_t* p) { if (p != nullptr) { av_free(p); } });
+      avpicture_fill((AVPicture *)frame_rgb.get(), buffer_rgb.get(), AV_PIX_FMT_RGB24, codec_context_->width, codec_context_->height);
+      sws_scale(sws_context_.get(), frame->data, frame->linesize, 0, codec_context_->height, frame_rgb->data, frame_rgb->linesize);
+
+      frames_.push_back(std::move(frame_rgb));
+      frames_buffer_.push_back(std::move(buffer_rgb));
+    }
+    return Status::OK();
+  }
+  virtual Status Peek(int64* record_to_read) {
+    if (!initialized_) {
+      TF_RETURN_IF_ERROR(InitializeDecoder());
+      TF_RETURN_IF_ERROR(DecodePacket());
+      initialized_ = true;
+    }
+    Status status;
+    do {
+      status = DecodePacket();
+    } while (status.ok());
+    *record_to_read = frames_.size();
+    return Status::OK();
+  }
+  
+  int64 Height() { return height_; }
+  int64 Width() { return width_; }
+
+ private:
+  int64 height_;
+  int64 width_;
+  int64 num_bytes_;
+  std::deque<std::unique_ptr<uint8_t, void(*)(uint8_t*)>> frames_buffer_;
+  std::unique_ptr<SwsContext, void(*)(SwsContext*)> sws_context_;
+};
+
+class FFmpegAudioReadStreamMeta : public FFmpegReadStreamMeta {
+ public:
+  FFmpegAudioReadStreamMeta(const string&filename, SizedRandomAccessFile* file, uint64 file_size)
+  : FFmpegReadStreamMeta(filename, file, file_size, AVMEDIA_TYPE_AUDIO)
+  , channels_(-1)
+  , rate_(-1) {}
+  virtual ~FFmpegAudioReadStreamMeta() {}
+
+  virtual Status Open(int64 stream_index) override {
+    TF_RETURN_IF_ERROR(FFmpegReadStreamMeta::Open(stream_index));
+#if LIBAVCODEC_VERSION_MAJOR > 56
+    int format = format_context_->streams[stream_index]->codecpar->format;
+    channels_ = format_context_->streams[stream_index]->codecpar->channels;
+    rate_ = format_context_->streams[stream_index]->codecpar->sample_rate;
+#else
+    int format = format_context_->streams[stream_index]->codec->sample_fmt;
+    channels_ = format_context_->streams[stream_index]->codec->channels;
+    rate_ = format_context_->streams[stream_index]->codec->sample_rate;
+#endif
+    shape_ = PartialTensorShape({-1, channels_});
+    switch (format)
+    {
+    case AV_SAMPLE_FMT_U8:          ///< unsigned 8 bits
+      dtype_ = DT_UINT8;
+      break;
+    case AV_SAMPLE_FMT_S16:         ///< signed 16 bits
+      dtype_ = DT_INT16;
+      break;
+    case AV_SAMPLE_FMT_S32:         ///< signed 32 bits
+      dtype_ = DT_INT32;
+      break;
+    case AV_SAMPLE_FMT_FLT:         ///< float
+      dtype_ = DT_FLOAT;
+      break;
+    case AV_SAMPLE_FMT_DBL:         ///< double
+      dtype_ = DT_DOUBLE;
+      break;
+
+    case AV_SAMPLE_FMT_U8P:         ///< unsigned 8 bits, planar
+      dtype_ = DT_UINT8;
+      break;
+    case AV_SAMPLE_FMT_S16P:        ///< signed 16 bits, planar
+      dtype_ = DT_INT16;
+      break;
+    case AV_SAMPLE_FMT_S32P:        ///< signed 32 bits, planar
+      dtype_ = DT_INT32;
+      break;
+    case AV_SAMPLE_FMT_FLTP:        ///< float, planar
+      dtype_ = DT_FLOAT;
+      break;
+    case AV_SAMPLE_FMT_DBLP:        ///< double, planar
+      dtype_ = DT_DOUBLE;
+      break;
+    // case AV_SAMPLE_FMT_S64:         ///< signed 64 bits
+    // case AV_SAMPLE_FMT_S64P:        ///< signed 64 bits, planar
+    default:
+      return errors::InvalidArgument("invalid audio (", stream_index, ") format: ", format);
+    }
+
+    return Status::OK();
+  }
+  Status ReadDecodedRecord(int64 record_to_read, int64* record_read, Tensor* value) {
+    int64 datasize = av_get_bytes_per_sample(codec_context_->sample_fmt);
+    if (datasize != DataTypeSize(dtype_)) {
+      return errors::InvalidArgument("failed to calculate data size");
+    }
+    char *base;
+    switch (dtype_) {
+    case DT_INT16:
+      base = ((char *)(value->flat<int16>().data()));
+      break;
+    default:
+      return errors::InvalidArgument("data type not supported: ", DataTypeString(dtype_));
+    }
+    while (samples_index_ < frames_.front()->nb_samples) {
+      for (int64 channel = 0; channel < codec_context_->channels; channel++) {
+        char *data = base + datasize * ((*record_read) * codec_context_->channels + channel);
+        char *copy = ((char *)(frames_.front()->data[channel])) + datasize * samples_index_;
+        memcpy(data, copy, datasize);
+      }
+      (*record_read)++;
+      samples_index_++;
+      if ((*record_read) >= record_to_read) {
+        return Status::OK();
+      }
+    }
+    return Status::OK();
+  }
+  Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) override {
+    while ((*record_read) < record_to_read) {
+      if (frames_.empty()) {
+        return Status::OK();
+      }
+      if (samples_index_ < frames_.front()->nb_samples) {
+        TF_RETURN_IF_ERROR(ReadDecodedRecord(record_to_read, record_read, value));
+      }
+      if (!frames_.empty() && samples_index_ >= frames_.front()->nb_samples) {
+        frames_.pop_front();
+        samples_index_ = 0;
+      }
+    }
+    return Status::OK();
+  }
+  Status DecodeFrame(int* got_frame) override {
+    std::unique_ptr<AVFrame, void(*)(AVFrame*)> frame(av_frame_alloc(), [](AVFrame* p) { if (p != nullptr) { av_frame_free(&p); } });
+    int decoded = avcodec_decode_audio4(codec_context_, frame.get(), got_frame, &packet_);
+    if (decoded < 0) {
+      return errors::InvalidArgument("error decoding audio frame (", decoded, ")");
+    }
+    decoded = FFMIN(decoded, packet_.size);      
+    packet_.data += decoded;
+    packet_.size -= decoded;
+    if (*got_frame) {
+      frames_.push_back(std::move(frame));
+    }
+    return Status::OK();
+  }
+  int64 Channels() { return channels_; }
+  int64 Rate() { return rate_; }
+ private:
+  int64 channels_;
+  int64 rate_;
+};
+
+class FFmpegSubtitleReadStreamMeta : public FFmpegReadStreamMeta {
+ public:
+  FFmpegSubtitleReadStreamMeta(const string&filename, SizedRandomAccessFile* file, uint64 file_size)
+  : FFmpegReadStreamMeta(filename, file, file_size, AVMEDIA_TYPE_SUBTITLE) {}
+  virtual ~FFmpegSubtitleReadStreamMeta() {}
+  virtual Status Open(int64 stream_index) override {
+    TF_RETURN_IF_ERROR(FFmpegReadStreamMeta::Open(stream_index));
+    shape_ = PartialTensorShape({-1});
+    dtype_ = DT_STRING;
+    return Status::OK();
+  }
+ private:
+  Status ReadDecoded(int64 record_to_read, int64* record_read, Tensor* value) override {
+    while ((*record_read) < record_to_read) {
+      if (subtitles_.empty()) {
+        return Status::OK();
+      }
+      value->flat<string>()((*record_read)) = subtitles_.front();
+      subtitles_.pop_front();
+      (*record_read)++;
+    }
+    return Status::OK();
+  }
+  Status DecodeFrame(int* got_frame) override {
+    AVSubtitle subtitle;
+    int decoded = avcodec_decode_subtitle2(codec_context_, &subtitle, got_frame, &packet_);
+    if (decoded < 0) {
+      return errors::InvalidArgument("error decoding subtitle frame (", decoded, ")");
+    }
+    decoded = FFMIN(decoded, packet_.size);
+    packet_.data += decoded;
+    packet_.size -= decoded;
+    if (*got_frame) {
+      // We expect one rect
+      if (subtitle.num_rects != 1) {
+        return errors::InvalidArgument("number of rects has to be 1, received: ", subtitle.num_rects);
+      }
+      switch (subtitle.rects[0]->type)
+      {
+      case SUBTITLE_ASS:
+        if (!strncmp(subtitle.rects[0]->ass, "Dialogue: ", 10)) {
+          string buffer = string(subtitle.rects[0]->ass);
+          // find after 9th ","
+          size_t position = 0;
+          for (int64 i = 0; i < 9; i++) {
+            position = buffer.find(",", position);
+            if (position == string::npos) {
+              return errors::InvalidArgument("invalid libass format: ", buffer);
+            }
+            position++;
+          }
+          subtitles_.push_back(buffer.substr(position));
+        } else {
+          subtitles_.push_back(string(subtitle.rects[0]->ass));
+        }
+        break;
+      case SUBTITLE_TEXT:
+        subtitles_.push_back(string(subtitle.rects[0]->text));
+        break;
+      default:
+        return errors::InvalidArgument("unsupported subtitle type: ", subtitle.rects[0]->type);
+      }
+    }
+    return Status::OK();
+  }
+  std::deque<string> subtitles_;
+};
+class FFmpegReadable : public IOReadableInterface {
+ public:
+  FFmpegReadable(Env* env)
+  : env_(env) {}
+
+  ~FFmpegReadable() {}
+  Status Init(const std::vector<string>& input, const std::vector<string>& metadata, const void* memory_data, const int64 memory_size) override {
+    if (input.size() > 1) {
+      return errors::InvalidArgument("more than 1 filename is not supported");
+    }
+    const string& filename = input[0];
+    file_.reset(new SizedRandomAccessFile(env_, filename, memory_data, memory_size));
+    TF_RETURN_IF_ERROR(env_->GetFileSize(filename, &file_size_));
+    ffmpeg_file_.reset(new FFmpegReadStream(filename, file_.get(), file_size_));
+
+    FFmpegInit();
+    TF_RETURN_IF_ERROR(ffmpeg_file_->Open(-1));
+
+    int64 audio_index = 0, video_index = 0, subtitle_index = 0;
+    for (int64 i = 0; i < ffmpeg_file_->Streams(); i++) {
+      switch(ffmpeg_file_->StreamType(i)) {
+      case AVMEDIA_TYPE_VIDEO:
+        columns_meta_.push_back(std::unique_ptr<FFmpegReadStreamMeta>(new FFmpegVideoReadStreamMeta(filename, file_.get(), file_size_)));
+        TF_RETURN_IF_ERROR(columns_meta_[i]->Open(i));
+        shapes_.push_back(columns_meta_[i]->Shape());
+        dtypes_.push_back(columns_meta_[i]->DType());
+        columns_.push_back(absl::StrCat("v:", video_index));
+        columns_index_[columns_.back()] = i;
+        video_index++;
+        break;    
+      case AVMEDIA_TYPE_AUDIO:
+        columns_meta_.push_back(std::unique_ptr<FFmpegReadStreamMeta>(new FFmpegAudioReadStreamMeta(filename, file_.get(), file_size_)));
+        TF_RETURN_IF_ERROR(columns_meta_[i]->Open(i));
+        shapes_.push_back(columns_meta_[i]->Shape());
+        dtypes_.push_back(columns_meta_[i]->DType());
+        columns_.push_back(absl::StrCat("a:", audio_index));
+        columns_index_[columns_.back()] = i;
+        audio_index++;
+        break;
+      case AVMEDIA_TYPE_SUBTITLE:
+        columns_meta_.push_back(std::unique_ptr<FFmpegReadStreamMeta>(new FFmpegSubtitleReadStreamMeta(filename, file_.get(), file_size_)));
+        TF_RETURN_IF_ERROR(columns_meta_[i]->Open(i));
+        shapes_.push_back(columns_meta_[i]->Shape());
+        dtypes_.push_back(columns_meta_[i]->DType());
+        columns_.push_back(absl::StrCat("s:", subtitle_index));
+        columns_index_[columns_.back()] = i;
+        subtitle_index++;
+        break;
+      default:
+        return errors::InvalidArgument("invalid steam (", i, ") type: ", ffmpeg_file_->StreamType(i));
+      }
+    }
+    return Status::OK();
+  }
+  Status Components(std::vector<string>* components) override {
+    components->clear();
+    for (size_t i = 0; i < columns_.size(); i++) {
+      components->push_back(columns_[i]);
+    }
+    return Status::OK();
+  }
+  Status Spec(const string& component, PartialTensorShape* shape, DataType* dtype, bool label) override {
+    if (columns_index_.find(component) == columns_index_.end()) {
+      return errors::InvalidArgument("component ", component, " is invalid");
+    }
+    int64 column_index = columns_index_[component];
+    *shape = shapes_[column_index];
+    *dtype = dtypes_[column_index];
+    return Status::OK();
+  }
+
+  Status Extra(const string& component, std::vector<Tensor>* extra) override {
+    if (columns_index_.find(component) == columns_index_.end()) {
+      return errors::InvalidArgument("component ", component, " is invalid");
+    }
+    int64 column_index = columns_index_[component];
+    // Expose a sample `rate`
+    FFmpegAudioReadStreamMeta *meta = dynamic_cast<FFmpegAudioReadStreamMeta *>(columns_meta_[column_index].get());
+    Tensor rate(DT_INT64, TensorShape({}));
+    rate.scalar<int64>()() = (meta != nullptr) ? meta->Rate() : 0;
+    extra->push_back(rate);
+    return Status::OK();
+  }
+
+  Status Read(const int64 start, const int64 stop, const string& component, int64* record_read, Tensor* value, Tensor* label) override {
+    *record_read = 0;
+    if (columns_index_.find(component) == columns_index_.end()) {
+      return errors::InvalidArgument("component ", component, " is invalid");
+    }
+    int64 column_index = columns_index_[component];
+    if (start != columns_meta_[column_index]->RecordIndex()) {
+      // If we reach to the end, then just 0
+      if (start > columns_meta_[column_index]->RecordIndex()) {
+        return Status::OK();
+      }
+      if (start != 0) {
+        return errors::InvalidArgument("ffmepg dataset could not seek to a random location");
+      }
+      // Else we will recreate the meta.
+      TF_RETURN_IF_ERROR(columns_meta_[column_index]->Open(column_index));
+    }
+    return columns_meta_[column_index]->Read(stop - start, record_read, value);
+  }
+
+  string DebugString() const override {
+    mutex_lock l(mu_);
+    return strings::StrCat("FFmpegReadable");
+  }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+  std::unique_ptr<SizedRandomAccessFile> file_ GUARDED_BY(mu_);
+  uint64 file_size_ GUARDED_BY(mu_);
+  std::unique_ptr<FFmpegReadStream> ffmpeg_file_ GUARDED_BY(mu_);
+
+  std::vector<DataType> dtypes_;
+  std::vector<PartialTensorShape> shapes_;
+  std::vector<string> columns_;
+  std::unordered_map<string, int64> columns_index_;
+  std::vector<std::unique_ptr<FFmpegReadStreamMeta>> columns_meta_;
+};
+
+REGISTER_KERNEL_BUILDER(Name("IO>FfmpegReadableInit").Device(DEVICE_CPU),
+                        IOInterfaceInitOp<FFmpegReadable>);
+REGISTER_KERNEL_BUILDER(Name("IO>FfmpegReadableSpec").Device(DEVICE_CPU),
+                        IOInterfaceSpecOp<FFmpegReadable>);
+REGISTER_KERNEL_BUILDER(Name("IO>FfmpegReadableRead").Device(DEVICE_CPU),
+                        IOReadableReadOp<FFmpegReadable>);
+
+class FFmpegDecodeVideoOp : public OpKernel {
+ public:
+  explicit FFmpegDecodeVideoOp(OpKernelConstruction* context) : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    const Tensor* index_tensor;
+    OP_REQUIRES_OK(context, context->input("index", &index_tensor));
+
+    const string& input = input_tensor->scalar<string>()();
+    SizedRandomAccessFile file(env_, "memory", input.data(), input.size());
+
+    FFmpegInit();
+
+    FFmpegVideoReadStreamMeta video_meta("memory", &file, input.size());
+    OP_REQUIRES_OK(context, video_meta.Open(index_tensor->scalar<int64>()()));
+    int64 record_to_read = 0;
+    OP_REQUIRES_OK(context, video_meta.Peek(&record_to_read));
+
+    Tensor* video_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({record_to_read, video_meta.Height(), video_meta.Width(), channels_}), &video_tensor));
+
+    int64 record_read = 0;
+    OP_REQUIRES_OK(context, video_meta.Read(record_to_read, &record_read, video_tensor));
+    OP_REQUIRES(context, (record_read == record_to_read), errors::InvalidArgument("unable to read expected frames ", record_to_read, " vs. ", record_read));
+  }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+  static const int64 channels_ = 3;
+};
+
+REGISTER_KERNEL_BUILDER(Name("IO>FfmpegDecodeVideo").Device(DEVICE_CPU),
+                        FFmpegDecodeVideoOp);
+
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow_io/core/ops/ffmpeg_ops.cc
+++ b/tensorflow_io/core/ops/ffmpeg_ops.cc
@@ -91,4 +91,26 @@ REGISTER_OP("IO>FfmpegAudioReadableNext")
     return Status::OK();
    });
 
+
+REGISTER_OP("IO>FfmpegVideoReadableInit")
+  .Input("input: string")
+  .Input("index: int64")
+  .Output("resource: resource")
+  .Attr("container: string = ''")
+  .Attr("shared_name: string = ''")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->Scalar());
+    return Status::OK();
+   });
+
+REGISTER_OP("IO>FfmpegVideoReadableNext")
+  .Input("input: resource")
+  .Input("reset: bool")
+  .Output("value: dtype")
+  .Attr("dtype: type")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim(), c->UnknownDim(), c->UnknownDim()}));
+    return Status::OK();
+   });
+
 }  // namespace tensorflow

--- a/tensorflow_io/core/ops/ffmpeg_ops.cc
+++ b/tensorflow_io/core/ops/ffmpeg_ops.cc
@@ -70,4 +70,25 @@ REGISTER_OP("IO>FfmpegDecodeVideo")
     return Status::OK();
   });
 
+REGISTER_OP("IO>FfmpegAudioReadableInit")
+  .Input("input: string")
+  .Input("index: int64")
+  .Output("resource: resource")
+  .Attr("container: string = ''")
+  .Attr("shared_name: string = ''")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->Scalar());
+    return Status::OK();
+   });
+
+REGISTER_OP("IO>FfmpegAudioReadableNext")
+  .Input("input: resource")
+  .Input("reset: bool")
+  .Output("value: dtype")
+  .Attr("dtype: type")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
+    return Status::OK();
+   });
+
 }  // namespace tensorflow

--- a/tensorflow_io/core/python/ops/ffmpeg_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_dataset_ops.py
@@ -18,9 +18,46 @@ from __future__ import division
 from __future__ import print_function
 
 import uuid
+import sys
 
 import tensorflow as tf
 from tensorflow_io.core.python.ops import io_dataset_ops
+
+class FFmpegAudioGraphIODataset(tf.data.Dataset):
+  """FFmpegAudioGraphIODataset"""
+
+  def __init__(self,
+               resource, dtype,
+               internal=True):
+    """FFmpegAudioGraphIODataset."""
+    with tf.name_scope("FFmpegAudioGraphIODataset"):
+      from tensorflow_io.core.python.ops import ffmpeg_ops
+      assert internal
+
+      capacity = 1024 #kwargs.get("capacity", 4096)
+
+      self._resource = resource
+      dataset = tf.data.Dataset.range(0, sys.maxsize)
+      dataset = dataset.map(lambda e: e == 0)
+      dataset = dataset.map(
+          lambda reset: ffmpeg_ops.io_ffmpeg_audio_readable_next(
+              resource, reset, dtype=dtype))
+      dataset = dataset.apply(
+          tf.data.experimental.take_while(
+              lambda v: tf.greater(tf.shape(v)[0], 0)))
+      dataset = dataset.unbatch()
+      self._dataset = dataset
+      super(FFmpegAudioGraphIODataset, self).__init__(
+          self._dataset._variant_tensor) # pylint: disable=protected-access
+
+  def _inputs(self):
+    return []
+
+  @property
+  def element_spec(self):
+    return self._dataset.element_spec
+
+
 
 class _FFmpegIODatasetFunction(object):
   def __init__(self, function, resource, component, shape, dtype):

--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -64,3 +64,5 @@ io_ffmpeg_readable_init = _ffmpeg_ops.io_ffmpeg_readable_init
 io_ffmpeg_readable_spec = _ffmpeg_ops.io_ffmpeg_readable_spec
 io_ffmpeg_readable_read = _ffmpeg_ops.io_ffmpeg_readable_read
 io_ffmpeg_decode_video = _ffmpeg_ops.io_ffmpeg_decode_video
+io_ffmpeg_audio_readable_init = _ffmpeg_ops.io_ffmpeg_audio_readable_init
+io_ffmpeg_audio_readable_next = _ffmpeg_ops.io_ffmpeg_audio_readable_next

--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -66,3 +66,5 @@ io_ffmpeg_readable_read = _ffmpeg_ops.io_ffmpeg_readable_read
 io_ffmpeg_decode_video = _ffmpeg_ops.io_ffmpeg_decode_video
 io_ffmpeg_audio_readable_init = _ffmpeg_ops.io_ffmpeg_audio_readable_init
 io_ffmpeg_audio_readable_next = _ffmpeg_ops.io_ffmpeg_audio_readable_next
+io_ffmpeg_video_readable_init = _ffmpeg_ops.io_ffmpeg_video_readable_init
+io_ffmpeg_video_readable_next = _ffmpeg_ops.io_ffmpeg_video_readable_next

--- a/tensorflow_io/core/python/ops/io_dataset.py
+++ b/tensorflow_io/core/python/ops/io_dataset.py
@@ -447,6 +447,11 @@ class GraphIODataset(tf.data.Dataset):
             filename, int(stream[2:]))
         dtype = cls._dtype
         return ffmpeg_dataset_ops.FFmpegAudioGraphIODataset(
-          resource, dtype, internal=True)
-      else:
-        assert stream.startswith("a:")
+            resource, dtype, internal=True)
+      elif stream.startswith("v:"):
+        resource = ffmpeg_ops.io_ffmpeg_video_readable_init(
+            filename, int(stream[2:]))
+        dtype = cls._dtype
+        return ffmpeg_dataset_ops.FFmpegVideoGraphIODataset(
+            resource, dtype, internal=True)
+      return None

--- a/tensorflow_io/core/python/ops/io_dataset.py
+++ b/tensorflow_io/core/python/ops/io_dataset.py
@@ -424,3 +424,29 @@ class GraphIODataset(tf.data.Dataset):
       shape, _, _ = core_ops.io_wav_readable_spec(resource)
       return audio_dataset_ops.AudioGraphIODataset(
           resource, shape, dtype, internal=True)
+
+  @classmethod
+  def from_ffmpeg(cls,
+                  filename,
+                  stream,
+                  **kwargs):
+    """Creates an `GraphIODataset` from a media file by FFmpeg.
+
+    Args:
+      filename: A string, the filename of a media file.
+      name: A name prefix for the IOTensor (optional).
+
+    Returns:
+      A `IODataset`.
+
+    """
+    with tf.name_scope(kwargs.get("name", "IOFromFFmpeg")):
+      from tensorflow_io.core.python.ops import ffmpeg_ops
+      if stream.startswith("a:"):
+        resource = ffmpeg_ops.io_ffmpeg_audio_readable_init(
+            filename, int(stream[2:]))
+        dtype = cls._dtype
+        return ffmpeg_dataset_ops.FFmpegAudioGraphIODataset(
+          resource, dtype, internal=True)
+      else:
+        assert stream.startswith("a:")

--- a/tests/test_audio_eager.py
+++ b/tests/test_audio_eager.py
@@ -18,73 +18,208 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import sys
+import pytest
 import numpy as np
 
 import tensorflow as tf
 import tensorflow_io as tfio
 
-audio_path = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    "test_audio", "mono_10khz.wav")
+@pytest.fixture(name="audio_data", scope="module")
+def fixture_audio_data():
+  """fixture_audio_data"""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "mono_10khz.wav")
+  audio = tf.audio.decode_wav(tf.io.read_file(path))
+  value = audio.audio * (1 << 15)
+  value = tf.cast(value, tf.int16)
+  rate = audio.sample_rate
+  return path, value, rate
 
-def test_from_tensor():
-  """test_from_tensor"""
-  audio_data = tfio.IOTensor.from_audio(audio_path)
-  numpy_data = audio_data.to_tensor().numpy()
-  new_tensor = tfio.IOTensor.from_tensor(numpy_data)
-  # The behavior of from_audio and from_tesnor should match
-  for i, audio_value in enumerate(audio_data):
-    assert new_tensor[i].numpy() == audio_value.numpy()
-
-def test_audio_dataset():
-  """Test Audio Dataset"""
-  with open(audio_path, 'rb') as f:
-    wav_contents = f.read()
-  audio_v = tf.audio.decode_wav(wav_contents)
-
-  f = lambda x: float(x) / (1 << 15)
-
-  audio_dataset = tfio.IODataset.from_audio(audio_path)
-  i = 0
-  for v in audio_dataset:
-    assert audio_v.audio[i].numpy() == f(v.numpy())
-    i += 1
-  assert i == 5760
-
-  audio_dataset = tfio.IODataset.from_audio(audio_path).batch(2)
-  i = 0
-  for v in audio_dataset:
-    assert audio_v.audio[i].numpy() == f(v[0].numpy())
-    assert audio_v.audio[i + 1].numpy() == f(v[1].numpy())
-    i += 2
-  assert i == 5760
-
-  samples = tfio.IOTensor.from_audio(audio_path)
-  assert samples.dtype == tf.int16
-  assert samples.shape == [5760, 1]
-  assert samples.rate == audio_v.sample_rate.numpy()
-
-  audio_24bit_path = os.path.join(
+@pytest.fixture(name="audio_data_24", scope="module")
+def fixture_audio_data_24():
+  """fixture_audio_data_24"""
+  path = os.path.join(
       os.path.dirname(os.path.abspath(__file__)),
       "test_audio", "example_0.5s.wav")
   # raw was geenrated from:
   # $ sox example_0.5s.wav example_0.5s.s32
-  audio_24bit_raw_path = os.path.join(
+  raw_path = os.path.join(
       os.path.dirname(os.path.abspath(__file__)),
       "test_audio", "example_0.5s.s32")
-  expected = np.fromfile(audio_24bit_raw_path, np.int32)
-  expected = np.reshape(expected, [22050, 2])
+  value = np.fromfile(raw_path, np.int32)
+  value = np.reshape(value, [22050, 2])
+  value = tf.constant(value)
+  rate = tf.constant(44100)
+  return path, value, rate
 
-  samples = tfio.IOTensor.from_audio(audio_24bit_path)
-  assert samples.dtype == tf.int32
-  assert samples.shape == [22050, 2]
-  assert samples.rate == 44100
-  assert np.all(samples.to_tensor().numpy() == expected)
+@pytest.mark.parametrize(
+    ("io_tensor_func"),
+    [
+        (tfio.IOTensor.from_audio),
+        pytest.param(
+            lambda f: tfio.IOTensor.from_ffmpeg(f)("a:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+                pytest.mark.xfail(
+                    reason="does not support 24 bit yet"),
+            ],
+        ),
+    ],
+    ids=["from_audio", "from_ffmpeg"],
+)
+def test_audio_io_tensor_24(audio_data_24, io_tensor_func):
+  """test_audio_io_tensor_24"""
+  audio_path, audio_value, audio_rate = audio_data_24
 
-def test_dataset_with_io_tensor():
-  """test_from_tensor"""
-  audio_v = tf.audio.decode_wav(tf.io.read_file(audio_path))
-  f = lambda x: float(x) / (1 << 15)
+  audio_tensor = io_tensor_func(audio_path)
+  assert audio_tensor.rate == audio_rate
+  assert audio_tensor.shape == audio_value.shape
+  assert np.all(audio_tensor.to_tensor() == audio_value)
+  for step in [1, 100, 101, 200, 501, 600, 1001, 2000, 5001]:
+    indices = range(0, 22050, step)
+    # TODO: -1 vs. 22050 might need fix
+    for (start, stop) in zip(indices, indices[1:] + [22050]):
+      audio_tensor_value = audio_tensor[start:stop]
+      audio_value_value = audio_value[start:stop]
+      assert audio_tensor_value.shape == audio_value_value.shape
+      assert np.all(audio_tensor_value == audio_value_value)
+
+
+@pytest.mark.parametrize(
+    ("io_dataset_func"),
+    [
+        (tfio.IODataset.from_audio),
+        pytest.param(
+            lambda f: tfio.IODataset.from_ffmpeg(f, "a:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+                pytest.mark.xfail(
+                    reason="does not support 24 bit yet"),
+            ],
+        ),
+    ],
+    ids=["from_audio", "from_ffmpeg"],
+)
+def test_audio_io_dataset_24(audio_data_24, io_dataset_func):
+  """test_audio_io_dataset_24"""
+  audio_path, audio_value, _ = audio_data_24
+
+  audio_dataset = io_dataset_func(audio_path)
+
+  i = 0
+  for value in audio_dataset:
+    assert value.shape == [2]
+    assert np.all(audio_value[i] == value)
+    i += 1
+  assert i == 22050
+
+  audio_dataset = io_dataset_func(audio_path).batch(2)
+
+  i = 0
+  for value in audio_dataset:
+    assert value.shape == [2, 2]
+    assert np.all(audio_value[i] == value[0])
+    assert np.all(audio_value[i + 1] == value[1])
+    i += 2
+  assert i == 22050
+
+@pytest.mark.parametrize(
+    ("io_tensor_func"),
+    [
+        (tfio.IOTensor.from_audio),
+        pytest.param(
+            lambda f: tfio.IOTensor.from_ffmpeg(f)("a:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+                pytest.mark.xfail(
+                    reason="shape does not work correctly yet"),
+            ],
+        ),
+    ],
+    ids=["from_audio", "from_ffmpeg"],
+)
+def test_audio_io_tensor(audio_data, io_tensor_func):
+  """test_audio_io_tensor"""
+  audio_path, audio_value, audio_rate = audio_data
+
+  audio_tensor = io_tensor_func(audio_path)
+  assert audio_tensor.rate == audio_rate
+  assert audio_tensor.shape == audio_value.shape
+  assert np.all(audio_tensor.to_tensor() == audio_value)
+  for step in [1, 100, 101, 200, 501, 600, 1001, 2000, 5001]:
+    indices = range(0, 5760, step)
+    # TODO: -1 vs. 5760 might need fix
+    for (start, stop) in zip(indices, indices[1:] + [5760]):
+      audio_tensor_value = audio_tensor[start:stop]
+      audio_value_value = audio_value[start:stop]
+      assert audio_tensor_value.shape == audio_value_value.shape
+      assert np.all(audio_tensor_value == audio_value_value)
+
+
+@pytest.mark.parametrize(
+    ("io_dataset_func"),
+    [
+        (tfio.IODataset.from_audio),
+        pytest.param(
+            lambda f: tfio.IODataset.from_ffmpeg(f, "a:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+            ],
+        ),
+    ],
+    ids=["from_audio", "from_ffmpeg"],
+)
+def test_audio_io_dataset(audio_data, io_dataset_func):
+  """test_audio_io_dataset"""
+  audio_path, audio_value, _ = audio_data
+
+  audio_dataset = io_dataset_func(audio_path)
+
+  i = 0
+  for value in audio_dataset:
+    assert audio_value[i] == value
+    i += 1
+  assert i == 5760
+
+  audio_dataset = io_dataset_func(audio_path).batch(2)
+
+  i = 0
+  for value in audio_dataset:
+    assert audio_value[i] == value[0]
+    assert audio_value[i + 1] == value[1]
+    i += 2
+  assert i == 5760
+
+@pytest.mark.parametrize(
+    ("io_tensor_func"),
+    [
+        (tfio.IOTensor.graph(tf.int16).from_audio),
+        pytest.param(
+            tfio.IOTensor.from_ffmpeg,
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+                pytest.mark.xfail(
+                    reason="does not work in graph yet"),
+            ],
+        ),
+    ],
+    ids=["from_audio", "from_ffmpeg"],
+)
+def test_audio_io_tensor_with_dataset(audio_data, io_tensor_func):
+  """test_audio_io_dataset_with_dataset"""
+  audio_path, audio_value, audio_rate = audio_data
 
   filename_dataset = tf.data.Dataset.from_tensor_slices(
       [audio_path, audio_path])
@@ -99,24 +234,41 @@ def test_dataset_with_io_tensor():
   # Return: audio chunk from position:position+100, and the rate.
   @tf.function
   def func(filename, position):
-    audio = tfio.IOTensor.graph(tf.int16).from_audio(filename)
+    audio = io_tensor_func(filename)
     return audio[position:position+100], audio.rate
 
   dataset = dataset.map(func)
 
   item = 0
   for (data, rate) in dataset:
-    assert rate == audio_v.sample_rate
+    assert audio_rate == rate
     assert data.shape == (100, 1)
     position = 1000 if item == 0 else 2000
     for i in range(100):
-      assert audio_v.audio[position + i].numpy() == f(data[i].numpy())
+      assert audio_value[position + i] == data[i]
     item += 1
+  assert item == 2
 
-def test_dataset_with_io_dataset():
-  """test_dataset_with_io_dataset"""
-  audio_v = tf.audio.decode_wav(tf.io.read_file(audio_path))
-  f = lambda x: float(x) / (1 << 15)
+@pytest.mark.parametrize(
+    ("io_dataset_func"),
+    [
+        (tfio.IODataset.graph(tf.int16).from_audio),
+        pytest.param(
+            lambda f: tfio.IODataset.from_ffmpeg(f, "a:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+                pytest.mark.xfail(
+                    reason="does not work in graph yet"),
+            ],
+        ),
+    ],
+    ids=["from_audio", "from_ffmpeg"],
+)
+def test_audio_io_dataset_with_dataset(audio_data, io_dataset_func):
+  """test_audio_io_dataset_with_dataset"""
+  audio_path, audio_value, _ = audio_data
 
   filename_dataset = tf.data.Dataset.from_tensor_slices(
       [audio_path, audio_path])
@@ -131,7 +283,7 @@ def test_dataset_with_io_dataset():
   # Return: an embedded dataset (in an outer dataset) for position:position+100
   @tf.function
   def func(filename, position):
-    audio_dataset = tfio.IODataset.graph(tf.int16).from_audio(filename)
+    audio_dataset = io_dataset_func(filename)
     return audio_dataset.skip(position).take(100)
 
   dataset = dataset.map(func)
@@ -142,7 +294,8 @@ def test_dataset_with_io_dataset():
     position = 1000 if item == 0 else 2000
     i = 0
     for value in audio_dataset:
-      assert audio_v.audio[position + i].numpy() == f(value.numpy())
+      assert audio_value[position + i] == value
       i += 1
     assert i == 100
     item += 1
+  assert item == 2

--- a/tests/test_audio_eager.py
+++ b/tests/test_audio_eager.py
@@ -169,6 +169,14 @@ def test_audio_io_tensor(audio_data, io_tensor_func):
     [
         (tfio.IODataset.from_audio),
         pytest.param(
+            lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+            ],
+        ),
+        pytest.param(
             lambda f: tfio.IODataset.from_ffmpeg(f, "a:0"),
             marks=[
                 pytest.mark.skipif(
@@ -177,7 +185,7 @@ def test_audio_io_tensor(audio_data, io_tensor_func):
             ],
         ),
     ],
-    ids=["from_audio", "from_ffmpeg"],
+    ids=["from_audio", "from_ffmpeg", "from_ffmpeg(eager)"],
 )
 def test_audio_io_dataset(audio_data, io_dataset_func):
   """test_audio_io_dataset"""
@@ -254,13 +262,11 @@ def test_audio_io_tensor_with_dataset(audio_data, io_tensor_func):
     [
         (tfio.IODataset.graph(tf.int16).from_audio),
         pytest.param(
-            lambda f: tfio.IODataset.from_ffmpeg(f, "a:0"),
+            lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0"),
             marks=[
                 pytest.mark.skipif(
                     sys.platform == "darwin",
                     reason="macOS does not support FFmpeg"),
-                pytest.mark.xfail(
-                    reason="does not work in graph yet"),
             ],
         ),
     ],

--- a/tests/test_audio_eager.py
+++ b/tests/test_audio_eager.py
@@ -80,7 +80,7 @@ def test_audio_io_tensor_24(audio_data_24, io_tensor_func):
   assert audio_tensor.shape == audio_value.shape
   assert np.all(audio_tensor.to_tensor() == audio_value)
   for step in [1, 100, 101, 200, 501, 600, 1001, 2000, 5001]:
-    indices = range(0, 22050, step)
+    indices = list(range(0, 22050, step))
     # TODO: -1 vs. 22050 might need fix
     for (start, stop) in zip(indices, indices[1:] + [22050]):
       audio_tensor_value = audio_tensor[start:stop]
@@ -155,7 +155,7 @@ def test_audio_io_tensor(audio_data, io_tensor_func):
   assert audio_tensor.shape == audio_value.shape
   assert np.all(audio_tensor.to_tensor() == audio_value)
   for step in [1, 100, 101, 200, 501, 600, 1001, 2000, 5001]:
-    indices = range(0, 5760, step)
+    indices = list(range(0, 5760, step))
     # TODO: -1 vs. 5760 might need fix
     for (start, stop) in zip(indices, indices[1:] + [5760]):
       audio_tensor_value = audio_tensor[start:stop]

--- a/tests/test_ffmpeg_eager.py
+++ b/tests/test_ffmpeg_eager.py
@@ -46,29 +46,6 @@ audio_path = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     "test_audio", "mono_10khz.wav")
 
-def test_audio_dataset():
-  """Test Audio Dataset"""
-  with open(audio_path, 'rb') as f:
-    wav_contents = f.read()
-  audio_v = tf.audio.decode_wav(wav_contents)
-
-  f = lambda x: float(x) / (1 << 15)
-
-  audio_dataset = tfio.IODataset.from_ffmpeg(audio_path, "a:0")
-  i = 0
-  for v in audio_dataset:
-    assert audio_v.audio[i].numpy() == f(v.numpy())
-    i += 1
-  assert i == 5760
-
-  audio_dataset = tfio.IODataset.from_ffmpeg(audio_path, "a:0").batch(2)
-  i = 0
-  for v in audio_dataset:
-    assert audio_v.audio[i].numpy() == f(v[0].numpy())
-    assert audio_v.audio[i + 1].numpy() == f(v[1].numpy())
-    i += 2
-  assert i == 5760
-
 def test_ffmpeg_io_tensor_audio():
   """test_ffmpeg_io_tensor_audio"""
   audio = tfio.IOTensor.from_audio(audio_path)

--- a/tests/test_ffmpeg_eager.py
+++ b/tests/test_ffmpeg_eager.py
@@ -29,18 +29,6 @@ if sys.platform == "darwin":
 
 video_path = "file://" + os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "test_video", "small.mp4")
-def test_video_dataset():
-  """test_video_dataset"""
-  num_repeats = 2
-
-  video_dataset = tfio.IODataset.from_ffmpeg(
-      video_path, "v:0").repeat(num_repeats)
-
-  i = 0
-  for v in video_dataset:
-    assert v.shape == (320, 560, 3)
-    i += 1
-  assert i == 166 * num_repeats
 
 audio_path = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),

--- a/tests/test_video_eager.py
+++ b/tests/test_video_eager.py
@@ -1,0 +1,126 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""test ffmpeg dataset"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import sys
+import pytest
+
+import tensorflow as tf
+import tensorflow_io as tfio
+
+@pytest.fixture(name="video_data", scope="module")
+def fixture_video_data():
+  """fixture_video_data"""
+  path = "file://" + os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_video", "small.mp4")
+  # TODO: get raw value
+  value = tf.zeros((166, 320, 560, 3), tf.uint8)
+  return path, value
+
+@pytest.mark.parametrize(
+    ("io_dataset_func"),
+    [
+        pytest.param(
+            lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+            ],
+        ),
+        pytest.param(
+            lambda f: tfio.IODataset.from_ffmpeg(f, "v:0"),
+            marks=[
+                pytest.mark.skipif(
+                    True, #sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+            ],
+        ),
+    ],
+    ids=["from_ffmpeg", "from_ffmpeg(eager)"],
+)
+def test_video_io_dataset(video_data, io_dataset_func):
+  """test_video_io_dataset"""
+  video_path, video_value = video_data
+
+  video_dataset = io_dataset_func(video_path)
+
+  i = 0
+  for value in video_dataset:
+    assert video_value[i].shape == value.shape
+    i += 1
+  assert i == 166
+
+  video_dataset = io_dataset_func(video_path).batch(2)
+
+  i = 0
+  for value in video_dataset:
+    assert video_value[i:i+2].shape == value.shape
+    i += 2
+  assert i == 166
+
+
+@pytest.mark.parametrize(
+    ("io_dataset_func"),
+    [
+        pytest.param(
+            lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="macOS does not support FFmpeg"),
+            ],
+        ),
+    ],
+    ids=["from_ffmpeg"],
+)
+def test_video_io_dataset_with_dataset(video_data, io_dataset_func):
+  """test_video_io_dataset_with_dataset"""
+  video_path, video_value = video_data
+
+  filename_dataset = tf.data.Dataset.from_tensor_slices(
+      [video_path, video_path])
+  position_dataset = tf.data.Dataset.from_tensor_slices(
+      [tf.constant(50, tf.int64), tf.constant(100, tf.int64)])
+
+  dataset = tf.data.Dataset.zip((filename_dataset, position_dataset))
+
+  # Note: @tf.function is actually not needed, as tf.data.Dataset
+  # will automatically wrap the `func` into a graph anyway.
+  # The following is purely for explanation purposes.
+  # Return: an embedded dataset (in an outer dataset) for position:position+100
+  @tf.function
+  def func(filename, position):
+    video_dataset = io_dataset_func(filename)
+    return video_dataset.skip(position).take(10)
+
+  dataset = dataset.map(func)
+
+  item = 0
+  # Notice video_dataset in dataset:
+  for video_dataset in dataset:
+    position = 50 if item == 0 else 100
+    i = 0
+    for value in video_dataset:
+      assert video_value[position + i].shape == value.shape
+      i += 1
+    assert i == 10
+    item += 1
+  assert item == 2


### PR DESCRIPTION
This PR is part of the effort to resolve the issue in #616 where it was not possible to run video dataset (ffmpeg) inside another Dataset (graph mode).

This PR adds the following option:
```python
import tensorflow as tf
import tensorflow_io as tfio

filename_dataset = tf.data.Dataset.from_tensor_slices(
    [video_path, video_path])
position_dataset = tf.data.Dataset.from_tensor_slices(
    [tf.constant(50, tf.int64), tf.constant(100, tf.int64)])

dataset = tf.data.Dataset.zip((filename_dataset, position_dataset))

# Note: @tf.function is actually not needed, as tf.data.Dataset
# will automatically wrap the `func` into a graph anyway.
# The following is purely for explanation purposes.
# Return: an embedded dataset (in an outer dataset) for position:position+100
@tf.function
def func(filename, position):
  video_dataset = tfio.IODataset.graph(tf.uint8).from_ffmpeg(filename, "v:0")
  return video_dataset.skip(position).take(10)

dataset = dataset.map(func)


```

This PR fixes #616.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>