### PR TITLE
Add graph mode support for HDF5 Dataset and IOTensor

### DIFF
--- a/tensorflow_io/core/python/ops/hdf5_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/hdf5_dataset_ops.py
@@ -57,12 +57,9 @@ class HDF5IODataset(tf.data.Dataset):
           tf.data.Dataset.from_tensor_slices([shape[0]]))
       dataset = tf.data.Dataset.zip((indices_start, indices_stop))
       def f(start, stop):
-        shape = tf.concat(
-            [tf.convert_to_tensor([stop - start], tf.int64), self._shape[1:]],
-            axis=0)
         return core_ops.io_hdf5_readable_read(
-            self._resource, start=start, shape=shape,
-            component=self._component, dtype=self._dtype)
+            self._resource, component=self._component,
+            shape=self._shape, start=start, stop=stop, dtype=self._dtype)
       dataset = dataset.map(f)
       dataset = dataset.unbatch()
 

--- a/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
@@ -23,24 +23,81 @@ import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops
 from tensorflow_io.core.python.ops import io_tensor_ops
 
-class _HDF5IOTensorFunction():
-  """_HDF5IOTensorFunction will translate call"""
-  def __init__(self, function, resource, component, shape, dtype):
-    self._function = function
-    self._resource = resource
-    self._component = component
-    self._length = shape[0]
-    self._shape = tf.TensorShape([None]).concatenate(shape[1:])
-    self._dtype = dtype
-  def __call__(self, start, stop):
-    start, stop, _ = slice(start, stop).indices(self._length)
-    shape = tf.TensorShape([stop - start]).concatenate(self._shape[1:])
-    return self._function(
-        self._resource, start=start, shape=shape,
-        component=self._component, dtype=self._dtype)
+class BaseHDF5GraphIOTensor():
+  """BaseHDF5GraphIOTensor"""
+
+  #=============================================================================
+  # Constructor (private)
+  #=============================================================================
+  def __init__(self,
+               resource,
+               component,
+               shape, dtype,
+               internal=False):
+    with tf.name_scope("BaseHDF5GraphIOTensor"):
+      assert internal
+      self._resource = resource
+      self._component = component
+      self._shape = shape
+      self._dtype = dtype
+      super(BaseHDF5GraphIOTensor, self).__init__()
+
+  #=============================================================================
+  # Accessors
+  #=============================================================================
+
   @property
-  def length(self):
-    return self._length
+  def shape(self):
+    """Returns the `TensorShape` that represents the shape of the tensor."""
+    return self._shape
+
+  @property
+  def dtype(self):
+    """Returns the `dtype` of elements in the tensor."""
+    return self._dtype
+
+  #=============================================================================
+  # String Encoding
+  #=============================================================================
+  def __repr__(self):
+    return "<%s: shape=%s, dtype=%s>" % (
+        self.__class__.__name__, self.shape, self.dtype)
+
+  #=============================================================================
+  # Tensor Type Conversions
+  #=============================================================================
+
+  def to_tensor(self):
+    """Converts this `IOTensor` into a `tf.Tensor`.
+
+    Args:
+      name: A name prefix for the returned tensors (optional).
+
+    Returns:
+      A `Tensor` with value obtained from this `IOTensor`.
+    """
+    return core_ops.io_hdf5_readable_read(
+        self._resource, self._component, self._shape,
+        0, -1, dtype=self._dtype)
+
+  #=============================================================================
+  # Indexing and slicing
+  #=============================================================================
+  def __getitem__(self, key):
+    """Returns the specified piece of this IOTensor."""
+    if isinstance(key, slice):
+      return core_ops.io_hdf5_readable_read(
+          self._resource, self._component, self._shape,
+          key.start, key.stop, dtype=self._dtype)
+    item = core_ops.io_audio_readable_read(
+        self._resource, key, key + 1, dtype=self._dtype)
+    if tf.shape(item)[0] == 0:
+      raise IndexError("index %s is out of range" % key)
+    return item[0]
+
+  def __len__(self):
+    """Returns the total number of items of this IOTensor."""
+    return self._shape[0]
 
 class HDF5IOTensor(io_tensor_ops._CollectionIOTensor): # pylint: disable=protected-access
   """HDF5IOTensor"""
@@ -57,27 +114,25 @@ class HDF5IOTensor(io_tensor_ops._CollectionIOTensor): # pylint: disable=protect
           filename,
           container=scope,
           shared_name="%s/%s" % (filename, uuid.uuid4().hex))
-      columns = [column.decode() for column in columns.numpy().tolist()]
-      elements = []
-      for column in columns:
+      columns = tf.unstack(columns)
+      def f(column):
         shape, dtype = core_ops.io_hdf5_readable_spec(resource, column)
