### PR TITLE
Small fixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -261,6 +261,8 @@ pip3_import(
     requirements = "@com_github_grpc_grpc//:requirements.bazel.txt",
 )
 
+load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
+
 pip_repositories()
 
 pip_install()
@@ -676,10 +678,6 @@ llvm_toolchain(
     name = "llvm_toolchain",
     llvm_version = "8.0.0",
 )
-
-load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")
-
-llvm_register_toolchains()
 
 http_archive(
     name = "vorbis",

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -21,6 +21,7 @@ py_binary(
     main = "pylint_python.py",
     deps = [
         requirement("pylint"),
+        requirement("wrapt"),
         requirement("astroid"),
         requirement("isort"),
         requirement("lazy_object_proxy"),

--- a/tools/lint/lint.tpl
+++ b/tools/lint/lint.tpl
@@ -54,7 +54,7 @@ set -e
     cd "$BUILD_WORKSPACE_DIRECTORY" && \
     for i in \
         $( \
-            find -f tensorflow_io tests -type f \
+            find tensorflow_io tests -type f \
                 \( -name '*.py' \) \
         ) ; do \
         pylint_func $mode "$i" ; \


### PR DESCRIPTION
This PR adds a couple of small fixes. One is that in lint,
`find` command has an extra `-f` (`find <path>` instead of `find -f <path>`).
Another fix is that grpc_python_dependencies is not actually invoked,
also removed unneeded llvm_register_toolchains invoke.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>