### PR TITLE
Update boost to 1.72 and enable boost/avro on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
           python3 setup.py --package-version | xargs python3 -m pip install
           python3 tools/build/configure.py
           cat .bazelrc
-          bazel build -s --verbose_failures @boost//:boost
+          bazel build -s --verbose_failures @avro//:avro
           bazel build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,7 @@ jobs:
           python3 setup.py --package-version | xargs python3 -m pip install
           python3 tools/build/configure.py
           cat .bazelrc
+          bazel build -s --verbose_failures @boost//:boost
           bazel build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so
       - uses: actions/upload-artifact@v1
         with:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,17 @@ http_archive(
 )
 
 http_archive(
+    name = "boost",
+    build_file = "//third_party:boost.BUILD",
+    sha256 = "c66e88d5786f2ca4dbebb14e06b566fb642a1a6947ad8cc9091f9f445134143f",
+    strip_prefix = "boost_1_72_0",
+    urls = [
+        "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz",
+        "https://downloads.sourceforge.net/project/boost/boost/1.72.0/boost_1_72_0.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_absl",
     sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
     strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
@@ -151,18 +162,6 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/github.com/apache/arrow/archive/apache-arrow-0.14.1.tar.gz",
         "https://github.com/apache/arrow/archive/apache-arrow-0.14.1.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "boost",
-    build_file = "//third_party:boost.BUILD",
-    sha256 = "8aa4e330c870ef50a896634c931adf468b21f8a69b77007e45c444151229f665",
-    strip_prefix = "boost_1_67_0",
-    urls = [
-        "https://mirror.bazel.build/dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.gz",
-        "https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.gz",
-        "https://downloads.sourceforge.net/project/boost/boost/1.67.0/boost_1_67_0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,6 +61,16 @@ http_archive(
 )
 
 http_archive(
+    name = "avro",
+    build_file = "//third_party:avro.BUILD",
+    sha256 = "e382ac6685544ae9539084793ac0a4ffd377ba476ea756439625552e14d212b0",
+    strip_prefix = "avro-release-1.9.1/lang/c++",
+    urls = [
+        "https://github.com/apache/avro/archive/release-1.9.1.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_absl",
     sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
     strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
@@ -473,16 +483,6 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.gz",
         "https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "avro",
-    build_file = "//third_party:avro.BUILD",
-    sha256 = "e382ac6685544ae9539084793ac0a4ffd377ba476ea756439625552e14d212b0",
-    strip_prefix = "avro-release-1.9.1/lang/c++",
-    urls = [
-        "https://github.com/apache/avro/archive/release-1.9.1.tar.gz",
     ],
 )
 

--- a/third_party/boost.BUILD
+++ b/third_party/boost.BUILD
@@ -17,7 +17,9 @@ cc_library(
     ]) + [
         "boost/predef.h",
         "libs/filesystem/src/codecvt_error_category.cpp",
+        "libs/filesystem/src/directory.cpp",
         "libs/filesystem/src/error_handling.hpp",
+        "libs/filesystem/src/exception.cpp",
         "libs/filesystem/src/operations.cpp",
         "libs/filesystem/src/path.cpp",
         "libs/filesystem/src/path_traits.cpp",

--- a/third_party/boost.BUILD
+++ b/third_party/boost.BUILD
@@ -17,6 +17,7 @@ cc_library(
     ]) + [
         "boost/predef.h",
         "libs/filesystem/src/codecvt_error_category.cpp",
+        "libs/filesystem/src/error_handling.hpp",
         "libs/filesystem/src/operations.cpp",
         "libs/filesystem/src/path.cpp",
         "libs/filesystem/src/path_traits.cpp",


### PR DESCRIPTION
Update boost to 1.72 and enable boost/avro on Windows platform.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>