### PR TITLE
Enable SSE 4.2 and AVX on macOS as well, and further optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ jobs:
     os: osx
     osx_image: xcode10
     script:
+    - export BAZEL_CPU_OPTIMIZATION=yes
     - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
     - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
@@ -84,6 +85,7 @@ jobs:
     os: osx
     osx_image: xcode10
     script:
+    - export BAZEL_CPU_OPTIMIZATION=yes
     - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
     - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
@@ -93,6 +95,7 @@ jobs:
     os: osx
     osx_image: xcode10
     script:
+    - export BAZEL_CPU_OPTIMIZATION=yes
     - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
     - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
@@ -102,6 +105,7 @@ jobs:
     os: osx
     osx_image: xcode10
     script:
+    - export BAZEL_CPU_OPTIMIZATION=yes
     - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
     - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -86,8 +86,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -96,8 +96,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -106,8 +106,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
+    - echo bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -96,8 +96,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
+    - echo bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -106,8 +106,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
+    - echo bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
+    - echo bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -86,8 +86,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
+    - echo bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -96,8 +96,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
+    - echo bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -106,8 +106,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
-    - bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
+    - echo bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -96,8 +96,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
   - stage: build
@@ -106,8 +106,8 @@ jobs:
     osx_image: xcode10
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes
-    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER} & sleep 1800; kill $!
-    - echo bash -x -e .travis/wheel.test.sh
+    - bash -x -e .travis/python.release.sh --nightly ${TRAVIS_BUILD_NUMBER}
+    - bash -x -e .travis/wheel.test.sh
     after_success: bash -x -e .travis/after-success.sh
 
 notifications:

--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -57,9 +57,9 @@ if [[ "${BAZEL_CACHE}" != "" ]]; then
   args+=(--disk_cache=${BAZEL_CACHE})
 fi
 
-# Build with SSE4.2
+# Build with SSE4.2 and O2
 if [[ "${BAZEL_CPU_OPTIMIZATION}" == "yes" ]]; then
-  args+=(--copt=-msse4.2 --copt=-mavx)
+  args+=(--copt=-msse4.2 --copt=-mavx --compilation_mode=opt)
 fi
 
 bazel build \

--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -59,7 +59,7 @@ fi
 
 # Build with SSE4.2 and O2
 if [[ "${BAZEL_CPU_OPTIMIZATION}" == "yes" ]]; then
-  args+=(--copt=-msse4.2 --copt=-mavx --compilation_mode=opt)
+  args+=(--copt=-msse4.2 --copt=-mavx)
 fi
 
 bazel build \

--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -57,7 +57,7 @@ if [[ "${BAZEL_CACHE}" != "" ]]; then
   args+=(--disk_cache=${BAZEL_CACHE})
 fi
 
-# Build with SSE4.2 and O2
+# Build with SSE4.2 and AVX
 if [[ "${BAZEL_CPU_OPTIMIZATION}" == "yes" ]]; then
   args+=(--copt=-msse4.2 --copt=-mavx)
 fi


### PR DESCRIPTION
While looking into issue #647 I noticed several areas that could be further optimized.
1) SSE 4.2 and AVX are not enabled on macOS
2) By default bazel seems to use fastbuild mode which equal to -O0.
   Need to further confirm as bazel's behavior is not exactly clear. 
3) The -O2 may also apply to linux as well.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>