### PR TITLE
Add structured support for prometheus dataset

### DIFF
--- a/tensorflow_io/core/go/prometheus.go
+++ b/tensorflow_io/core/go/prometheus.go
@@ -16,8 +16,49 @@ import (
 	"github.com/prometheus/prom2json"
 )
 
+//export QuerySpecs
+func QuerySpecs(endpoint string, query string, timestamp int64, jobs [][]byte, instances [][]byte, names [][]byte) int {
+	client, err := api.NewClient(api.Config{
+		Address: endpoint,
+	})
+	if err != nil {
+		return -1
+	}
+	r := v1.Range{
+		Start: time.Unix(timestamp/1000, (timestamp%1000)*1000000),
+		End:   time.Unix(timestamp/1000, (timestamp%1000)*1000000),
+		Step:  time.Second,
+	}
+	v, err := v1.NewAPI(client).QueryRange(context.Background(), query, r)
+	if err != nil {
+		return -1
+	}
+	if m, ok := v.(model.Matrix); ok && m.Len() > 0 {
+		for index := 0; index < len(m) && index < len(jobs) && index < len(instances) && index < len(names); index++ {
+			job := string(m[index].Metric["job"])
+			if len(job) >= cap(jobs[index]) {
+				job = job[:cap(jobs[index])]
+			}
+			copy(jobs[index], []byte(job))
+			instance := string(m[index].Metric["instance"])
+			if len(instance) >= cap(instances[index]) {
+				instance = instance[:cap(instances[index])]
+			}
+			copy(instances[index], []byte(instance))
+			name := string(m[index].Metric["__name__"])
+			if len(name) >= cap(names[index]) {
+				name = name[:cap(names[index])]
+			}
+			copy(names[index], []byte(name))
+		}
+		return len(m)
+	}
+	return 0
+
+}
+
 //export QueryRange
