### PR TITLE
Add initial benchmark tests, and add initial standarized IODataset tests

### DIFF
--- a/.travis/wheel.test.sh
+++ b/.travis/wheel.test.sh
@@ -7,12 +7,12 @@ run_test() {
   CPYTHON_VERSION=$($entry -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
   (cd wheelhouse && $entry -m pip install tensorflow_io-*-cp${CPYTHON_VERSION}-*.whl)
   $entry -m pip install -q pytest boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.14.1 pandas==0.24.2 scikit-learn==0.20.4 gast==0.2.2 fastavro
-  (cd tests && $entry -m pytest -v --import-mode=append $(find . -type f \( -iname "test_*.py" ! \( -iname "test_*_eager.py" -o -iname "test_grpc.py" -o -iname "test_gcs_config_ops.py" \) \)))
-  (cd tests && $entry -m pytest -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \)))
+  (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*.py" ! \( -iname "test_*_eager.py" -o -iname "test_grpc.py" -o -iname "test_gcs_config_ops.py" \) \)))
+  (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \)))
   # GRPC and test_bigquery_eager tests have to be executed separately because of https://github.com/grpc/grpc/issues/20034
-  (cd tests && $entry -m pytest -v --import-mode=append $(find . -type f \( -iname "test_grpc.py" \)))
-  (cd tests && $entry -m pytest -v --import-mode=append $(find . -type f \( -iname "test_bigquery_eager.py" \)))
-  (cd tests && $entry -m pytest -v --import-mode=append $(find . -type f \( -iname "test_gcs_config_ops.py" \)))
+  (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_grpc.py" \)))
+  (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_bigquery_eager.py" \)))
+  (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_gcs_config_ops.py" \)))
 }
 
 PYTHON_VERSION=python

--- a/.travis/wheel.test.sh
+++ b/.travis/wheel.test.sh
@@ -6,7 +6,7 @@ run_test() {
   entry=$1
   CPYTHON_VERSION=$($entry -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
   (cd wheelhouse && $entry -m pip install tensorflow_io-*-cp${CPYTHON_VERSION}-*.whl)
-  $entry -m pip install -q pytest boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.14.1 pandas==0.24.2 scikit-learn==0.20.4 gast==0.2.2 fastavro
+  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.14.1 pandas==0.24.2 scikit-learn==0.20.4 gast==0.2.2 fastavro
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*.py" ! \( -iname "test_*_eager.py" -o -iname "test_grpc.py" -o -iname "test_gcs_config_ops.py" \) \)))
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \)))
   # GRPC and test_bigquery_eager tests have to be executed separately because of https://github.com/grpc/grpc/issues/20034

--- a/tests/test_audio_eager.py
+++ b/tests/test_audio_eager.py
@@ -207,7 +207,6 @@ def test_audio_io_tensor(audio_data, io_tensor_func):
 @pytest.mark.parametrize(
     ("io_dataset_func"),
     [
-        (tfio.IODataset.from_audio),
         pytest.param(
             lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0"),
             marks=[
@@ -225,7 +224,7 @@ def test_audio_io_tensor(audio_data, io_tensor_func):
             ],
         ),
     ],
-    ids=["from_audio", "from_ffmpeg", "from_ffmpeg(eager)"],
+    ids=["from_ffmpeg", "from_ffmpeg(eager)"],
 )
 def test_audio_io_dataset(audio_data, io_dataset_func):
   """test_audio_io_dataset"""
@@ -303,7 +302,6 @@ def test_audio_io_tensor_with_dataset(
 @pytest.mark.parametrize(
     ("io_dataset_func"),
     [
-        (tfio.IODataset.graph(tf.int16).from_audio),
         pytest.param(
             lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0"),
             marks=[
@@ -313,7 +311,7 @@ def test_audio_io_tensor_with_dataset(
             ],
         ),
     ],
-    ids=["from_audio", "from_ffmpeg"],
+    ids=["from_ffmpeg"],
 )
 def test_audio_io_dataset_with_dataset(audio_data, io_dataset_func):
   """test_audio_io_dataset_with_dataset"""

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -1,0 +1,178 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Test IODataset"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import shutil
+import tempfile
+import pytest
+
+import tensorflow as tf
+import tensorflow_io as tfio
+
+@pytest.fixture(name="fixture_lookup")
+def fixture_lookup_func(request):
+  def _fixture_lookup(name):
+    return request.getfixturevalue(name)
+  return _fixture_lookup
+
+@pytest.fixture(name="lmdb")
+def fixture_lmdb(request):
+  """fixture_lmdb"""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)), "test_lmdb", "data.mdb")
+  tmp_path = tempfile.mkdtemp()
+  filename = os.path.join(tmp_path, "data.mdb")
+  shutil.copy(path, filename)
+
+  def fin():
+    shutil.rmtree(tmp_path)
+  request.addfinalizer(fin)
+
+  args = filename
+  func = tfio.IODataset.from_lmdb
+  expected = [
+      (str(i).encode(), str(chr(ord("a") + i)).encode()) for i in range(10)]
+
+  return args, func, expected
+
+@pytest.fixture(name="audio_wav", scope="module")
+def fixture_audio_wav():
+  """fixture_audio_wav"""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "mono_10khz.wav")
+  audio = tf.audio.decode_wav(tf.io.read_file(path))
+  value = audio.audio * (1 << 15)
+  value = tf.cast(value, tf.int16)
+
+  args = path
+  func = lambda args: tfio.IODataset.graph(tf.int16).from_audio(args)
+  expected = [v for _, v in enumerate(value)]
+
+  return args, func, expected
+
+@pytest.mark.parametrize(
+    ("io_dataset_fixture"),
+    [
+        pytest.param(
+            "lmdb",
+            marks=[
+                pytest.mark.xfail(reason="TODO"),
+            ],
+        ),
+        pytest.param("audio_wav"),
+    ],
+    ids=[
+        "lmdb",
+        "audio[wav]",
+    ],
+)
+def test_io_dataset(fixture_lookup, io_dataset_fixture):
+  """test_io_dataset"""
+  args, func, expected = fixture_lookup(io_dataset_fixture)
+
+  dataset = func(args)
+
+  # Run of dataset iteration
+  entries = [e for e in dataset]
+
+  assert len(entries) == len(expected)
+  assert all([a == b for (a, b) in zip(entries, expected)])
+
+  # A re-run of dataset iteration will yield the same result,
+  # this is needed for training with tf.keras
+  entries = [e for e in dataset]
+
+  assert len(entries) == len(expected)
+  assert all([a == b for (a, b) in zip(entries, expected)])
+
+  # Test of take
+  expected_taken = expected[:5]
+  entries_taken = [e for e in dataset.take(5)]
+
+  assert len(entries_taken) == len(expected_taken)
+  assert all([a == b for (a, b) in zip(entries_taken, expected_taken)])
+
+  # Test of batch
+  indices = list(range(0, len(entries), 3))
+  indices = list(zip(indices, indices[1:] + [len(entries)]))
+  expected_batched = [expected[i:j] for i, j in indices]
+
+  entries_batched = [e for e in dataset.batch(3)]
+
+  assert len(entries_batched) == len(expected_batched)
+  assert all([
+      all([i == i for (i, j) in zip(a, b)]) for (a, b) in zip(
+          entries_batched, expected_batched)])
+
+  # Test of dataset within dataset
+
+  # Note: @tf.function is actually not needed, as tf.data.Dataset
+  # will automatically wrap the `func` into a graph anyway.
+  # The following is purely for explanation purposes.
+  @tf.function
+  def f(v):
+    return func(v)
+
+  args_dataset = tf.data.Dataset.from_tensor_slices([args])
+
+  # Test with num_parallel_calls None, 1, 2
+  for num_parallel_calls in [None, 1, 2]:
+    dataset = args_dataset.map(f)
+
+    item = 0
+    # Notice dataset in dataset:
+    for d in dataset:
+      i = 0
+      for v in d:
+        assert expected[i] == v
+        i += 1
+      assert i == len(expected)
+      item += 1
+
+    # Test with num_parallel_calls=2+
+    dataset = args_dataset.map(f, num_parallel_calls=num_parallel_calls)
+
+@pytest.mark.benchmark(
+    group="io_dataset",
+)
+@pytest.mark.parametrize(
+    ("io_dataset_fixture"),
+    [
+        pytest.param("lmdb"),
+        pytest.param("audio_wav"),
+    ],
+    ids=[
+        "lmdb",
+        "audio[wav]",
+    ],
+)
+def test_io_dataset_benchmark(benchmark, fixture_lookup, io_dataset_fixture):
+  """test_io_dataset_benchmark"""
+  args, func, expected = fixture_lookup(io_dataset_fixture)
+
+  def f(v):
+    dataset = func(v)
+    entries = [e for e in dataset]
+    return entries
+
+  entries = benchmark(f, args)
+
+  assert len(entries) == len(expected)
+  assert all([a == b for (a, b) in zip(entries, expected)])


### PR DESCRIPTION
This PR is an effort to:
1) Add benchmark tests
2) Add standarized IODataset tests
so that all IODataset (especially graph mode GraphIODataset)
behaves the same across the board.

At the moment only from_audio has been moved to this standarized
tests with the help of fixtures and parametrized tests in pytest.

This PR also found out that from_lmdb can not repeat the iteration,
in other words:
```
dataset = tfio.IODataset.from_lmdb(...)
entries = [e for e in dataset]
entries = [e for e in dataset] <= failure!
```

This PR has not fixed the lmdb yet, will have a follow up PR
to fix lmdb.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>