### PR TITLE
Update GitHub Actions to add release and nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,22 +283,6 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-nightly
           path: wheelhouse
-      - name: Setup ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          bash -x -e tests/test_kafka/kafka_test.sh start kafka
-          bash -x -e tests/test_azure/start_azure.sh
-          bash -x -e tests/test_pubsub/pubsub_test.sh start pubsub
-      - name: Install ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python --version
-          (cd wheelhouse && python -m pip install *.whl)
-      - name: Test ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python --version
-          bash -x -e .github/workflows/build.wheel.sh python
 
   linux-nightly:
     name: Nightly ${{ matrix.python }} Linux
@@ -345,21 +329,6 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-nightly
           path: wheelhouse
-      - name: Setup Linux
-        run: |
-          set -x -e
-          bash -x -e tests/test_ignite/start_ignite.sh
-          bash -x -e tests/test_kafka/kafka_test.sh start kafka
-          bash -x -e tests/test_kinesis/kinesis_test.sh start kinesis
-          bash -x -e tests/test_pubsub/pubsub_test.sh start pubsub
-          bash -x -e tests/test_prometheus/prometheus_test.sh start
-          bash -x -e tests/test_azure/start_azure.sh
-      - name: Test Linux
-        run: |
-          set -x -e
-          docker run -i --rm -v $PWD:/v -w /v --net=host \
-            buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
-            bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
 
   nightly:
     name: Nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,5 +404,5 @@ jobs:
           sha256sum dist/*.whl
       - uses: pypa/gh-action-pypi-publish@master
         with:
-          user: github-tensorflow-io-nightly
+          user: __token__
           password: ${{ secrets.github_tensorflow_io_nightly }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,20 +11,6 @@ env:
   BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
 
 jobs:
-  build-number:
-    name: Build Number
-    if: github.event_name == 'push'
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: einaregilsson/build-number@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: BUILD_NUMBER
-          path: BUILD_NUMBER
-
   lint:
     name: Lint
     runs-on: ubuntu-18.04
@@ -241,10 +227,24 @@ jobs:
           name: tensorflow-io-release
           path: wheelhouse
 
+  build-number:
+    name: Build Number
+    if: github.event_name == 'push'
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: einaregilsson/build-number@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: BUILD_NUMBER
+          path: BUILD_NUMBER
+
   macos-nightly:
     name: Nightly ${{ matrix.python }} macOS
     if: github.event_name == 'push'
-    needs: [build-number, lint, macos-bazel]
+    needs: [lint, build-number, macos-bazel]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -283,11 +283,27 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-nightly
           path: wheelhouse
+      - name: Setup ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          bash -x -e tests/test_kafka/kafka_test.sh start kafka
+          bash -x -e tests/test_azure/start_azure.sh
+          bash -x -e tests/test_pubsub/pubsub_test.sh start pubsub
+      - name: Install ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python --version
+          (cd wheelhouse && python -m pip install *.whl)
+      - name: Test ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python --version
+          bash -x -e .github/workflows/build.wheel.sh python
 
   linux-nightly:
     name: Nightly ${{ matrix.python }} Linux
     if: github.event_name == 'push'
-    needs: [build-number, lint, linux-bazel]
+    needs: [lint, build-number, linux-bazel]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -329,6 +345,21 @@ jobs:
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-nightly
           path: wheelhouse
+      - name: Setup Linux
+        run: |
+          set -x -e
+          bash -x -e tests/test_ignite/start_ignite.sh
+          bash -x -e tests/test_kafka/kafka_test.sh start kafka
+          bash -x -e tests/test_kinesis/kinesis_test.sh start kinesis
+          bash -x -e tests/test_pubsub/pubsub_test.sh start pubsub
+          bash -x -e tests/test_prometheus/prometheus_test.sh start
+          bash -x -e tests/test_azure/start_azure.sh
+      - name: Test Linux
+        run: |
+          set -x -e
+          docker run -i --rm -v $PWD:/v -w /v --net=host \
+            buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
+            bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
 
   nightly:
     name: Nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,8 +212,20 @@ jobs:
           name: Linux-3.7-wheel
           path: Linux-3.7-wheel
       - run: |
-          ls -la Linux-3.5-wheel/
-          ls -la macOS-3.5-wheel/
+          set -e -x
+          mkdir -p wheelhouse
+          cp macOS-3.5-wheel/*.whl wheelhouse/
+          cp macOS-3.6-wheel/*.whl wheelhouse/
+          cp macOS-3.7-wheel/*.whl wheelhouse/
+          cp Linux-3.5-wheel/*.whl wheelhouse/
+          cp Linux-3.6-wheel/*.whl wheelhouse/
+          cp Linux-3.7-wheel/*.whl wheelhouse/
+          ls -la wheelhouse/
+          sha256sum wheelhouse/*.whl
+      - uses: actions/upload-artifact@v1
+        with:
+          name: tensorflow-io-release
+          path: wheelhouse
 
   build-number:
     name: Build Number
@@ -268,6 +280,10 @@ jobs:
             delocate-wheel -w wheelhouse  $f
           done
           ls wheelhouse/*
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-nightly
+          path: wheelhouse
 
   linux-nightly:
     name: Nightly ${{ matrix.python }} Linux
@@ -310,3 +326,53 @@ jobs:
           done
           sudo chown -R $(id -nu):$(id -ng) .
           ls wheelhouse/*
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-nightly
+          path: wheelhouse
+
+  nightly:
+    name: Nightly
+    if: github.event_name == 'push'
+    needs: [linux-nightly, macos-nightly]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.5-nightly
+          path: macOS-3.5-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.6-nightly
+          path: macOS-3.6-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.7-nightly
+          path: macOS-3.7-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.5-nightly
+          path: Linux-3.5-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.6-nightly
+          path: Linux-3.6-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.7-nightly
+          path: Linux-3.7-nightly
+      - run: |
+          set -e -x
+          mkdir -p dist
+          cp macOS-3.5-nightly/*.whl dist/
+          cp macOS-3.6-nightly/*.whl dist/
+          cp macOS-3.7-nightly/*.whl dist/
+          cp Linux-3.5-nightly/*.whl dist/
+          cp Linux-3.6-nightly/*.whl dist/
+          cp Linux-3.7-nightly/*.whl dist/
+          ls -la dist/
+          sha256sum dist/*.whl
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: github-tensorflow-io-nightly
+          password: ${{ secrets.github_tensorflow_io_nightly }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,7 +244,7 @@ jobs:
   macos-nightly:
     name: Nightly ${{ matrix.python }} macOS
     if: github.event_name == 'push'
-    needs: [build-number, release]
+    needs: [build-number, lint, macos-bazel]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -287,7 +287,7 @@ jobs:
   linux-nightly:
     name: Nightly ${{ matrix.python }} Linux
     if: github.event_name == 'push'
-    needs: [build-number, release]
+    needs: [build-number, lint, linux-bazel]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: GitHub CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: GitHub CI
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -182,3 +180,45 @@ jobs:
           docker run -i --rm -v $PWD:/v -w /v --net=host \
             buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
             bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
+
+  release:
+    name: release
+    if: github.event_name == 'push'
+    needs: [lint, linux-bazel, macos-bazel]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: einaregilsson/build-number@v2
+        with:
+          token: ${{secrets.github_token}}
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: BUILD_NUMBER
+          path: BUILD_NUMBER
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.7-wheel
+          path: macOS-3.7-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.6-wheel
+          path: macOS-3.6-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.5-wheel
+          path: macOS-3.5-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.7-wheel
+          path: Linux-3.7-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.6-wheel
+          path: Linux-3.6-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.5-wheel
+          path: Linux-3.5-wheel
+      - run: |
+          ls -la Linux-3.5-wheel/
+          ls -la macOS-3.5-wheel/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,28 +197,109 @@ jobs:
           path: BUILD_NUMBER
       - uses: actions/download-artifact@v1
         with:
-          name: macOS-3.7-wheel
-          path: macOS-3.7-wheel
+          name: macOS-3.5-wheel
+          path: macOS-3.5-wheel
       - uses: actions/download-artifact@v1
         with:
           name: macOS-3.6-wheel
           path: macOS-3.6-wheel
       - uses: actions/download-artifact@v1
         with:
-          name: macOS-3.5-wheel
-          path: macOS-3.5-wheel
+          name: macOS-3.7-wheel
+          path: macOS-3.7-wheel
       - uses: actions/download-artifact@v1
         with:
-          name: Linux-3.7-wheel
-          path: Linux-3.7-wheel
+          name: Linux-3.5-wheel
+          path: Linux-3.5-wheel
       - uses: actions/download-artifact@v1
         with:
           name: Linux-3.6-wheel
           path: Linux-3.6-wheel
       - uses: actions/download-artifact@v1
         with:
-          name: Linux-3.5-wheel
-          path: Linux-3.5-wheel
+          name: Linux-3.7-wheel
+          path: Linux-3.7-wheel
       - run: |
           ls -la Linux-3.5-wheel/
           ls -la macOS-3.5-wheel/
+
+  macos-nightly:
+    if: github.event_name == 'push'
+    needs: release
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7']
+    name: Nightly ${{ matrix.python }} macOS
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: BUILD_NUMBER
+      - uses: einaregilsson/build-number@v2
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Wheel ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python -m pip install -U wheel setuptools
+          python --version
+          python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
+      - name: Auditwheel ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python -m pip install twine delocate
+          delocate-wheel --version
+          ls dist/*
+          for f in dist/*.whl; do
+            delocate-wheel -w wheelhouse  $f
+          done
+          ls wheelhouse/*
+
+  linux-nightly:
+    if: github.event_name == 'push'
+    needs: release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04]
+        python: ['3.5', '3.6', '3.7']
+        exclude:
+          - os: ubuntu-16.04
+            python: '3.6'
+          - os: ubuntu-16.04
+            python: '3.7'
+          - os: ubuntu-18.04
+            python: '3.5'
+    name: Nightly ${{ matrix.python }} Linux
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: BUILD_NUMBER
+      - uses: einaregilsson/build-number@v2
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - name: Wheel ${{ matrix.python }} Linux
+        run: |
+          set -x -e
+          mv bazel-bin/tensorflow_io/.bazelrc .
+          docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
+      - name: Auditwheel ${{ matrix.python }} Linux
+        run: |
+          set -x -e
+          ls dist/*
+          for f in dist/*.whl; do
+            docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/third_party/tf/auditwheel repair --plat manylinux2010_x86_64 $f
+          done
+          sudo chown -R $(id -nu):$(id -ng) .
+          ls wheelhouse/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,12 @@ jobs:
           path: bazel-bin/tensorflow_io
 
   macos-wheel:
+    name: Wheel ${{ matrix.python }} macOS
     needs: macos-bazel
     runs-on: macos-latest
     strategy:
       matrix:
         python: ['3.5', '3.6', '3.7']
-    name: Wheel ${{ matrix.python }} macOS
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1
@@ -127,6 +127,7 @@ jobs:
           path: build/tensorflow_io
 
   linux-wheel:
+    name: Wheel ${{ matrix.python }} Linux
     needs: linux-bazel
     runs-on: ${{ matrix.os }}
     strategy:
@@ -140,7 +141,6 @@ jobs:
             python: '3.7'
           - os: ubuntu-18.04
             python: '3.5'
-    name: Wheel ${{ matrix.python }} Linux
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1
@@ -182,19 +182,11 @@ jobs:
             bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
 
   release:
-    name: release
+    name: Release
     if: github.event_name == 'push'
-    needs: [lint, linux-bazel, macos-bazel]
+    needs: [lint, linux-wheel, macos-wheel]
     runs-on: ubuntu-18.04
     steps:
-      - uses: einaregilsson/build-number@v2
-        with:
-          token: ${{secrets.github_token}}
-      - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: BUILD_NUMBER
-          path: BUILD_NUMBER
       - uses: actions/download-artifact@v1
         with:
           name: macOS-3.5-wheel
@@ -223,14 +215,29 @@ jobs:
           ls -la Linux-3.5-wheel/
           ls -la macOS-3.5-wheel/
 
-  macos-nightly:
+  build-number:
+    name: Build Number
     if: github.event_name == 'push'
     needs: release
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: einaregilsson/build-number@v2
+        with:
+          token: ${{secrets.github_token}}
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: BUILD_NUMBER
+          path: BUILD_NUMBER
+
+  macos-nightly:
+    name: Nightly ${{ matrix.python }} macOS
+    if: github.event_name == 'push'
+    needs: build-number
     runs-on: macos-latest
     strategy:
       matrix:
         python: ['3.5', '3.6', '3.7']
-    name: Nightly ${{ matrix.python }} macOS
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -263,8 +270,9 @@ jobs:
           ls wheelhouse/*
 
   linux-nightly:
+    name: Nightly ${{ matrix.python }} Linux
     if: github.event_name == 'push'
-    needs: release
+    needs: build-number
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -277,7 +285,6 @@ jobs:
             python: '3.7'
           - os: ubuntu-18.04
             python: '3.5'
-    name: Nightly ${{ matrix.python }} Linux
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,10 +232,10 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-18.04
     steps:
-      - uses: einaregilsson/build-number@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo "Build number is $BUILD_NUMBER"
+      - run: |
+          set -e -x
+          BUILD_NUMBER=$(date "+%Y%m%d%H%M%S")
+          echo ${BUILD_NUMBER} > BUILD_NUMBER
       - uses: actions/upload-artifact@v1
         with:
           name: BUILD_NUMBER

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,20 @@ env:
   BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
 
 jobs:
+  build-number:
+    name: Build Number
+    if: github.event_name == 'push'
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: einaregilsson/build-number@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: BUILD_NUMBER
+          path: BUILD_NUMBER
+
   lint:
     name: Lint
     runs-on: ubuntu-18.04
@@ -227,25 +241,10 @@ jobs:
           name: tensorflow-io-release
           path: wheelhouse
 
-  build-number:
-    name: Build Number
-    if: github.event_name == 'push'
-    needs: release
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: einaregilsson/build-number@v2
-        with:
-          token: ${{secrets.github_token}}
-      - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/upload-artifact@v1
-        with:
-          name: BUILD_NUMBER
-          path: BUILD_NUMBER
-
   macos-nightly:
     name: Nightly ${{ matrix.python }} macOS
     if: github.event_name == 'push'
-    needs: build-number
+    needs: [build-number, release]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -288,7 +287,7 @@ jobs:
   linux-nightly:
     name: Nightly ${{ matrix.python }} Linux
     if: github.event_name == 'push'
-    needs: build-number
+    needs: [build-number, release]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
This PR updates GitHub Actions to add release and nightly build in case a commit is pushed to master branch:
1) The release candidate binaries are build and pushed to GitHub artifact.
2) the nightly build is pushed to PyPI.org automatically.

The reason release candidate binary is not pushed to PyPI.org, is that we want to manually decide with commit goes to final release. (Other than push to PyPI.org all other steps for binary build are done automatically though.)


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>