### PR TITLE
DICOM doc update

### DIFF
--- a/docs/tutorials/dicom.ipynb
+++ b/docs/tutorials/dicom.ipynb
@@ -172,7 +172,8 @@
         "colab": {}
       },
       "source": [
-        "!pip install tensorflow-io"
+        "%tensorflow_version 2.x \n",
+        "!pip install tensorflow-io-nightly"
       ],
       "execution_count": 0,
       "outputs": []
@@ -195,8 +196,6 @@
         "colab": {}
       },
       "source": [
-        "%tensorflow_version 2.x \n",
-        "\n",
         "import matplotlib.pyplot as plt\n",
         "import numpy as np\n",
         "import tensorflow as tf\n",

--- a/docs/tutorials/dicom.ipynb
+++ b/docs/tutorials/dicom.ipynb
@@ -132,7 +132,7 @@
         "\n",
         "Google Cloud also provides a DICOM version of the images, available in [Cloud Storage](https://cloud.google.com/healthcare/docs/resources/public-datasets/nih-chest).\n",
         "\n",
-        "In this tutorial, we will download a sample file of the dataset from the [GitHub repo](https://github.com/yongtang/io/raw/dicom2/docs/tutorials/dicom/dicom_00000001_000.dcm)\n",
+        "In this tutorial, we will download a sample file of the dataset from the [GitHub repo](https://github.com/tensorflow/io/raw/master/docs/tutorials/dicom/dicom_00000001_000.dcm)\n",
         "\n",
         "\n",
         "Note: For more information about the dataset, please find the following reference:\n",
@@ -148,7 +148,7 @@
         "colab": {}
       },
       "source": [
-        "!curl -OL https://github.com/yongtang/io/raw/dicom2/docs/tutorials/dicom/dicom_00000001_000.dcm\n",
+        "!curl -OL https://github.com/tensorflow/io/raw/master/docs/tutorials/dicom/dicom_00000001_000.dcm\n",
         "!ls -l dicom_00000001_000.dcm"
       ],
       "execution_count": 0,
@@ -172,8 +172,7 @@
         "colab": {}
       },
       "source": [
-        "# Note: change to tensorflow-io\n",
-        "!pip install tensorflow-io-nightly"
+        "!pip install tensorflow-io"
       ],
       "execution_count": 0,
       "outputs": []
@@ -237,8 +236,8 @@
         "    contents,\n",
         "    color_dim=False,\n",
         "    on_error='skip',\n",
-        "    scale='preserve'\n",
-        "    dtype=tf.uint16\n",
+        "    scale='preserve',\n",
+        "    dtype=tf.uint16,\n",
         "    name=None\n",
         ")\n",
         "```\n",

--- a/tensorflow_io/core/python/ops/dicom_ops.py
+++ b/tensorflow_io/core/python/ops/dicom_ops.py
@@ -20,11 +20,120 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow_io.core.python.ops import core_ops as dicom_ops
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
 
