### PR TITLE
Fix Windows Nightly build where build number env was not populated

### DIFF
--- a/.github/workflows/build.windows.sh
+++ b/.github/workflows/build.windows.sh
@@ -1,8 +1,0 @@
-set -e -x
-
-python3 --version
-
-export MSYS2_ARG_CONV_EXCL="//"
-${BAZEL_PATH:=bazel} build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so
-
-exit $?

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,7 +456,7 @@ jobs:
           @echo on
           python --version
           python -m pip install -U wheel setuptools
-          python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
+          python setup.py --data bazel-bin -q bdist_wheel --nightly %BUILD_NUMBER%
           ls -la dist
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
The build number was not populated so it did not reach to PyPI.org,
This PR fixes it.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>