### PR TITLE
Fix a small typo of `"` => `'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import tensorflow_io as tfio
 
 # Read MNIST into Dataset
 d_train = tfio.IODataset.from_mnist(
-    'http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz",
+    'http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz',
     'http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz').batch(1)
 
 # By default image data is uint8 so conver to float32.


### PR DESCRIPTION
as otherwise the example code in README.md will not run correctly

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>