-decode_dicom_data = dicom_ops.io_decode_dicom_data
-decode_dicom_image = dicom_ops.io_decode_dicom_image
+def decode_dicom_image(
+    contents,
+    color_dim=False,
+    on_error='skip',
+    scale='preserve',
+    dtype=tf.uint16,
+    name=None):
+  """Getting DICOM Image Data.
 
+  This package has two operations which wrap `DCMTK` functions.
+  `decode_dicom_image` decodes the pixel data from DICOM files, and
+  `decode_dicom_data` decodes tag information.
+  `dicom_tags` contains useful DICOM tags such as `dicom_tags.PatientsName`.
+  We borrow the same tag notation from the
+  [`pydicom`](https://pydicom.github.io/) dicom package.
+
+  The detailed usage of DICOM is available in
+  [tutorial](https://www.tensorflow.org/io/tutorials/dicom).
+
+  If this package helped, please kindly cite the below:
+  ```
+  @misc{marcelo_lerendegui_2019_3337331,
+    author       = {Marcelo Lerendegui and Ouwen Huang},
+    title        = {Tensorflow Dicom Decoder},
+    month        = jul,
+    year         = 2019,
+    doi          = {10.5281/zenodo.3337331},
+    url          = {https://doi.org/10.5281/zenodo.3337331}
+  }
+  ```
+
+  Args:
+    contents: A Tensor of type string. 0-D. The byte string encoded DICOM file.
+    color_dim: An optional `bool`. Defaults to `False`. If `True`, a third
+      channel will be appended to all images forming a 3-D tensor.
+      A 1024 x 1024 grayscale image will be 1024 x 1024 x 1.
+    on_error: Defaults to `skip`. This attribute establishes the behavior in
+      case an error occurs on opening the image or if the output type cannot
+      accomodate all the possible input values. For example if the user sets
+      the output dtype to `tf.uint8`, but a dicom image stores a `tf.uint16`
+      type. `strict` throws an error. `skip` returns a 1-D empty tensor.
+      `lossy` continues with the operation scaling the value via the `scale`
+      attribute.
+    scale:  Defaults to `preserve`. This attribute establishes what to do with
+      the scale of the input values. `auto` will autoscale the input values,
+      if the output type is integer, `auto` will use the maximum output scale
+      for example a `uint8` which stores values from [0, 255] can be linearly
+      stretched to fill a `uint16` that is [0,65535]. If the output is float,
+      `auto` will scale to [0,1]. `preserve` keeps the values as they are, an
+      input value greater than the maximum possible output will be clipped.
+    dtype: An optional `tf.DType` from: `tf.uint8`, `tf.uint16`, `tf.uint32`,
+      `tf.uint64`, `tf.float16`, `tf.float32`, `tf.float64`. Defaults to
+      `tf.uint16`.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `dtype` and the shape is determined by the DICOM file.
+  """
+  return core_ops.io_decode_dicom_image(
+      contents=contents,
+      color_dim=color_dim,
+      on_error=on_error,
+      scale=scale,
+      dtype=dtype,
+      name=name)
+
+def decode_dicom_data(
+    contents,
+    tags=None,
+    name=None):
+  """Getting DICOM Tag Data.
+
+  This package has two operations which wrap `DCMTK` functions.
+  `decode_dicom_image` decodes the pixel data from DICOM files, and
+  `decode_dicom_data` decodes tag information.
+  `dicom_tags` contains useful DICOM tags such as `dicom_tags.PatientsName`.
+  We borrow the same tag notation from the
+  [`pydicom`](https://pydicom.github.io/) dicom package.
+
+  The detailed usage of DICOM is available in
+  [tutorial](https://www.tensorflow.org/io/tutorials/dicom).
+
+  If this package helped, please kindly cite the below:
+  ```
+  @misc{marcelo_lerendegui_2019_3337331,
+    author       = {Marcelo Lerendegui and Ouwen Huang},
+    title        = {Tensorflow Dicom Decoder},
+    month        = jul,
+    year         = 2019,
+    doi          = {10.5281/zenodo.3337331},
+    url          = {https://doi.org/10.5281/zenodo.3337331}
+  }
+  ```
+
+  Args:
+    contents: A Tensor of type string. 0-D. The byte string encoded DICOM file.
+    tags: A Tensor of type `tf.uint32` of any dimension.
+      These `uint32` numbers map directly to DICOM tags.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` of type `tf.string` and same shape as `tags`. If a dicom tag is
+      a list of strings, they are combined into one string and seperated by a
+      double backslash `\\`. There is a bug in
+      [DCMTK](https://support.dcmtk.org/docs/) if the tag is a list of numbers,
+      only the zeroth element will be returned as a string.
+  """
+  return core_ops.io_decode_dicom_data(
+      contents=contents,
+      tags=tags,
+      name=name)
 
 class dicom_tags(object): # pylint: disable=invalid-name
   """dicom_tags"""


### PR DESCRIPTION
This PR is a follow up for #624, which was merged prematurely (sorry).

This PR:
1) Popoulate the python docstring of `tfio.image.decode_dicom_image`
   and `tfio.image.decode_dicom_data` and carry the content from original
   README.md.
2) Added linking to the tutorial from the python docstring, as was suggested
   in the review.
3) The tensorflow_io/dicom had been move to tfio.image.decode_dicom_image
   and tfio.image.decode_dicom_data. As such the REAME.md in tensorflow_io/dicom
   is not visible anymore. This PR uses python docstring to provides all
   the necessarily information, including additional links and citations.

Also a couple of small typos and missing `,` have been fixed.

This PR is a following up of #624.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>