### PR TITLE
Add the option to configure with python3

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -15,9 +15,15 @@
 # ==============================================================================
 
 rm -f .bazelrc
-if python -c "import tensorflow as tf" &> /dev/null; then
+
+PYTHON=python
+if [[ "$#" -gt 0 ]]; then
+  PYTHON=$1
+fi
+
+if $PYTHON -c "import tensorflow as tf" &> /dev/null; then
     echo 'using installed tensorflow'
 else
-    python -m pip install $(python setup.py --package-version)
+    $PYTHON -m pip install $(python setup.py --package-version)
 fi
-python third_party/tf/configure.py
+$PYTHON third_party/tf/configure.py


### PR DESCRIPTION
In macOS, catalina by default ships python 3.7 already (through XCode).
As such I expect many people to use python 3.7 with tensorflow.
For that I think it makes sense to allow configure with python3 thorough configure.sh

This PR add the optional argument for configure.sh to take python3 (instead of default python).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>