-        shape = tf.TensorShape(shape.numpy())
-        dtype = tf.as_dtype(dtype.numpy())
-        spec = tf.TensorSpec(shape, dtype, column)
-        if shape.rank == 0:
-          value = core_ops.io_hdf5_readable_read(
-              resource, 0, shape, column, dtype)
-          elements.append(
-              io_tensor_ops.ScalarIOTensor(
-                  spec, value, internal=internal))
-        else:
-          function = _HDF5IOTensorFunction(
-              core_ops.io_hdf5_readable_read,
-              resource, column, shape, dtype)
-          elements.append(
-              io_tensor_ops.BaseIOTensor(
-                  spec, function, internal=internal))
-      spec = tuple([e.spec for e in elements])
+        return shape, dtype
+      entries = [f(column) for column in columns]
+      shapes, dtypes = zip(*entries)
+      shapes, dtypes = list(shapes), list(dtypes)
+      dtypes = [tf.as_dtype(dtype.numpy()) for dtype in dtypes]
+
+      entries = [
+          tf.TensorSpec(shape, dtype, column) for (
+              shape, dtype, column) in zip(shapes, dtypes, columns)]
+
+      def g(entry, shape):
+        return BaseHDF5GraphIOTensor(
+            resource, entry.name, shape, entry.dtype,
+            internal=True)
+      elements = [g(entry, shape) for (entry, shape) in zip(entries, shapes)]
+      spec = tuple(entries)
       super(HDF5IOTensor, self).__init__(
           spec, columns, elements,
           internal=internal)