-func QueryRange(endpoint string, query string, start int64, end int64, timestamp []int64, value []float64) int {
+func QueryRange(endpoint string, query string, start int64, end int64, job string, instance string, name string, timestamp []int64, value []float64) int {
 	client, err := api.NewClient(api.Config{
 		Address: endpoint,
 	})
@@ -34,14 +75,17 @@ func QueryRange(endpoint string, query string, start int64, end int64, timestamp
 		return -1
 	}
 	if m, ok := v.(model.Matrix); ok && m.Len() > 0 {
+		for index := 0; index < len(m); index++ {
+			if m[index].Metric["job"] == model.LabelValue(job) && m[index].Metric["instance"] == model.LabelValue(instance) && m[index].Metric["__name__"] == model.LabelValue(name) {
+				for i := 0; i < len(m[index].Values) && i < len(timestamp) && i < len(value); i++ {
+					v := m[index].Values[i]
+					timestamp[i] = int64(v.Timestamp)
+					value[i] = float64(v.Value)
+				}
 
-		for i := 0; i < len(m[0].Values) && i < len(timestamp) && i < len(value); i++ {
-			v := m[0].Values[i]
-			timestamp[i] = int64(v.Timestamp)
-			value[i] = float64(v.Value)
+				return len(m[index].Values)
+			}
 		}
-
-		return len(m[0].Values)
 	}
 	return 0
 }
@@ -91,7 +135,7 @@ func main() {
 	end := time.Now().Unix() * 1000
 	start := end - 5*1000
 	fmt.Println(start, end)
-	returned := QueryRange("http://localhost:9090", "coredns_dns_request_count_total", start, end, key, val)
+	returned := QueryRange("http://localhost:9090", "coredns_dns_request_count_total", start, end, "", "", "", key, val)
 	fmt.Println(returned)
 	for i := range key {
 		fmt.Printf("%d, %q, %v\n", i, model.TimeFromUnix(key[i]).Time(), val[i])

--- a/tensorflow_io/core/kernels/prometheus_kernels.cc
+++ b/tensorflow_io/core/kernels/prometheus_kernels.cc
@@ -166,9 +166,12 @@ class PrometheusReadableResource : public ResourceBase {
     GoString query_go = {query_.c_str(), static_cast<int64>(query_.size())};
 
     for (size_t index = 0; index < jobs.size(); index++) {
-      GoString job_go = {jobs[index].data(), jobs[index].size()};
-      GoString instance_go = {instances[index].data(), instances[index].size()};
-      GoString name_go = {names[index].data(), names[index].size()};
+      GoString job_go = {jobs[index].data(),
+                         static_cast<ptrdiff_t>(jobs[index].size())};
+      GoString instance_go = {instances[index].data(),
+                              static_cast<ptrdiff_t>(instances[index].size())};
+      GoString name_go = {names[index].data(),
+                          static_cast<ptrdiff_t>(names[index].size())};
       GoSlice timestamp_go = {timestamp->flat<int64>().data(),
                               timestamp->NumElements(),
                               timestamp->NumElements()};

--- a/tensorflow_io/core/kernels/prometheus_kernels.cc
+++ b/tensorflow_io/core/kernels/prometheus_kernels.cc
@@ -21,24 +21,15 @@ limitations under the License.
 namespace tensorflow {
 namespace data {
 namespace {
-class SeriesReadableResourceBase : public ResourceBase {
- public:
-  virtual Status Init(const string& input,
-                      const std::vector<string>& metadata) = 0;
-  virtual Status Spec(int64* start, int64* stop) = 0;
-  virtual Status Read(const int64 start, const int64 stop,
-                      std::function<Status(const TensorShape& shape,
-                                           Tensor** timestamp, Tensor** value)>
-                          allocate_func) = 0;
-};
 
-class PrometheusReadableResource : public SeriesReadableResourceBase {
+class PrometheusReadableResource : public ResourceBase {
  public:
   PrometheusReadableResource(Env* env) : env_(env) {}
   ~PrometheusReadableResource() {}
 
-  Status Init(const string& input,
-              const std::vector<string>& metadata) override {
+  Status Init(const string& input, const std::vector<string>& metadata,
+              std::function<Status(const TensorShape& shape, Tensor** metrics)>
+                  allocate_func) {
     mutex_lock l(mu_);
 
     query_ = input;
@@ -76,39 +67,120 @@ class PrometheusReadableResource : public SeriesReadableResourceBase {
       stop_ = offset;
     }
     start_ = stop_ - length * 1000;
-    return Status::OK();
-  }
-  Status Spec(int64* start, int64* stop) override {
-    mutex_lock l(mu_);
-    *start = start_;
-    *stop = stop_;
-    return Status::OK();
-  }
-  Status Read(const int64 start, const int64 stop,
-              std::function<Status(const TensorShape& shape, Tensor** timestamp,
-                                   Tensor** value)>
-                  allocate_func) override {
-    mutex_lock l(mu_);
-    int64 interval = (stop - start) / 1000;
-
-    Tensor* value;
-    Tensor* timestamp;
-    TF_RETURN_IF_ERROR(
-        allocate_func(TensorShape({interval}), &timestamp, &value));
 
     GoString endpoint_go = {endpoint_.c_str(),
                             static_cast<int64>(endpoint_.size())};
     GoString query_go = {query_.c_str(), static_cast<int64>(query_.size())};
 
-    GoSlice timestamp_go = {timestamp->flat<int64>().data(),
-                            timestamp->NumElements(), timestamp->NumElements()};
-    GoSlice value_go = {value->flat<double>().data(), value->NumElements(),
-                        value->NumElements()};
-
-    GoInt returned =
-        QueryRange(endpoint_go, query_go, start, stop, timestamp_go, value_go);
+    GoSlice jobs_go = {nullptr, 0, 0};
+    GoSlice instances_go = {nullptr, 0, 0};
+    GoSlice names_go = {nullptr, 0, 0};
+    GoInt returned = QuerySpecs(endpoint_go, query_go, start_, jobs_go,
+                                instances_go, names_go);
     if (returned < 0) {
       return errors::InvalidArgument("unable to query prometheus");
+    }
+    Tensor* metrics;
+    TF_RETURN_IF_ERROR(allocate_func(TensorShape({returned, 3}), &metrics));
+
+    // The buffer is used to hold memory in C++ and pass to Golang
+    // Mamory management are done in C++
+    // TODO: Much of the logic could be pushed to Golang by passing
+    // Tensor directly.
+    std::vector<string> buffer;
+    std::vector<GoSlice> jobs_v;
+    for (GoInt i = 0; i < returned; i++) {
+      buffer.push_back(string());
+      buffer.back().resize(1024);
+      jobs_v.push_back(GoSlice{&buffer.back()[0], 1024 - 1, 1024 - 1});
+    }
+    std::vector<GoSlice> instances_v;
+    for (GoInt i = 0; i < returned; i++) {
+      buffer.push_back(string());
+      buffer.back().resize(1024);
+      instances_v.push_back(GoSlice{&buffer.back()[0], 1024 - 1, 1024 - 1});
+    }
+    std::vector<GoSlice> names_v;
+    for (GoInt i = 0; i < returned; i++) {
+      buffer.push_back(string());
+      buffer.back().resize(1024);
+      names_v.push_back(GoSlice{&buffer.back()[0], 1024 - 1, 1024 - 1});
+    }
+    jobs_go.data = &jobs_v[0];
+    jobs_go.len = returned;
+    jobs_go.cap = returned;
+    instances_go.data = &instances_v[0];
+    instances_go.len = returned;
+    instances_go.cap = returned;
+    names_go.data = &names_v[0];
+    names_go.len = returned;
+    names_go.cap = returned;
+    returned = QuerySpecs(endpoint_go, query_go, start_, jobs_go, instances_go,
+                          names_go);
+    if (returned < 0) {
+      return errors::InvalidArgument("unable to query prometheus");
+    }
+    for (size_t index = 0; index < returned; index++) {
+      string job((char*)(jobs_v[index].data));
+      string instance((char*)(instances_v[index].data));
+      string name((char*)(names_v[index].data));
+      jobs_.push_back(job);
+      instances_.push_back(instance);
+      names_.push_back(name);
+      metrics->tensor<string, 2>()(index, 0) = job;
+      metrics->tensor<string, 2>()(index, 1) = instance;
+      metrics->tensor<string, 2>()(index, 2) = name;
+    }
+    return Status::OK();
+  }
+  Status Spec(int64* start, int64* stop) {
+    mutex_lock l(mu_);
+    *start = start_;
+    *stop = stop_;
+    return Status::OK();
+  }
+  Status Read(const int64 start, const int64 stop, std::vector<string>& jobs,
+              std::vector<string>& instances, std::vector<string>& names,
+              std::function<Status(const TensorShape& timestamp_shape,
+                                   const TensorShape& value_shape,
+                                   Tensor** timestamp, Tensor** value)>
+                  allocate_func) {
+    mutex_lock l(mu_);
+    int64 interval = (stop - start) / 1000;
+
+    if (jobs.size() != instances.size() || jobs.size() != names.size()) {
+      return errors::InvalidArgument(
+          "jobs, instances, names must be equal: ", jobs.size(), " vs. ",
+          instances.size(), " vs. ", names.size());
+    }
+
+    Tensor* value;
+    Tensor* timestamp;
+    TF_RETURN_IF_ERROR(
+        allocate_func(TensorShape({interval}),
+                      TensorShape({static_cast<int64>(names.size()), interval}),
+                      &timestamp, &value));
+
+    GoString endpoint_go = {endpoint_.c_str(),
+                            static_cast<int64>(endpoint_.size())};
+    GoString query_go = {query_.c_str(), static_cast<int64>(query_.size())};
+
+    for (size_t index = 0; index < jobs.size(); index++) {
+      GoString job_go = {jobs[index].data(), jobs[index].size()};
+      GoString instance_go = {instances[index].data(), instances[index].size()};
+      GoString name_go = {names[index].data(), names[index].size()};
+      GoSlice timestamp_go = {timestamp->flat<int64>().data(),
+                              timestamp->NumElements(),
+                              timestamp->NumElements()};
+      double* value_p = (double*)(value->flat<double>().data()) +
+                        index * timestamp->NumElements();
+      GoSlice value_go = {value_p, timestamp->NumElements(),
+                          timestamp->NumElements()};
+      GoInt returned = QueryRange(endpoint_go, query_go, start, stop, job_go,
+                                  instance_go, name_go, timestamp_go, value_go);
+      if (returned < 0) {
+        return errors::InvalidArgument("unable to query prometheus");
+      }
     }
 
     return Status::OK();
@@ -125,6 +197,9 @@ class PrometheusReadableResource : public SeriesReadableResourceBase {
   string endpoint_ GUARDED_BY(mu_);
   int64 start_ GUARDED_BY(mu_);
   int64 stop_ GUARDED_BY(mu_);
+  std::vector<string> jobs_ GUARDED_BY(mu_);
+  std::vector<string> instances_ GUARDED_BY(mu_);
+  std::vector<string> names_ GUARDED_BY(mu_);
 };
 
 class PrometheusReadableInitOp
@@ -150,7 +225,14 @@ class PrometheusReadableInitOp
       metadata.push_back(metadata_tensor->flat<string>()(i));
     }
 
-    OP_REQUIRES_OK(context, resource_->Init(input, metadata));
+    OP_REQUIRES_OK(
+        context,
+        resource_->Init(
+            input, metadata,
+            [&](const TensorShape& shape, Tensor** metrics) -> Status {
+              TF_RETURN_IF_ERROR(context->allocate_output(1, shape, metrics));
+              return Status::OK();
+            }));
   }
   Status CreateResource(PrometheusReadableResource** resource)
       EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
@@ -216,16 +298,27 @@ class PrometheusReadableReadOp : public OpKernel {
     OP_REQUIRES_OK(context, context->input("stop", &stop_tensor));
     const int64 stop = stop_tensor->scalar<int64>()();
 
+    const Tensor* metrics_tensor;
+    OP_REQUIRES_OK(context, context->input("metrics", &metrics_tensor));
+    std::vector<string> jobs, instances, names;
+    for (int64 i = 0; i < metrics_tensor->NumElements() / 3; i++) {
+      jobs.push_back(metrics_tensor->tensor<string, 2>()(i, 0));
+      instances.push_back(metrics_tensor->tensor<string, 2>()(i, 1));
+      names.push_back(metrics_tensor->tensor<string, 2>()(i, 2));
+    }
+
     OP_REQUIRES_OK(
         context,
-        resource->Read(
-            start, stop,
-            [&](const TensorShape& shape, Tensor** timestamp,
-                Tensor** value) -> Status {
-              TF_RETURN_IF_ERROR(context->allocate_output(0, shape, timestamp));
-              TF_RETURN_IF_ERROR(context->allocate_output(1, shape, value));
-              return Status::OK();
-            }));
+        resource->Read(start, stop, jobs, instances, names,
+                       [&](const TensorShape& timestamp_shape,
+                           const TensorShape& value_shape, Tensor** timestamp,
+                           Tensor** value) -> Status {
+                         TF_RETURN_IF_ERROR(context->allocate_output(
+                             0, timestamp_shape, timestamp));
+                         TF_RETURN_IF_ERROR(
+                             context->allocate_output(1, value_shape, value));
+                         return Status::OK();
+                       }));
   }
 
  private:

--- a/tensorflow_io/core/ops/prometheus_ops.cc
+++ b/tensorflow_io/core/ops/prometheus_ops.cc
@@ -25,10 +25,12 @@ REGISTER_OP("IO>PrometheusReadableInit")
     .Input("input: string")
     .Input("metadata: string")
     .Output("resource: resource")
+    .Output("metrics: string")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       c->set_output(0, c->Scalar());
+      c->set_output(1, c->MakeShape({c->UnknownDim(), 3}));
       return Status::OK();
     });
 
@@ -46,11 +48,12 @@ REGISTER_OP("IO>PrometheusReadableRead")
     .Input("input: resource")
     .Input("start: int64")
     .Input("stop: int64")
+    .Input("metrics: string")
     .Output("timestamp: int64")
     .Output("value: float64")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       c->set_output(0, c->MakeShape({c->UnknownDim()}));
-      c->set_output(1, c->MakeShape({c->UnknownDim()}));
+      c->set_output(1, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
       return Status::OK();
     });
 

--- a/tensorflow_io/core/python/experimental/io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/io_dataset_ops.py
@@ -198,6 +198,35 @@ class IODataset(io_dataset.IODataset):
           filename, spec=spec, internal=True)
 
   @classmethod
+  def from_prometheus(cls,
+                      query,
+                      length,
+                      offset=None,
+                      endpoint=None,
+                      spec=None):
+    """Creates an `GraphIODataset` from a prometheus endpoint.
+
+    Args:
+      query: A string, the query string for prometheus.
+      length: An integer, the length of the query (in seconds).
+      offset: An integer, the a millisecond-precision timestamp, by default
+        the time when graph runs.
+      endpoint: A string, the server address of prometheus, by default
+        `http://localhost:9090`.
+      spec: A structured tf.TensorSpec of the dataset.
+        The format should be {"job": {"instance": {"name": tf.TensorSpec}}}.
+        In graph mode, spec is needed. In eager mode,
+        spec is probed automatically.
+      name: A name prefix for the IODataset (optional).
+
+    Returns:
+      A `IODataset`.
+    """
+    from tensorflow_io.core.python.ops import prometheus_dataset_ops # pylint: disable=import-outside-toplevel
+    return prometheus_dataset_ops.PrometheusIODataset(
+        query, length, offset=offset, endpoint=endpoint, spec=spec)
+
+  @classmethod
   def to_file(cls,
               dataset,
               filename,

--- a/tensorflow_io/core/python/ops/io_dataset.py
+++ b/tensorflow_io/core/python/ops/io_dataset.py
@@ -335,7 +335,8 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
                       query,
                       length,
                       offset=None,
-                      endpoint=None):
+                      endpoint=None,
+                      spec=None):
     """Creates an `GraphIODataset` from a prometheus endpoint.
 
     Args:
@@ -345,13 +346,17 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
         the time when graph runs.
       endpoint: A string, the server address of prometheus, by default
         `http://localhost:9090`.
+      spec: A structured tf.TensorSpec of the dataset.
+        The format should be {"job": {"instance": {"name": tf.TensorSpec}}}.
+        In graph mode, spec is needed. In eager mode,
+        spec is probed automatically.
       name: A name prefix for the IODataset (optional).
 
     Returns:
       A `IODataset`.
     """
     return GraphIODataset.from_prometheus(
-        query, length, offset=offset, endpoint=endpoint)
+        query, length, offset=offset, endpoint=endpoint, spec=spec)
 
 class StreamIODataset(io_dataset_ops._StreamIODataset):  # pylint: disable=protected-access
   """StreamIODataset
@@ -490,7 +495,8 @@ class GraphIODataset(tf.data.Dataset):
                       query,
                       length,
                       offset=None,
-                      endpoint=None):
+                      endpoint=None,
+                      spec=None):
     """Creates an `GraphIODataset` from a prometheus endpoint.
 
     Args:
@@ -500,6 +506,10 @@ class GraphIODataset(tf.data.Dataset):
         the time when graph runs.
       endpoint: A string, the server address of prometheus, by default
         `http://localhost:9090`.
+      spec: A structured tf.TensorSpec of the dataset.
+        The format should be {"job": {"instance": {"name": tf.TensorSpec}}}.
+        In graph mode, spec is needed. In eager mode,
+        spec is probed automatically.
       name: A name prefix for the IODataset (optional).
 
     Returns:
@@ -507,4 +517,4 @@ class GraphIODataset(tf.data.Dataset):
     """
     from tensorflow_io.core.python.ops import prometheus_dataset_ops # pylint: disable=import-outside-toplevel
     return prometheus_dataset_ops.PrometheusGraphIODataset(
-        query, length, offset=offset, endpoint=endpoint)
+        query, length, offset=offset, endpoint=endpoint, spec=spec)

--- a/tensorflow_io/core/python/ops/io_dataset.py
+++ b/tensorflow_io/core/python/ops/io_dataset.py
@@ -330,34 +330,6 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
       return pcap_dataset_ops.PcapIODataset(
           filename, internal=True, **kwargs)
 
-  @classmethod
-  def from_prometheus(cls,
-                      query,
-                      length,
-                      offset=None,
-                      endpoint=None,
-                      spec=None):
-    """Creates an `GraphIODataset` from a prometheus endpoint.
-
-    Args:
-      query: A string, the query string for prometheus.
-      length: An integer, the length of the query (in seconds).
-      offset: An integer, the a millisecond-precision timestamp, by default
-        the time when graph runs.
-      endpoint: A string, the server address of prometheus, by default
-        `http://localhost:9090`.
-      spec: A structured tf.TensorSpec of the dataset.
-        The format should be {"job": {"instance": {"name": tf.TensorSpec}}}.
-        In graph mode, spec is needed. In eager mode,
-        spec is probed automatically.
-      name: A name prefix for the IODataset (optional).
-
-    Returns:
-      A `IODataset`.
-    """
-    return GraphIODataset.from_prometheus(
-        query, length, offset=offset, endpoint=endpoint, spec=spec)
-
 class StreamIODataset(io_dataset_ops._StreamIODataset):  # pylint: disable=protected-access
   """StreamIODataset
 
@@ -489,32 +461,3 @@ class GraphIODataset(tf.data.Dataset):
             resource, dtype, internal=True)
 
       return None
-
-  @classmethod
-  def from_prometheus(cls,
-                      query,
-                      length,
-                      offset=None,
-                      endpoint=None,
-                      spec=None):
-    """Creates an `GraphIODataset` from a prometheus endpoint.
-
-    Args:
-      query: A string, the query string for prometheus.
-      length: An integer, the length of the query (in seconds).
-      offset: An integer, the a millisecond-precision timestamp, by default
-        the time when graph runs.
-      endpoint: A string, the server address of prometheus, by default
-        `http://localhost:9090`.
-      spec: A structured tf.TensorSpec of the dataset.
-        The format should be {"job": {"instance": {"name": tf.TensorSpec}}}.
-        In graph mode, spec is needed. In eager mode,
-        spec is probed automatically.
-      name: A name prefix for the IODataset (optional).
-
-    Returns:
-      A `IODataset`.
-    """
-    from tensorflow_io.core.python.ops import prometheus_dataset_ops # pylint: disable=import-outside-toplevel
-    return prometheus_dataset_ops.PrometheusGraphIODataset(
-        query, length, offset=offset, endpoint=endpoint, spec=spec)

--- a/tensorflow_io/core/python/ops/prometheus_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/prometheus_dataset_ops.py
@@ -119,7 +119,7 @@ class PrometheusScrapeStreamIODataset(tf.data.Dataset):
 
       interval = 1000000 if interval is None else interval
 
-      dataset = tf.data.Dataset.range(0, 10, 1)
+      dataset = tf.data.experimental.Counter(start=0, step=1, dtype=tf.int64)
       dataset = dataset.map(lambda i: golang_ops.io_prometheus_scrape(metric, endpoint, i))
       dataset = dataset.apply(sleep(interval))
 

--- a/tensorflow_io/core/python/ops/prometheus_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/prometheus_dataset_ops.py
@@ -29,7 +29,7 @@ class PrometheusGraphIODataset(tf.data.Dataset):
                length,
                offset=None,
                endpoint=None,
-               internal=True):
+               spec=None, internal=True):
     """PrometheusGraphIODataset."""
     with tf.name_scope("PrometheusGraphIODataset"):
       assert internal
@@ -40,7 +40,49 @@ class PrometheusGraphIODataset(tf.data.Dataset):
         metadata.append("offset=%d" % offset)
       if endpoint is not None:
         metadata.append("endpoint=%d" % endpoint)
-      resource = golang_ops.io_prometheus_readable_init(query, metadata)
+      resource, metrics = golang_ops.io_prometheus_readable_init(
+          query, metadata)
+      # Construct spec in eager mode, and take spec from user in graph mode.
+      if spec is None:
+        spec = {}
+        metrics = tf.unstack(metrics)
+        jobs = list({e[0].numpy().decode() for e in metrics})
+        for job in jobs:
+          entries_by_job = [e for e in metrics if e[0] == job]
+          instances = list({e[1].numpy().decode() for e in entries_by_job})
+          spec_by_job = {}
+          for instance in instances:
+            entries_by_instance = [
+                e for e in entries_by_job if e[1] == instance]
+            spec_by_instance = {}
+            for e in entries_by_instance:
+              spec_by_instance[e[2].numpy().decode()] = tf.TensorSpec(
+                  [], tf.float64, e[2].numpy().decode())
+            spec_by_job[instance] = spec_by_instance
+          spec[job] = spec_by_job
+      # Map spec to entries of 3 tuple (job, instance, name)
+      class MetricEntry():
+        def __init__(self, job, instance, name):
+          self.job = job
+          self.instance = instance
+          self.name = name
+      entries = {}
+      for job, spec_by_job in spec.items():
+        entries_by_job = {}
+        for instance, spec_by_instance in spec_by_job.items():
+          entries_by_instance = {}
+          for name in spec_by_instance.keys():
+            entries_by_instance[name] = MetricEntry(job, instance, name)
+          entries_by_job[instance] = entries_by_instance
+        entries[job] = entries_by_job
+      flatten = tf.nest.flatten(entries)
+      metrics = [tf.stack([e.job, e.instance, e.name]) for e in flatten]
+      metrics = tf.stack(metrics)
+      def f(start, stop):
+        timestamp, value = golang_ops.io_prometheus_readable_read(
+            resource, start=start, stop=stop, metrics=metrics)
+        value = tf.unstack(value, num=len(flatten))
+        return timestamp, tf.nest.pack_sequence_as(entries, value)
 
       step = 1 * 1000 # 1 second
 
@@ -50,9 +92,7 @@ class PrometheusGraphIODataset(tf.data.Dataset):
       indices_stop = indices_start.skip(1).concatenate(
           tf.data.Dataset.from_tensor_slices([stop]))
       dataset = tf.data.Dataset.zip((indices_start, indices_stop))
-      dataset = dataset.map(
-          lambda start, stop: golang_ops.io_prometheus_readable_read(
-              resource, start, stop))
+      dataset = dataset.map(f)
       dataset = dataset.unbatch()
       self._dataset = dataset
       super(PrometheusGraphIODataset, self).__init__(

--- a/tensorflow_io/core/python/ops/prometheus_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/prometheus_dataset_ops.py
@@ -21,8 +21,8 @@ import tensorflow as tf
 from tensorflow.python.data.experimental.ops.sleep import sleep
 from tensorflow_io.core.python.ops import golang_ops
 
-class PrometheusGraphIODataset(tf.data.Dataset):
-  """PrometheusGraphIODataset"""
+class PrometheusIODataset(tf.data.Dataset):
+  """PrometheusIODataset"""
 
   def __init__(self,
                query,
@@ -30,8 +30,8 @@ class PrometheusGraphIODataset(tf.data.Dataset):
                offset=None,
                endpoint=None,
                spec=None, internal=True):
-    """PrometheusGraphIODataset."""
-    with tf.name_scope("PrometheusGraphIODataset"):
+    """PrometheusIODataset."""
+    with tf.name_scope("PrometheusIODataset"):
       assert internal
 
       metadata = []
@@ -95,7 +95,7 @@ class PrometheusGraphIODataset(tf.data.Dataset):
       dataset = dataset.map(f)
       dataset = dataset.unbatch()
       self._dataset = dataset
-      super(PrometheusGraphIODataset, self).__init__(
+      super(PrometheusIODataset, self).__init__(
           self._dataset._variant_tensor) # pylint: disable=protected-access
 
   def _inputs(self):
@@ -106,7 +106,7 @@ class PrometheusGraphIODataset(tf.data.Dataset):
     return self._dataset.element_spec
 
 class PrometheusScrapeStreamIODataset(tf.data.Dataset):
-  """PrometheusScrapeStreamGraphIODataset"""
+  """PrometheusScrapeStreamIODataset"""
 
   def __init__(self,
                metric,

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -199,7 +199,7 @@ def fixture_prometheus():
   offset = int(round(time.time() * 1000))
   args = "coredns_dns_request_count_total"
   def func(q):
-    v = tfio.IODataset.from_prometheus(q, 5, offset=offset)
+    v = tfio.experimental.IODataset.from_prometheus(q, 5, offset=offset)
     v = v.map(lambda timestamp, value: (
         timestamp,
         value['coredns']['localhost:9153']['coredns_dns_request_count_total']))
@@ -217,7 +217,7 @@ def fixture_prometheus_graph():
   offset = int(round(time.time() * 1000))
   args = "up"
   def func(q):
-    v = tfio.IODataset.from_prometheus(
+    v = tfio.experimental.IODataset.from_prometheus(
         q, 5, offset=offset,
         spec={
             'coredns': {

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -200,9 +200,42 @@ def fixture_prometheus():
   args = "coredns_dns_request_count_total"
   def func(q):
     v = tfio.IODataset.from_prometheus(q, 5, offset=offset)
-    v = v.map(lambda v: tf.stack([tf.cast(v.timestamp - offset, tf.float64), v.value]))
+    v = v.map(lambda timestamp, value: (
+        timestamp,
+        value['coredns']['localhost:9153']['coredns_dns_request_count_total']))
+    v = v.map(lambda timestamp, value: (
+        tf.stack([tf.cast(timestamp - offset, tf.float64), value])))
     return v
   expected = [[np.float64(i), 6.0] for i in range(-5000, 0, 1000)]
+
+  return args, func, expected
+
+@pytest.fixture(name="prometheus_graph")
+def fixture_prometheus_graph():
+  """fixture_prometheus_graph"""
+
+  offset = int(round(time.time() * 1000))
+  args = "up"
+  def func(q):
+    v = tfio.IODataset.from_prometheus(
+        q, 5, offset=offset,
+        spec={
+            'coredns': {
+                'localhost:9153': {
+                    'up': tf.TensorSpec([], tf.float64),
+                },
+            },
+            'prometheus': {
+                'localhost:9090': {
+                    'up': tf.TensorSpec([], tf.float64),
+                },
+            },
+        })
+    v = v.map(lambda _, value: (
+        value['coredns']['localhost:9153']['up'],
+        value['prometheus']['localhost:9090']['up']))
+    return v
+  expected = [[1.0, 1.0] for _ in range(0, 5000, 1000)]
 
   return args, func, expected
 
@@ -872,7 +905,7 @@ def test_io_dataset_for_training(fixture_lookup, io_dataset_fixture):
             ],
         ),
         pytest.param(
-            "prometheus", None,
+            "prometheus_graph", None,
             marks=[
                 pytest.mark.skipif(
                     sys.platform == "darwin",
@@ -880,7 +913,7 @@ def test_io_dataset_for_training(fixture_lookup, io_dataset_fixture):
             ],
         ),
         pytest.param(
-            "prometheus", 2,
+            "prometheus_graph", 2,
             marks=[
                 pytest.mark.skipif(
                     sys.platform == "darwin",


### PR DESCRIPTION
This PR add structured support for prometheus dataset, so that it is possible to obtain multiple/structured values from prometheus servers.

The spec of the value structure is:
```
{
  "job_1": {
    "instance_1": {
      "name_1": Tensor,
      "name_2": Tensor,
    },
    "instance_2": {
      "name_1": Tensor,
      "name_2": Tensor,
    },
  },
  "job_2": {
    "instance_1": {
      "name_1": Tensor,
      "name_2": Tensor,
    },
    "instance_2": {
      "name_1": Tensor,
      "name_2": Tensor,
    },
  },
}
```

Note in eager mode, the strucutre of the value is automatically probed. In graph mode, it has to be provided through the `spec` to args.

***NOTE: This PR also moves prometheus dataset to tfio.experimental**, as API is undergoing changes and we want to wait for one or two more releases to stabilize the API.

This PR fixes #717.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>