### PR TITLE
TensorFlow.org Docs update for v0.10

### DIFF
--- a/docs/tutorials/bigquery.ipynb
+++ b/docs/tutorials/bigquery.ipynb
@@ -167,6 +167,23 @@
     {
       "cell_type": "code",
       "metadata": {
+        "id": "QeBQuayhuvhg",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "try:\n",
+        "  # Use the Colab's preinstalled TensorFlow 2.x\n",
+        "  %tensorflow_version 2.x \n",
+        "except:\n",
+        "  pass"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
         "id": "Tu01THzWcE-J",
         "colab_type": "code",
         "colab": {}
@@ -403,11 +420,11 @@
       "metadata": {
         "id": "wFZcK03-YDm4",
         "colab_type": "code",
+        "outputId": "9a545bc5-e017-4df6-dbf9-fa46bda50bf1",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 118
-        },
-        "outputId": "9a545bc5-e017-4df6-dbf9-fa46bda50bf1"
+        }
       },
       "source": [
         "load_data_into_bigquery(TRAINING_URL, TRAINING_TABLE_ID)\n",
@@ -448,11 +465,11 @@
       "metadata": {
         "id": "CVy3UkDgx2zi",
         "colab_type": "code",
+        "outputId": "67a769b2-cb12-4e26-beaa-c33ade9c5565",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 202
-        },
-        "outputId": "67a769b2-cb12-4e26-beaa-c33ade9c5565"
+        }
       },
       "source": [
         "%%bigquery --use_bqstorage_api\n",
@@ -820,16 +837,16 @@
       "metadata": {
         "id": "gPKrlFCN1y00",
         "colab_type": "code",
+        "outputId": "b2fcd6f3-3ece-46b3-916e-5e675b81c090",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 426
-        },
-        "outputId": "b2fcd6f3-3ece-46b3-916e-5e675b81c090"
+        }
       },
       "source": [
         "model.fit(training_ds, epochs=5)"
       ],
-      "execution_count": 17,
+      "execution_count": 0,
       "outputs": [
         {
           "output_type": "stream",
@@ -898,17 +915,17 @@
       "metadata": {
         "id": "8eGHVkmI5LBT",
         "colab_type": "code",
+        "outputId": "2d42c592-23d1-4f11-d1ef-7db0a0e0f256",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 51
-        },
-        "outputId": "2d42c592-23d1-4f11-d1ef-7db0a0e0f256"
+        }
       },
       "source": [
         "loss, accuracy = model.evaluate(eval_ds)\n",
         "print(\"Accuracy\", accuracy)"
       ],
-      "execution_count": 18,
+      "execution_count": 0,
       "outputs": [
         {
           "output_type": "stream",
@@ -935,11 +952,11 @@
       "metadata": {
         "id": "aMou1t1xngXP",
         "colab_type": "code",
+        "outputId": "f973298c-2a57-48a3-9ca9-e602a6b4b1f9",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 51
-        },
-        "outputId": "f973298c-2a57-48a3-9ca9-e602a6b4b1f9"
+        }
       },
       "source": [
         "sample_x = {\n",
@@ -959,7 +976,7 @@
         "\n",
         "model.predict(sample_x)"
       ],
-      "execution_count": 19,
+      "execution_count": 0,
       "outputs": [
         {
           "output_type": "execute_result",

--- a/docs/tutorials/dicom.ipynb
+++ b/docs/tutorials/dicom.ipynb
@@ -5,6 +5,7 @@
     "colab": {
       "name": "dicom.ipynb",
       "provenance": [],
+      "private_outputs": true,
       "collapsed_sections": [
         "Tce3stUlHN0L"
       ],

--- a/docs/tutorials/dicom.ipynb
+++ b/docs/tutorials/dicom.ipynb
@@ -167,12 +167,28 @@
     {
       "cell_type": "code",
       "metadata": {
+        "id": "NwL3fEMQuZrk",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "try:\n",
+        "  # Use the Colab's preinstalled TensorFlow 2.x\n",
+        "  %tensorflow_version 2.x \n",
+        "except:\n",
+        "  pass"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
         "id": "uUDYyMZRfkX4",
         "colab_type": "code",
         "colab": {}
       },
       "source": [
-        "%tensorflow_version 2.x \n",
         "!pip install tensorflow-io-nightly"
       ],
       "execution_count": 0,
@@ -198,7 +214,20 @@
       "source": [
         "import matplotlib.pyplot as plt\n",
         "import numpy as np\n",
-        "import tensorflow as tf\n",
+        "\n",
+        "import tensorflow as tf"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zK7IEukfuUuF",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "import tensorflow_io as tfio\n",
         "\n",
         "image_bytes = tf.io.read_file('dicom_00000001_000.dcm')\n",

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -102,7 +102,7 @@ def main(argv):
         code_url_prefix=code_url_prefix,
         private_map={'tfio': ['__version__', 'utils', 'version', 'core']},
         # This callback cleans up a lot of aliases caused by internal imports.
-        callbacks=[public_api.local_definitions_filter],
+        callbacks=[],
         search_hints=FLAGS.search_hints,
         site_path=FLAGS.site_path)
 


### PR DESCRIPTION
- Add the missing try/except around the "%tensorflow_version" (These only work in colab).

- Remove the "local definitions filter" from the build_docs script. With the change in the project architecture (Objects are defined in a separate place from where they are exposed) this is just hiding all your symbols.