### PR TITLE
Add decode_json support

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -369,6 +369,21 @@ cc_library(
 )
 
 cc_library(
+    name = "serialization_ops",
+    srcs = [
+        "kernels/serialization_kernels.cc",
+        "ops/serialization_ops.cc",
+    ],
+    copts = tf_io_copts(),
+    linkstatic = True,
+    deps = [
+        "//tensorflow_io/core:dataset_ops",
+        "@rapidjson",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "grpc_ops",
     srcs = [
         "kernels/grpc_kernels.cc",
@@ -424,6 +439,7 @@ cc_binary(
         "//tensorflow_io/core:parquet_ops",
         "//tensorflow_io/core:pcap_ops",
         "//tensorflow_io/core:pubsub_ops",
+        "//tensorflow_io/core:serialization_ops",
         "//tensorflow_io/core:text_ops",
         "//tensorflow_io/core/azure:azfs_ops",
         "//tensorflow_io/core/oss:oss_ops",

--- a/tensorflow_io/core/kernels/serialization_kernels.cc
+++ b/tensorflow_io/core/kernels/serialization_kernels.cc
@@ -1,0 +1,136 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/resource_op_kernel.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/pointer.h"
+
+namespace tensorflow {
+namespace data {
+namespace {
+
+class DecodeJSONOp : public OpKernel {
+ public:
+  explicit DecodeJSONOp(OpKernelConstruction* context) : OpKernel(context) {
+    env_ = context->env();
+    OP_REQUIRES_OK(context, context->GetAttr("shapes", &shapes_));
+  }
+
+  void Compute(OpKernelContext* context) override {
+    // TODO: support batch (1-D) input
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+    const string& input = input_tensor->scalar<string>()();
+
+    const Tensor* names_tensor;
+    OP_REQUIRES_OK(context, context->input("names", &names_tensor));
+
+    OP_REQUIRES(context, (names_tensor->NumElements() == shapes_.size()),
+                errors::InvalidArgument(
+                    "shapes and names should have same number: ",
+                    shapes_.size(), " vs. ", names_tensor->NumElements()));
+    rapidjson::Document d;
+    d.Parse(input.c_str());
+    OP_REQUIRES(context, d.IsObject(),
+                errors::InvalidArgument("not a valid JSON object"));
+    for (size_t i = 0; i < shapes_.size(); i++) {
+      Tensor* value_tensor;
+      OP_REQUIRES_OK(context,
+                     context->allocate_output(i, shapes_[i], &value_tensor));
+      rapidjson::Value* entry =
+          rapidjson::Pointer(names_tensor->flat<string>()(i).c_str()).Get(d);
+      OP_REQUIRES(context, (entry != nullptr),
+                  errors::InvalidArgument("no value for ",
+                                          names_tensor->flat<string>()(i)));
+      if (entry->IsArray()) {
+        OP_REQUIRES(context, entry->Size() == value_tensor->NumElements(),
+                    errors::InvalidArgument(
+                        "number of elements in JSON does not match spec: ",
+                        entry->Size(), " vs. ", value_tensor->NumElements()));
+
+        switch (value_tensor->dtype()) {
+          case DT_INT32:
+            for (int64 j = 0; j < entry->Size(); j++) {
+              value_tensor->flat<int32>()(j) = (*entry)[j].GetInt();
+            }
+            break;
+          case DT_INT64:
+            for (int64 j = 0; j < entry->Size(); j++) {
+              value_tensor->flat<int64>()(j) = (*entry)[j].GetInt64();
+            }
+            break;
+          case DT_FLOAT:
+            for (int64 j = 0; j < entry->Size(); j++) {
+              value_tensor->flat<float>()(j) = (*entry)[j].GetDouble();
+            }
+            break;
+          case DT_DOUBLE:
+            for (int64 j = 0; j < entry->Size(); j++) {
+              value_tensor->flat<double>()(j) = (*entry)[j].GetDouble();
+            }
+            break;
+          case DT_STRING:
+            for (int64 j = 0; j < entry->Size(); j++) {
+              value_tensor->flat<string>()(j) = (*entry)[j].GetString();
+            }
+            break;
+          default:
+            OP_REQUIRES(
+                context, false,
+                errors::InvalidArgument("data type not supported: ",
+                                        DataTypeString(value_tensor->dtype())));
+            break;
+        }
+
+      } else {
+        switch (value_tensor->dtype()) {
+          case DT_INT32:
+            value_tensor->scalar<int32>()() = entry->GetInt();
+            break;
+          case DT_INT64:
+            value_tensor->scalar<int64>()() = entry->GetInt64();
+            break;
+          case DT_FLOAT:
+            value_tensor->scalar<float>()() = entry->GetDouble();
+            break;
+          case DT_DOUBLE:
+            value_tensor->scalar<double>()() = entry->GetDouble();
+            break;
+          case DT_STRING:
+            value_tensor->scalar<string>()() = entry->GetString();
+            break;
+          default:
+            OP_REQUIRES(
+                context, false,
+                errors::InvalidArgument("data type not supported: ",
+                                        DataTypeString(value_tensor->dtype())));
+            break;
+        }
+      }
+    }
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+  std::vector<TensorShape> shapes_ GUARDED_BY(mu_);
+};
+REGISTER_KERNEL_BUILDER(Name("IO>DecodeJSON").Device(DEVICE_CPU), DecodeJSONOp);
+
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow_io/core/ops/serialization_ops.cc
+++ b/tensorflow_io/core/ops/serialization_ops.cc
@@ -1,0 +1,52 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+namespace io {
+namespace {
+
+REGISTER_OP("IO>DecodeJSON")
+    .Input("input: string")
+    .Input("names: string")
+    .Output("value: dtypes")
+    .Attr("shapes: list(shape)")
+    .Attr("dtypes: list(type)")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      // TODO: support batch (1-D) input
+      shape_inference::ShapeHandle unused;
+      TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(0), 0, &unused));
+      std::vector<TensorShape> shapes;
+      TF_RETURN_IF_ERROR(c->GetAttr("shapes", &shapes));
+      if (shapes.size() != c->num_outputs()) {
+        return errors::InvalidArgument(
+            "shapes and types should be the same: ", shapes.size(), " vs. ",
+            c->num_outputs());
+      }
+      for (size_t i = 0; i < shapes.size(); ++i) {
+        shape_inference::ShapeHandle shape;
+        TF_RETURN_IF_ERROR(
+            c->MakeShapeFromPartialTensorShape(shapes[i], &shape));
+        c->set_output(static_cast<int64>(i), shape);
+      }
+      return Status::OK();
+    });
+
+}  // namespace
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/python/api/experimental/serialization.py
+++ b/tensorflow_io/core/python/api/experimental/serialization.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""tensorflow_io.experimental"""
+"""tensorflow_io.experimental.serialization"""
 
-from tensorflow_io.core.python.experimental.io_dataset_ops import IODataset
-from tensorflow_io.core.python.experimental.io_tensor import IOTensor
-from tensorflow_io.core.python.experimental.io_layer import IOLayer
-
-from tensorflow_io.core.python.api.experimental import serialization
-from tensorflow_io.core.python.api.experimental import ffmpeg
-from tensorflow_io.core.python.api.experimental import image
-from tensorflow_io.core.python.api.experimental import text
+from tensorflow_io.core.python.experimental.serialization_ops import decode_json # pylint: disable=unused-import

--- a/tensorflow_io/core/python/experimental/serialization_ops.py
+++ b/tensorflow_io/core/python/experimental/serialization_ops.py
@@ -1,0 +1,73 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Serialization Ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
+
+# _NamedTensorSpec allows adding a `named` key while traversing,
+# so that it is possible to build up the `/R/Foo` JSON Pointers.
+class _NamedTensorSpec(tf.TensorSpec):
+  """_NamedTensorSpec"""
+  def named(self, named=None):
+    if named is not None:
+      self._named = named
+    return self._named
+
+# named_spec updates named field for JSON Pointers while traversing.
+def named_spec(specs, name=''):
+  """named_spec"""
+  if isinstance(specs, _NamedTensorSpec):
+    specs.named(name)
+    return
+
+  if isinstance(specs, dict):
+    for k in specs.keys():
+      named_spec(specs[k], "{}/{}".format(name, k))
+    return
+
+  for k, _ in enumerate(specs):
+    named_spec(specs[k], "{}/{}".format(name, k))
+  return
+
+
+def decode_json(json, specs, name=None):
+  """
+  Decode JSON string into Tensors.
+
+  TODO: support batch (1-D) input
+
+  Args:
+    json: A String Tensor. The JSON strings to decode.
+    specs: A structured TensorSpecs describing the signature
+      of the JSON elements.
+    name: A name for the operation (optional).
+
+  Returns:
+    A structured Tensors.
+  """
+  # Make a copy of specs to keep the original specs
+  named = tf.nest.map_structure(lambda e: _NamedTensorSpec(e.shape, e.dtype), specs)
+  named_spec(named)
+  named = tf.nest.flatten(named)
+  names = [e.named() for e in named]
+  shapes = [e.shape for e in named]
+  dtypes = [e.dtype for e in named]
+
+  values = core_ops.io_decode_json(json, names, shapes, dtypes, name=name)
+  return tf.nest.pack_sequence_as(specs, values)

--- a/tests/test_serialization_eager.py
+++ b/tests/test_serialization_eager.py
@@ -1,0 +1,132 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Test Serialization"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import pytest
+
+import tensorflow as tf
+import tensorflow_io as tfio
+
+@pytest.fixture(name="fixture_lookup")
+def fixture_lookup_func(request):
+  def _fixture_lookup(name):
+    return request.getfixturevalue(name)
+  return _fixture_lookup
+
+@pytest.fixture(name="json", scope="module")
+def fixture_json():
+  """fixture_json"""
+  data = """{
+    "R": {
+      "Foo": 208.82240295410156,
+      "Bar": 93
+    },
+    "Background": [
+      "~/0109.jpg",
+      "~/0110.jpg"
+    ],
+    "Focal Length": 36.9439697265625,
+    "Location": [
+      7.8685874938964844,
+      -4.7373886108398438,
+      -0.038147926330566406],
+    "Rotation": [
+      -4.592592716217041,
+      -4.4698805809020996,
+      -6.9197754859924316]
+   }
+  """
+  value = {
+      "R": {
+          "Foo": tf.constant(208.82240295410156, tf.float64),
+          "Bar": tf.constant(93, tf.int64)
+      },
+      "Background": (
+          tf.constant("~/0109.jpg", tf.string),
+          tf.constant("~/0110.jpg", tf.string)
+      ),
+      "Location": tf.constant([
+          7.8685874938964844,
+          -4.7373886108398438,
+          -0.038147926330566406
+      ], tf.float64),
+      "Rotation": tf.constant([
+          -4.592592716217041,
+          -4.4698805809020996,
+          -6.9197754859924316
+      ], tf.float64)
+  }
+  specs = {
+      "R": {
+          "Foo": tf.TensorSpec(tf.TensorShape([]), tf.float64),
+          "Bar": tf.TensorSpec(tf.TensorShape([]), tf.int64)
+      },
+      "Background": (
+          tf.TensorSpec(tf.TensorShape([]), tf.string),
+          tf.TensorSpec(tf.TensorShape([]), tf.string)
+      ),
+      "Location": tf.TensorSpec(tf.TensorShape([3]), tf.float64),
+      "Rotation": tf.TensorSpec(tf.TensorShape([3]), tf.float64)
+  }
+
+  return data, value, specs
+
+@pytest.mark.parametrize(
+    ("decode_fixture", "decode_function"),
+    [
+        pytest.param("json", tfio.experimental.serialization.decode_json),
+    ],
+    ids=[
+        "json",
+    ],
+)
+def test_serialization_decode(fixture_lookup, decode_fixture, decode_function):
+  """test_serialization_decode"""
+  data, expected, specs = fixture_lookup(decode_fixture)
+
+  value = decode_function(data, specs)
+  tf.nest.assert_same_structure(value, expected)
+  assert all([
+      np.array_equal(v, e) for v, e in zip(
+          tf.nest.flatten(value), tf.nest.flatten(expected))])
+
+@pytest.mark.parametrize(
+    ("decode_fixture", "decode_function"),
+    [
+        pytest.param("json", tfio.experimental.serialization.decode_json),
+    ],
+    ids=[
+        "json",
+    ],
+)
+def test_serialization_decode_in_dataset(
+    fixture_lookup, decode_fixture, decode_function):
+  """test_serialization_decode_in_dataset"""
+  data, expected, specs = fixture_lookup(decode_fixture)
+
+  dataset = tf.data.Dataset.from_tensor_slices([data, data])
+  dataset = dataset.map(lambda e: decode_function(e, specs))
+  entries = list(dataset)
+
+  assert len(entries) == 2
+  for value in entries:
+    tf.nest.assert_same_structure(value, expected)
+    assert all([
+        np.array_equal(v, e) for v, e in zip(
+            tf.nest.flatten(value), tf.nest.flatten(expected))])


### PR DESCRIPTION
This PR adds decode_json support so that it is possible to use
```
values = tfio.experimental.serialization.decode_json(json, specs)
```
to decode a JSON string into a structured Tensors.

The specs field is the structured tf.TensorSpec that is necessary
to reconstruct the JSON values. The reason being JSON could be intepreted
differently in lists:
```
{
"v": [1, 2, 3]
}
```
could be considered as one Tensor of shape `(3)`, or a 3 Tensor structure within dict "v".

Note structured tf.TensorSpecs need to change list `[]` into tuple `()`
as list is not supported in structures in TensorFlow.

This PR fixes #692.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>