### PR TITLE
[dev experience] enhance the lint checking experience

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
           sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          bash -x -e .travis/lint.sh
+          bazel run //tools/lint:check
 
   macos-bazel:
     name: Bazel macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  BAZEL_VERSION: 0.29.0
+  BAZEL_VERSION: 1.2.0
   BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
           sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          bazel run //tools/lint:check
+          bazel run -s --verbose_failures //tools/lint:check
 
   macos-bazel:
     name: Bazel macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  BAZEL_VERSION: 1.2.0
+  BAZEL_VERSION: 2.0.0
   BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,14 @@ stages:
 jobs:
   include:
   - stage: build
+    name: "Lint (Python+Bazel)"
+    script:
+    - export BAZEL_VERSION=0.29.0 BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
+    - curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+    - sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+    - bash -x -e .travis/lint.sh
+
+  - stage: build
     name: "Nightly Release Build on Linux"
     script:
     - export BAZEL_CPU_OPTIMIZATION=yes

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -221,6 +221,26 @@ http_archive(
 )
 
 http_archive(
+    name = "rules_python",
+    sha256 = "c911dc70f62f507f3a361cbc21d6e0d502b91254382255309bc60b7a0f48de28",
+    strip_prefix = "rules_python-38f86fb55b698c51e8510c807489c9f4e047480e",
+    urls = [
+        "https://github.com/bazelbuild/rules_python/archive/38f86fb55b698c51e8510c807489c9f4e047480e.tar.gz",
+    ],
+)
+
+load("@rules_python//python:pip.bzl", "pip3_import")
+
+pip3_import(
+    name = "lint_dependencies",
+    requirements = "//tools/lint:requirements.txt",
+)
+
+load("@lint_dependencies//:requirements.bzl", "pip_install")
+
+pip_install()
+
+http_archive(
     name = "com_github_grpc_grpc",
     patch_args = ["-p1"],
     patches = [
@@ -237,7 +257,7 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+load("@rules_python//python:pip.bzl", "pip_import", "pip_repositories")
 
 pip_import(
     name = "grpc_python_dependencies",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -229,9 +229,9 @@ http_archive(
     ],
 )
 
-load("@rules_python//python:pip.bzl", "pip3_import")
+load("@rules_python//python:pip.bzl", "pip_import")
 
-pip3_import(
+pip_import(
     name = "lint_dependencies",
     requirements = "//tools/lint:requirements.txt",
 )

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -1,0 +1,55 @@
+load("defs.bzl", "lint")
+load("@lint_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+lint(
+    name = "lint",
+    mode = "lint",
+)
+
+lint(
+    name = "check",
+    mode = "check",
+)
+
+exports_files(["lint.tpl"])
+
+py_binary(
+    name = "pylint_py",
+    srcs = ["pylint_python.py"],
+    main = "pylint_python.py",
+    deps = [
+        requirement("pylint"),
+        requirement("astroid"),
+        requirement("isort"),
+        requirement("lazy_object_proxy"),
+    ],
+)
+
+filegroup(
+    name = "pylint_rc",
+    srcs = [
+        "pylint_python.rc",
+    ],
+)
+
+genrule(
+    name = "pylint",
+    srcs = [],
+    outs = ["pylint"],
+    cmd = "echo '$(location :pylint_py) --rcfile=$(location :pylint_rc) \"$$@\"' > $@",
+    executable = True,
+    tools = [
+        ":pylint_py",
+        ":pylint_rc",
+    ],
+)
+
+genrule(
+    name = "clang_format",
+    srcs = ["@llvm_toolchain//:bin/clang-format"],
+    outs = ["clang-format"],
+    cmd = "cat $< > $@",
+    executable = True,
+)

--- a/tools/lint/defs.bzl
+++ b/tools/lint/defs.bzl
@@ -1,0 +1,60 @@
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def _lint_impl(ctx):
+    bash_file = ctx.actions.declare_file(ctx.label.name + ".bash")
+    substitutions = {
+        "@@MODE@@": shell.quote(ctx.attr.mode),
+        "@@PYLINT_PATH@@": shell.quote(ctx.executable._pylint.short_path),
+        "@@BUILDIFIER_PATH@@": shell.quote(ctx.executable._buildifier.short_path),
+        "@@CLANG_FORMAT_PATH@@": shell.quote(ctx.executable._clang_format.short_path),
+    }
+    ctx.actions.expand_template(
+        template = ctx.file._runner,
+        output = bash_file,
+        substitutions = substitutions,
+        is_executable = True,
+    )
+    runfiles = ctx.runfiles(files = [ctx.executable._buildifier, ctx.executable._clang_format, ctx.executable._pylint])
+    return [DefaultInfo(
+        files = depset([bash_file]),
+        runfiles = runfiles,
+        executable = bash_file,
+    )]
+
+_lint = rule(
+    implementation = _lint_impl,
+    attrs = {
+        "mode": attr.string(
+            default = "lint",
+            doc = "Formatting mode",
+            values = ["lint", "check"],
+        ),
+        "_pylint": attr.label(
+            default = "//tools/lint:pylint",
+            cfg = "host",
+            executable = True,
+        ),
+        "_buildifier": attr.label(
+            default = "@com_github_bazelbuild_buildtools//buildifier",
+            cfg = "host",
+            executable = True,
+        ),
+        "_clang_format": attr.label(
+            default = "//tools/lint:clang_format",
+            cfg = "host",
+            executable = True,
+        ),
+        "_runner": attr.label(
+            default = "//tools/lint:lint.tpl",
+            allow_single_file = True,
+        ),
+    },
+    executable = True,
+)
+
+def lint(**kwargs):
+    tags = kwargs.get("tags", [])
+    if "manual" not in tags:
+        tags.append("manual")
+        kwargs["tags"] = tags
+    _lint(**kwargs)

--- a/tools/lint/lint.tpl
+++ b/tools/lint/lint.tpl
@@ -1,0 +1,103 @@
+#! /usr/bin/env bash
+
+MODE=@@MODE@@
+
+PYLINT_PATH=@@PYLINT_PATH@@
+BUILDIFIER_PATH=@@BUILDIFIER_PATH@@
+CLANG_FORMAT_PATH=@@CLANG_FORMAT_PATH@@
+
+mode="$MODE"
+
+pylint_path=$(readlink "$PYLINT_PATH")
+buildifier_path=$(readlink "$BUILDIFIER_PATH")
+clang_format_path=$(readlink "$CLANG_FORMAT_PATH")
+
+echo "mode:" $mode
+echo "pylint:" $pylint_path
+echo "buildifier:" $buildifier_path
+echo "clang-format:" $clang_format_path
+
+if [[ "$mode" == "lint" ]]; then
+    echo 
+    echo "WARN: pylint does not have lint mode, use check instead"
+    echo 
+fi
+
+
+pylint_func() {
+  echo $1 $2
+  return # TODO: enable after python 2 deprecation
+  $pylint_path $2
+}
+
+buildifier_func() {
+  echo $1 $2
+  if [[ "$1" == "lint" ]]; then
+    $buildifier_path -mode=fix $2
+  else
+    $buildifier_path -mode=check $2
+  fi
+}
+
+clang_format_func() {
+  echo $1 $2
+  return # TODO: enable after TF 2.1
+  if [[ "$1" == "lint" ]]; then
+    $clang_format_path --style=google -i $2
+  else
+    diff -u <(cat $2) <($clang_format_path --style=google $2)
+  fi
+}
+
+set -e
+
+( \
+    cd "$BUILD_WORKSPACE_DIRECTORY" && \
+    for i in \
+        $( \
+            find -f tensorflow_io tests -type f \
+                \( -name '*.py' \) \
+        ) ; do \
+        pylint_func $mode "$i" ; \
+    done \
+)
+
+( \
+    cd "$BUILD_WORKSPACE_DIRECTORY" && \
+    for i in \
+        $( \
+            find . -type f \
+                \( \
+                    -name '*.bzl' \
+                    -o -name '*.sky' \
+                    -o -name '*.BUILD' \
+                    -o -name 'BUILD.*.bazel' \
+                    -o -name 'BUILD.*.oss' \
+                    -o -name 'WORKSPACE.*.bazel' \
+                    -o -name 'WORKSPACE.*.oss' \
+                    -o -name BUILD.bazel \
+                    -o -name BUILD \
+                    -o -name WORKSPACE \
+                    -o -name WORKSPACE.bazel \
+                    -o -name WORKSPACE.oss \
+                \) \
+        ) ; do \
+        buildifier_func $mode "$i" ; \
+    done \
+)
+
+( \
+    cd "$BUILD_WORKSPACE_DIRECTORY" && \
+    for i in \
+        $( \
+            find tensorflow_io -type f \
+                \( \
+                    -name '*.cc' \
+                    -o -name '*.h' \
+                \) \
+        ) ; do \
+        clang_format_func $mode "$i" ; \
+    done \
+)
+
+exit 0

--- a/tools/lint/pylint_python.py
+++ b/tools/lint/pylint_python.py
@@ -1,0 +1,19 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""pylint"""
+import sys
+import pylint.lint
+
+pylint.lint.Run(sys.argv[1:])

--- a/tools/lint/pylint_python.rc
+++ b/tools/lint/pylint_python.rc
@@ -1,0 +1,335 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+enable=indexing-exception,old-raise-syntax
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=design,similarities,no-self-use,attribute-defined-outside-init,locally-disabled,star-args,pointless-except,bad-option-value,global-statement,fixme,suppressed-message,useless-suppression,locally-enabled,no-member,no-name-in-module,import-error,unsubscriptable-object,unbalanced-tuple-unpacking,undefined-variable,not-context-manager
+
+
+# Set the cache size for astng objects.
+cache-size=500
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+# List of decorators that create context managers from functions, such as
+# contextlib.contextmanager.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the beginning of the name of dummy variables
+# (i.e. not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=apply,input,reduce
+
+
+# Disable the report(s) with the given id(s).
+# All non-Google reports are disabled by default.
+disable-report=R0001,R0002,R0003,R0004,R0101,R0102,R0201,R0202,R0220,R0401,R0402,R0701,R0801,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,R0921,R0922,R0923
+
+# Regular expression which should only match correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match correct module level names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression which should only match correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression which should only match correct function names
+function-rgx=^(?:(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match correct method names
+method-rgx=^(?:(?P<exempt>__[a-z0-9_]+__|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression which should only match correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression which should only match correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression which should only match correct attribute names in class
+# bodies
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main)
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=(?x)
+  (^\s*(import|from)\s
+   |\$Id:\s\/\/depot\/.+#\d+\s\$
+   |^[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*("[^"]\S+"|'[^']\S+')
+   |^\s*\#\ LINT\.ThenChange
+   |^[^#]*\#\ type:\ [a-zA-Z_][a-zA-Z0-9_.,[\] ]*$
+   |pylint
+   |"""
+   |\#
+   |lambda
+   |(https?|ftp):)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=y
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='  '
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec,sets
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls,class_
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception,StandardError,BaseException
+
+
+[AST]
+
+# Maximum line length for lambdas
+short-func-length=1
+
+# List of module members that should be marked as deprecated.
+# All of the string functions are listed in 4.1.4 Deprecated string functions
+# in the Python 2.4 docs.
+deprecated-members=string.atof,string.atoi,string.atol,string.capitalize,string.expandtabs,string.find,string.rfind,string.index,string.rindex,string.count,string.lower,string.split,string.rsplit,string.splitfields,string.join,string.joinfields,string.lstrip,string.rstrip,string.strip,string.swapcase,string.translate,string.upper,string.ljust,string.rjust,string.center,string.zfill,string.replace,sys.exitfunc
+
+
+[DOCSTRING]
+
+# List of exceptions that do not need to be mentioned in the Raises section of
+# a docstring.
+ignore-exceptions=AssertionError,NotImplementedError,StopIteration,TypeError
+
+
+
+[TOKENS]
+
+# Number of spaces of indent required when the last token on the preceding line
+# is an open (, [, or {.
+indent-after-paren=4
+
+
+[GOOGLE LINES]
+
+# Regexp for a proper copyright notice.
+copyright=Copyright \d{4} The TensorFlow Authors\. +All [Rr]ights [Rr]eserved\.

--- a/tools/lint/requirements.txt
+++ b/tools/lint/requirements.txt
@@ -1,5 +1,1 @@
-pylint==2.4.4
-astroid>=2.3.0,<2.4
-isort>=4.2.5,<5
-mccabe>=0.6,<0.7
-lazy-object-proxy==1.4.3
+pylint==1.9.5

--- a/tools/lint/requirements.txt
+++ b/tools/lint/requirements.txt
@@ -1,0 +1,5 @@
+pylint==2.4.4
+astroid>=2.3.0,<2.4
+isort>=4.2.5,<5
+mccabe>=0.6,<0.7
+lazy-object-proxy==1.4.3


### PR DESCRIPTION
This is part of the process to enhance the developer experience for tensorflow-io.

In the past lint has to be done by using a combination of multiple tools: shell script, docker, Bazel and requires multiple commands to find the lint errors. It is getting more and more confusing.

This PR tries to improve the developer experience for lint checking in TensorFlow-io:
1) Lint checking has been consolidated and only Bazel is needed. No docker installation needed anymore.
2) This PR exposes two simple commands:


   a. `bazel run //tools/lint:check` will check the source files and if lint fails, exit with error
   b. `bazel run //tools/lint:lint` will lint the clang-format and buildifier bazel files automatically

Note pylint is also part of the check. Though pylint could not do the lint automatically so `bazel run //tools/lint:lint` will not correct pylint.

**Note some of the checks are disabled for now as we have to bump Bazel version to 1.2.0+ and wait for python 3 (will switch on once 0.11.0 is released).**

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
