### PR TITLE
Add virtual destructor when applicable

### DIFF
--- a/tensorflow_io/core/kernels/ffmpeg_kernels.cc
+++ b/tensorflow_io/core/kernels/ffmpeg_kernels.cc
@@ -47,7 +47,7 @@ class FFmpegStream {
   , nb_frames_(-1)
   , packet_scope_(nullptr, [](AVPacket* p) { if (p != nullptr) { av_packet_unref(p); }})
   { }
-  ~FFmpegStream() {}
+  virtual ~FFmpegStream() {}
   virtual Status Open(int64 media, int64 index) {
     offset_ = 0;
     AVFormatContext *format_context; 
@@ -345,7 +345,7 @@ class FFmpegAudioStream : public FFmpegStream {
 class FFmpegAudioReadableResource : public ResourceBase {
  public:
   FFmpegAudioReadableResource(Env* env) : env_(env) {}
-  ~FFmpegAudioReadableResource() {}
+  virtual ~FFmpegAudioReadableResource() {}
 
   Status Init(const string& input, const int64 index) {
     filename_ = input;
@@ -595,7 +595,7 @@ class FFmpegVideoStream : public FFmpegStream {
 class FFmpegVideoReadableResource : public ResourceBase {
  public:
   FFmpegVideoReadableResource(Env* env) : env_(env) {}
-  ~FFmpegVideoReadableResource() {}
+  virtual ~FFmpegVideoReadableResource() {}
 
   Status Init(const string& input, const int64 index) {
     filename_ = input;

--- a/tensorflow_io/core/kernels/ffmpeg_kernels_deprecated.cc
+++ b/tensorflow_io/core/kernels/ffmpeg_kernels_deprecated.cc
@@ -76,7 +76,7 @@ class FFmpegReadStream {
   , format_context_(nullptr, [](AVFormatContext* p) { if (p != nullptr) { avformat_close_input(&p); av_free(p); } })
   , io_context_(nullptr, [](AVIOContext* p) { if (p != nullptr) { av_free(p); } })
   , stream_index_(-1) { }
-  ~FFmpegReadStream() {}
+  virtual ~FFmpegReadStream() {}
 
   int64 Streams() {
     return format_context_.get()->nb_streams;
@@ -586,7 +586,7 @@ class FFmpegReadable : public IOReadableInterface {
   FFmpegReadable(Env* env)
   : env_(env) {}
 
-  ~FFmpegReadable() {}
+  virtual ~FFmpegReadable() {}
   Status Init(const std::vector<string>& input, const std::vector<string>& metadata, const void* memory_data, const int64 memory_size) override {
     if (input.size() > 1) {
       return errors::InvalidArgument("more than 1 filename is not supported");

--- a/tensorflow_io/core/kernels/io_interface.h
+++ b/tensorflow_io/core/kernels/io_interface.h
@@ -22,6 +22,7 @@ namespace data {
 
 class IOInterface : public ResourceBase {
  public:
+  virtual ~IOInterface() {}
   virtual Status Init(const std::vector<string>& input, const std::vector<string>& metadata, const void* memory_data, const int64 memory_size) = 0;
   virtual Status Spec(const string& component, PartialTensorShape* shape, DataType* dtype, bool label) = 0;
 
@@ -62,6 +63,7 @@ class IOInterfaceInitOp : public ResourceOpKernel<Type> {
       : ResourceOpKernel<Type>(context) {
     env_ = context->env();
   }
+  virtual ~IOInterfaceInitOp<Type>() {}
  private:
   void Compute(OpKernelContext* context) override {
     ResourceOpKernel<Type>::Compute(context);
@@ -128,6 +130,7 @@ class IOInterfaceSpecOp : public OpKernel {
       component_ = component;
     }
   }
+  virtual ~IOInterfaceSpecOp<Type>() {}
 
   void Compute(OpKernelContext* context) override {
     Type* resource;
@@ -187,6 +190,7 @@ class IOReadableReadOp : public OpKernel {
       component_ = component;
     }
   }
+  virtual ~IOReadableReadOp<Type>() {}
 
   void Compute(OpKernelContext* context) override {
     Type* resource;
@@ -261,6 +265,7 @@ class IOMappingReadOp : public OpKernel {
   explicit IOMappingReadOp<Type>(OpKernelConstruction* ctx)
       : OpKernel(ctx) {
   }
+  virtual ~IOMappingReadOp<Type>() {}
 
   void Compute(OpKernelContext* context) override {
     Type* resource;
@@ -281,6 +286,7 @@ class IOReadablePartitionsOp : public OpKernel {
   explicit IOReadablePartitionsOp<Type>(OpKernelConstruction* ctx)
       : OpKernel(ctx) {
   }
+  virtual ~IOReadablePartitionsOp<Type>() {}
 
   void Compute(OpKernelContext* context) override {
     Type* resource;


### PR DESCRIPTION
This PR adds virtual destructor when applicable. It may not be the root
cause of memory leak mentioned in #680, though it won't hurt either.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>