--- a/tensorflow_io/core/python/ops/io_dataset.py
+++ b/tensorflow_io/core/python/ops/io_dataset.py
@@ -187,12 +187,16 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
   def from_hdf5(cls,
                 filename,
                 dataset,
+                spec=None,
                 **kwargs):
     """Creates an `IODataset` from a hdf5 file's dataset object.
 
     Args:
       filename: A string, the filename of a hdf5 file.
       dataset: A string, the dataset name within hdf5 file.
+      spec: A tf.TensorSpec or a dtype (e.g., tf.int64) of the
+        dataset. In graph mode, spec is needed. In eager mode,
+        spec is probed automatically.
       name: A name prefix for the IOTensor (optional).
 
     Returns:
@@ -201,7 +205,7 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
     """
     with tf.name_scope(kwargs.get("name", "IOFromHDF5")):
       return hdf5_dataset_ops.HDF5IODataset(
-          filename, dataset, internal=True)
+          filename, dataset, spec=spec, internal=True)
 
   @classmethod
   def from_avro(cls,

--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -359,11 +359,16 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
   @classmethod
   def from_hdf5(cls,
                 filename,
+                spec=None,
                 **kwargs):
     """Creates an `IOTensor` from an hdf5 file.
 
     Args:
       filename: A string, the filename of an hdf5 file.
+      spec: A dict of `dataset:tf.TensorSpec` or `dataset:dtype`
+        pairs that specify the dataset selected and the tf.TensorSpec
+        or dtype of the dataset. In eager mode the spec is probed
+        automatically. In graph mode spec has to be specified.
       name: A name prefix for the IOTensor (optional).
 
     Returns:
@@ -371,7 +376,8 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
 
     """
     with tf.name_scope(kwargs.get("name", "IOFromHDF5")):
-      return hdf5_io_tensor_ops.HDF5IOTensor(filename, internal=True)
+      return hdf5_io_tensor_ops.HDF5IOTensor(
+          filename, spec=spec, internal=True)
 
   @classmethod
   def from_csv(cls,

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -411,6 +411,74 @@ def fixture_hdf5(request):
 
   return args, func, expected
 
+@pytest.fixture(name="hdf5_graph", scope="module")
+def fixture_hdf5_graph(request):
+  """fixture_hdf5_graph"""
+  import h5py # pylint: disable=import-outside-toplevel
+
+  tmp_path = tempfile.mkdtemp()
+  filename = os.path.join(tmp_path, "test.h5")
+
+  data = list(range(5000))
+
+  string_data = ["D" + str(i) for i in range(5000)]
+
+  complex_data = [(1. + 2.j) * i for i in range(5000)]
+
+  with h5py.File(filename, 'w') as f:
+    f.create_dataset('uint8', data=np.asarray(data, np.uint8) % 256, dtype='u1')
+    f.create_dataset('uint16', data=np.asarray(data, np.uint16), dtype='u2')
+    f.create_dataset('uint32', data=np.asarray(data, np.uint32), dtype='u4')
+    f.create_dataset('uint64', data=np.asarray(data, np.uint64), dtype='u8')
+    f.create_dataset('int8', data=np.asarray(data, np.int8) % 128, dtype='i1')
+    f.create_dataset('int16', data=np.asarray(data, np.int16), dtype='i2')
+    f.create_dataset('int32', data=np.asarray(data, np.int32), dtype='i4')
+    f.create_dataset('int64', data=np.asarray(data, np.int64), dtype='i8')
+    f.create_dataset('float32', data=np.asarray(data, np.float32), dtype='f4')
+    f.create_dataset('float64', data=np.asarray(data, np.float64), dtype='f8')
+    f.create_dataset('complex64', data=np.asarray(complex_data, np.complex64))
+    f.create_dataset('complex128', data=np.asarray(complex_data, np.complex128))
+    f.create_dataset('string', data=np.asarray(string_data, '<S5'))
+  args = filename
+  def func(args):
+    """func"""
+    u8 = tfio.IODataset.from_hdf5(args, dataset='/uint8', spec=tf.uint8)
+    u16 = tfio.IODataset.from_hdf5(args, dataset='/uint16', spec=tf.uint16)
+    u32 = tfio.IODataset.from_hdf5(args, dataset='/uint32', spec=tf.uint32)
+    u64 = tfio.IODataset.from_hdf5(args, dataset='/uint64', spec=tf.uint64)
+    i8 = tfio.IODataset.from_hdf5(args, dataset='/int8', spec=tf.int8)
+    i16 = tfio.IODataset.from_hdf5(args, dataset='/int16', spec=tf.int16)
+    i32 = tfio.IODataset.from_hdf5(args, dataset='/int32', spec=tf.int32)
+    i64 = tfio.IODataset.from_hdf5(args, dataset='/int64', spec=tf.int64)
+    f32 = tfio.IODataset.from_hdf5(args, dataset='/float32', spec=tf.float32)
+    f64 = tfio.IODataset.from_hdf5(args, dataset='/float64', spec=tf.float64)
+    c64 = tfio.IODataset.from_hdf5(
+        args, dataset='/complex64', spec=tf.complex64)
+    c128 = tfio.IODataset.from_hdf5(
+        args, dataset='/complex128', spec=tf.complex128)
+    ss = tfio.IODataset.from_hdf5(args, dataset='/string', spec=tf.string)
+    return tf.data.Dataset.zip(
+        (u8, u16, u32, u64, i8, i16, i32, i64, f32, f64, c64, c128, ss))
+  expected = list(zip(
+      (np.asarray(data, np.uint8) % 256).tolist(),
+      np.asarray(data, np.uint16).tolist(),
+      np.asarray(data, np.uint32).tolist(),
+      np.asarray(data, np.uint64).tolist(),
+      (np.asarray(data, np.int8) % 128) .tolist(),
+      np.asarray(data, np.int16).tolist(),
+      np.asarray(data, np.int32).tolist(),
+      np.asarray(data, np.int64).tolist(),
+      np.asarray(data, np.float32).tolist(),
+      np.asarray(data, np.float64).tolist(),
+      np.asarray(complex_data, np.complex64).tolist(),
+      np.asarray(complex_data, np.complex128).tolist(),
+      np.asarray(string_data, '<S5').tolist()))
+  def fin():
+    shutil.rmtree(tmp_path)
+  request.addfinalizer(fin)
+
+  return args, func, expected
+
 @pytest.fixture(name="to_file")
 def fixture_to_file(request):
   """fixture_to_file"""
@@ -777,14 +845,9 @@ def test_io_dataset_for_training(fixture_lookup, io_dataset_fixture):
         pytest.param("audio_ogg", 2),
         pytest.param("audio_flac", None),
         pytest.param("audio_flac", 2),
+        pytest.param("hdf5_graph", None),
         pytest.param(
-            "hdf5", None,
-            marks=[
-                pytest.mark.skip(reason="TODO"),
-            ],
-        ),
-        pytest.param(
-            "hdf5", 2,
+            "hdf5_graph", 2,
             marks=[
                 pytest.mark.skip(reason="TODO"),
             ],


### PR DESCRIPTION
This PR adds graph mode support for HDF5 IODataset and IOTensor by require a spec args provided by user (either a tf.TensorSpec, or a tf.dtypes.DType).

Note hdf5 dataset could not be run in parallel, mostly likely caused by hdf5 not compiled with thread safe. This is to be fixed later.

Example usage for IOTensor:
```
tfio.IOTensor.from_hdf5(filename, spec={'/float64': tf.float64})('/float64')
```

Example usage for IODataset:
```
tfio.IODataset.from_hdf5(filename, dataset='/float64', spec=tf.float64)
```

This PR fixes #710 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>