### PR TITLE
Add option to initialize decode_avro resource, so that compiled avro schema could be reused

### DIFF
--- a/tensorflow_io/kafka/__init__.py
+++ b/tensorflow_io/kafka/__init__.py
@@ -19,6 +19,7 @@
 @@write_kafka
 @@decode_avro
 @@encode_avro
+@@decode_avro_init
 """
 
 from __future__ import absolute_import
@@ -30,6 +31,7 @@ from tensorflow_io.kafka.python.ops.kafka_dataset_ops import KafkaDataset
 from tensorflow_io.kafka.python.ops.kafka_dataset_ops import write_kafka
 from tensorflow_io.kafka.python.ops.kafka_dataset_ops import decode_avro
 from tensorflow_io.kafka.python.ops.kafka_dataset_ops import encode_avro
+from tensorflow_io.kafka.python.ops.kafka_dataset_ops import decode_avro_init
 
 from tensorflow.python.util.all_util import remove_undocumented
 

--- a/tensorflow_io/kafka/kernels/kafka_kernels.cc
+++ b/tensorflow_io/kafka/kernels/kafka_kernels.cc
@@ -318,33 +318,72 @@ REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableInit").Device(DEVICE_CPU),
 REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableRead").Device(DEVICE_CPU),
                         IOReadableReadOp<KafkaReadable>);
 
+class DecodeAvroResource : public ResourceBase {
+ public:
+  DecodeAvroResource(Env* env) : env_(env) {}
+  ~DecodeAvroResource() {}
+
+  Status Init(const string& input) {
+    mutex_lock lock(mu_);
+    schema_ = input;
+    schema_stream_ = std::istringstream(schema_);
+
+    string error;
+    if (!(avro::compileJsonSchema(schema_stream_, avro_schema_, error))) {
+      return errors::Unimplemented("Avro schema error: ", error);
+    }
+
+    return Status::OK();
+  }
+  const avro::ValidSchema& avro_schema() {
+    return avro_schema_;
+  }
+  string DebugString() const override {
+    return "DecodeAvroResource";
+  }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+  string schema_ GUARDED_BY(mu_);
+  std::istringstream schema_stream_;
+  avro::ValidSchema avro_schema_;
+};
+
 class DecodeAvroOp : public OpKernel {
  public:
   explicit DecodeAvroOp(OpKernelConstruction* context) : OpKernel(context) {
+    env_ = context->env();
   }
 
   void Compute(OpKernelContext* context) override {
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
 
-    const Tensor* schema_tensor;
-    OP_REQUIRES_OK(context, context->input("schema", &schema_tensor));
-    const string& schema = schema_tensor->scalar<string>()();
+    DecodeAvroResource* resource;
+    std::unique_ptr<DecodeAvroResource> resource_scope;
+    if (context->input_dtype(1) == DT_RESOURCE) {
+      OP_REQUIRES_OK(context, GetResourceFromContext(context, "schema", &resource));
+    } else {
+      const Tensor* schema_tensor;
+      OP_REQUIRES_OK(context, context->input("schema", &schema_tensor));
+      const string& schema = schema_tensor->scalar<string>()();
 
-    avro::ValidSchema avro_schema;
-    std::istringstream ss(schema);
-    string error;
-    OP_REQUIRES(context, (avro::compileJsonSchema(ss, avro_schema, error)), errors::Unimplemented("Avro schema error: ", error));
+      resource_scope.reset(new DecodeAvroResource(env_));
+      OP_REQUIRES_OK(context, resource_scope->Init(schema));
+      resource_scope->Ref();
+      resource = resource_scope.get();
+    }
+    core::ScopedUnref unref(resource);
 
-    avro::GenericDatum datum(avro_schema);
     std::vector<Tensor*> value;
-    value.reserve(avro_schema.root()->names());
-    for (size_t i = 0; i < avro_schema.root()->names(); i++) {
+    value.reserve(resource->avro_schema().root()->names());
+    for (size_t i = 0; i < resource->avro_schema().root()->names(); i++) {
       Tensor* value_tensor = nullptr;
       OP_REQUIRES_OK(context, context->allocate_output(static_cast<int64>(i), input_tensor->shape(), &value_tensor));
       value.push_back(value_tensor);
     }
 
+    avro::GenericDatum datum(resource->avro_schema());
     for (int64 entry_index = 0; entry_index < input_tensor->NumElements(); entry_index++) {
       const string& entry = input_tensor->flat<string>()(entry_index);
       std::unique_ptr<avro::InputStream> in = avro::memoryInputStream((const uint8_t*)entry.data(), entry.size());
@@ -353,7 +392,7 @@ class DecodeAvroOp : public OpKernel {
       d->init(*in);
       avro::decode(*d, datum);
       const avro::GenericRecord& record = datum.value<avro::GenericRecord>();
-      for (int i = 0; i < avro_schema.root()->names(); i++) {
+      for (int i = 0; i < resource->avro_schema().root()->names(); i++) {
         const avro::GenericDatum& field = record.fieldAt(i);
         switch(field.type()) {
         case avro::AVRO_NULL:
@@ -438,6 +477,9 @@ class DecodeAvroOp : public OpKernel {
       }
     }
   }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
 };
 
 class EncodeAvroOp : public OpKernel {
@@ -526,12 +568,37 @@ class EncodeAvroOp : public OpKernel {
 private:
   string schema_;
 };
+class DecodeAvroInitOp : public ResourceOpKernel<DecodeAvroResource> {
+ public:
+  explicit DecodeAvroInitOp(OpKernelConstruction* context)
+      : ResourceOpKernel<DecodeAvroResource>(context) {
+    env_ = context->env();
+  }
+ private:
+  void Compute(OpKernelContext* context) override {
+    ResourceOpKernel<DecodeAvroResource>::Compute(context);
 
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    OP_REQUIRES_OK(context, resource_->Init(input_tensor->scalar<string>()()));
+  }
+  Status CreateResource(DecodeAvroResource** resource)
+      EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+    *resource = new DecodeAvroResource(env_);
+    return Status::OK();
+  }
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
 
 REGISTER_KERNEL_BUILDER(Name("IO>DecodeAvro").Device(DEVICE_CPU),
                         DecodeAvroOp);
 REGISTER_KERNEL_BUILDER(Name("IO>EncodeAvro").Device(DEVICE_CPU),
                         EncodeAvroOp);
+REGISTER_KERNEL_BUILDER(Name("IO>DecodeAvroInit").Device(DEVICE_CPU),
+                        DecodeAvroInitOp);
 
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/kafka/kernels/kafka_kernels.cc
+++ b/tensorflow_io/kafka/kernels/kafka_kernels.cc
@@ -321,15 +321,18 @@ REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableRead").Device(DEVICE_CPU),
 class DecodeAvroOp : public OpKernel {
  public:
   explicit DecodeAvroOp(OpKernelConstruction* context) : OpKernel(context) {
-   OP_REQUIRES_OK(context, context->GetAttr("schema", &schema_));
   }
 
   void Compute(OpKernelContext* context) override {
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
 
+    const Tensor* schema_tensor;
+    OP_REQUIRES_OK(context, context->input("schema", &schema_tensor));
+    const string& schema = schema_tensor->scalar<string>()();
+
     avro::ValidSchema avro_schema;
-    std::istringstream ss(schema_);
+    std::istringstream ss(schema);
     string error;
     OP_REQUIRES(context, (avro::compileJsonSchema(ss, avro_schema, error)), errors::Unimplemented("Avro schema error: ", error));
 
@@ -435,8 +438,6 @@ class DecodeAvroOp : public OpKernel {
       }
     }
   }
-private:
-  string schema_;
 };
 
 class EncodeAvroOp : public OpKernel {

--- a/tensorflow_io/kafka/ops/kafka_ops.cc
+++ b/tensorflow_io/kafka/ops/kafka_ops.cc
@@ -31,9 +31,10 @@ REGISTER_OP("IO>EncodeAvro")
 
 REGISTER_OP("IO>DecodeAvro")
   .Input("input: string")
+  .Input("schema: T")
   .Output("value: dtype")
-  .Attr("schema: string")
   .Attr("dtype: list({float,double,int32,int64,string})")
+  .Attr("T: {string, resource}")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
     for (int64 i = 0; i < c->num_outputs(); i++) {
       c->set_output(i, c->input(0));

--- a/tensorflow_io/kafka/ops/kafka_ops.cc
+++ b/tensorflow_io/kafka/ops/kafka_ops.cc
@@ -29,6 +29,16 @@ REGISTER_OP("IO>EncodeAvro")
     return Status::OK();
    });
 
+REGISTER_OP("IO>DecodeAvroInit")
+  .Input("input: string")
+  .Output("resource: resource")
+  .Attr("container: string = ''")
+  .Attr("shared_name: string = ''")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->Scalar());
+    return Status::OK();
+   });
+
 REGISTER_OP("IO>DecodeAvro")
   .Input("input: string")
   .Input("schema: T")

--- a/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
@@ -24,6 +24,7 @@ from tensorflow import dtypes
 from tensorflow.compat.v1 import data
 from tensorflow_io.core.python.ops import core_ops
 
+decode_avro_init = core_ops.io_decode_avro_init
 decode_avro = core_ops.io_decode_avro
 encode_avro = core_ops.io_encode_avro
 


### PR DESCRIPTION
This PR add a decode_avro_init which returns a resource handle with compiled avro schema.

The resource handle could then be passed to decode_avro multiple times, thus avoiding recompile of avro schema.

Note decode_avro could accept both a string (schema) or a resource handle. If a string is passed, the recompile of schema will be done in place within the kernel ops of decode_avro. This PR is backward-compatible.

This PR is part of the effort for issue #611.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>