### PR TITLE
Remove Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 # TensorFlow I/O
 
-[![Travis-CI Build Status](https://travis-ci.org/tensorflow/io.svg?branch=master)](https://travis-ci.org/tensorflow/io)
 [![PyPI Status Badge](https://badge.fury.io/py/tensorflow-io.svg)](https://pypi.org/project/tensorflow-io/)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/tfio)](https://cran.r-project.org/package=tfio)
 


### PR DESCRIPTION
We are not relying on Travis anymore so we should remove this uninformative badge. Otherwise it’s misleading that the project seems to be unstable.