### PR TITLE
Enable --compilation_mode=opt to bring -O2 to the build

### DIFF
--- a/.travis/bazel.build.sh
+++ b/.travis/bazel.build.sh
@@ -59,7 +59,7 @@ fi
 
 # Build with SSE4.2 and AVX
 if [[ "${BAZEL_CPU_OPTIMIZATION}" == "yes" ]]; then
-  args+=(--copt=-msse4.2 --copt=-mavx)
+  args+=(--copt=-msse4.2 --copt=-mavx --compilation_mode=opt)
 fi
 
 bazel build \


### PR DESCRIPTION
This PR is part of the effort to speed up the audio loading speed.
This PR enables --compilation_mode=opt which add -O2 flag to compiler.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>