### PR TITLE
Add `alwayslink = 1` for Bazel rules to support bazel 1.0+

### DIFF
--- a/tensorflow_io/arrow/BUILD
+++ b/tensorflow_io/arrow/BUILD
@@ -25,4 +25,5 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "@arrow",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/azure/BUILD
+++ b/tensorflow_io/azure/BUILD
@@ -21,6 +21,7 @@ cc_library(
         ":azfs_readonly_memory_region",
         ":azfs_writable_file",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -38,6 +39,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -53,6 +55,7 @@ cc_library(
     deps = [
         ":azfs_client",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -68,6 +71,7 @@ cc_library(
     deps = [
         ":azfs_client",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -81,6 +85,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 # bazel test \

--- a/tensorflow_io/bigquery/BUILD
+++ b/tensorflow_io/bigquery/BUILD
@@ -45,6 +45,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 # A library for use in the bigquery kernels.
@@ -61,4 +62,5 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/bigtable/BUILD
+++ b/tensorflow_io/bigtable/BUILD
@@ -44,6 +44,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -61,6 +62,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 # using cc_test in tensorflow_io currently results in segmentation fault. Using cc_binary is an interim solution.
@@ -102,6 +104,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 # A library for use in the bigtable kernels.
@@ -116,4 +119,5 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -21,6 +21,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -35,6 +36,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -51,6 +53,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -64,6 +67,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -79,6 +83,7 @@ cc_library(
         ":dataset_ops",
         "@curl",
     ],
+    alwayslink = 1,
 )
 
 go_binary(
@@ -101,6 +106,7 @@ cc_library(
     deps = [
         "//tensorflow_io/core:golang_ops.cc",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -115,6 +121,7 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "@lmdb",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -128,6 +135,7 @@ cc_library(
     deps = [
         "//tensorflow_io/core:dataset_ops",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -142,6 +150,7 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "//tensorflow_io/core:go_ops",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -157,6 +166,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -188,6 +198,7 @@ cc_library(
         "@libwebp",
         "@openexr",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -201,6 +212,7 @@ cc_library(
     deps = [
         "//tensorflow_io/core:dataset_ops",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -216,6 +228,7 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "@ffmpeg_3_4//:ffmpeg",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -231,6 +244,7 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "@ffmpeg_2_8//:ffmpeg",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -245,6 +259,7 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "@avro",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -268,6 +283,7 @@ cc_library(
         "//tensorflow_io/core:sequence_ops",
         "@com_googlesource_code_re2//:re2",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -282,6 +298,7 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "@nucleus//:fastq_reader",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -296,6 +313,7 @@ cc_library(
         "//tensorflow_io/core:dataset_ops",
         "@hdf5",
     ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -310,6 +328,7 @@ cc_library(
         "//tensorflow_io/arrow:arrow_ops",
         "//tensorflow_io/core:dataset_ops",
     ],
+    alwayslink = 1,
 )
 
 cc_binary(

--- a/tensorflow_io/gcs/BUILD
+++ b/tensorflow_io/gcs/BUILD
@@ -21,4 +21,5 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/grpc/BUILD
+++ b/tensorflow_io/grpc/BUILD
@@ -46,6 +46,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )
 
 py_proto_library(

--- a/tensorflow_io/ignite/BUILD
+++ b/tensorflow_io/ignite/BUILD
@@ -54,4 +54,5 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/json/BUILD
+++ b/tensorflow_io/json/BUILD
@@ -24,4 +24,5 @@ cc_library(
         "@arrow",
         "@jsoncpp_git//:jsoncpp",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/kafka/BUILD
+++ b/tensorflow_io/kafka/BUILD
@@ -25,4 +25,5 @@ cc_library(
         "@avro",
         "@kafka",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/kinesis/BUILD
+++ b/tensorflow_io/kinesis/BUILD
@@ -21,4 +21,5 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/oss/BUILD
+++ b/tensorflow_io/oss/BUILD
@@ -23,4 +23,5 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )

--- a/tensorflow_io/pubsub/BUILD
+++ b/tensorflow_io/pubsub/BUILD
@@ -22,4 +22,5 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],
+    alwayslink = 1,
 )


### PR DESCRIPTION
For some reason, Bazel 1.0+ changed the way cc_library is generated,
as a result, with bazel 1.0+, building tensorflow-io fails.

This PR adds `alwayslink = 1` so that code base of tensorflow-io
still works with bazel 1.0+.

Note on Travis CI we still use 0.29.0 for now (as TF 2.1 release is comming).

We will upgrade Travis CI's Bazel version later.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>