### PR TITLE
Update rapidjson/lmdb and enable Windows for serialization ops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
         run: |
           @echo on
           python --version
-          python -m pip install -U pytest
+          python -m pip install -U pytest-benchmark
           rm -rf tensorflow_io
           (cd tests && python -m pytest -s -v test_lmdb_eager.py)
           (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,6 +265,7 @@ jobs:
           rm -rf tensorflow_io
           (cd tests && python -m pytest -s -v test_lmdb_eager.py)
           (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr")
+          (python -m pytest -s -v test_serialization_eager.py)
 
   release:
     name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,7 @@ jobs:
           (cd tests && python -m pytest -s -v test_lmdb_eager.py)
           (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr")
           (python -m pytest -s -v test_serialization_eager.py)
+          (python -m pytest -s -v test_io_dataset_eager.py -k "numpy")
 
   release:
     name: Release

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,6 +71,16 @@ http_archive(
 )
 
 http_archive(
+    name = "rapidjson",
+    build_file = "//third_party:rapidjson.BUILD",
+    sha256 = "30bd2c428216e50400d493b38ca33a25efb1dd65f79dfc614ab0c957a3ac2c28",
+    strip_prefix = "rapidjson-418331e99f859f00bdc8306f69eba67e8693c55e",
+    urls = [
+        "https://github.com/miloyip/rapidjson/archive/418331e99f859f00bdc8306f69eba67e8693c55e.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_absl",
     sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
     strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
@@ -630,16 +640,6 @@ http_archive(
     urls = [
         "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/double-conversion/archive/3992066a95b823efc8ccc1baf82a1cfc73f6e9b8.zip",
         "https://github.com/google/double-conversion/archive/3992066a95b823efc8ccc1baf82a1cfc73f6e9b8.zip",
-    ],
-)
-
-http_archive(
-    name = "rapidjson",
-    build_file = "//third_party:rapidjson.BUILD",
-    sha256 = "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
-    strip_prefix = "rapidjson-1.1.0",
-    urls = [
-        "https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,6 +91,16 @@ http_archive(
 )
 
 http_archive(
+    name = "zlib",
+    build_file = "//third_party:zlib.BUILD",
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+    strip_prefix = "zlib-1.2.11",
+    urls = [
+        "https://zlib.net/zlib-1.2.11.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_absl",
     sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
     strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
@@ -107,17 +117,6 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz",
         "https://github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "zlib",
-    build_file = "//third_party:zlib.BUILD",
-    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-    strip_prefix = "zlib-1.2.11",
-    urls = [
-        "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-        "https://zlib.net/zlib-1.2.11.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,6 +81,16 @@ http_archive(
 )
 
 http_archive(
+    name = "lmdb",
+    build_file = "//third_party:lmdb.BUILD",
+    sha256 = "44602436c52c29d4f301f55f6fd8115f945469b868348e3cddaf91ab2473ea26",
+    strip_prefix = "lmdb-LMDB_0.9.24/libraries/liblmdb",
+    urls = [
+        "https://github.com/LMDB/lmdb/archive/LMDB_0.9.24.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_absl",
     sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
     strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
@@ -225,16 +235,6 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/github.com/FFmpeg/FFmpeg/archive/n3.4.4.tar.gz",
         "https://github.com/FFmpeg/FFmpeg/archive/n3.4.4.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "lmdb",
-    build_file = "//third_party:lmdb.BUILD",
-    sha256 = "f3927859882eb608868c8c31586bb7eb84562a40a6bf5cc3e13b6b564641ea28",
-    strip_prefix = "lmdb-LMDB_0.9.22/libraries/liblmdb",
-    urls = [
-        "https://github.com/LMDB/lmdb/archive/LMDB_0.9.22.tar.gz",
     ],
 )
 

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -442,6 +442,7 @@ cc_binary(
     deps = [
         "//tensorflow_io/core:image_ops",
         "//tensorflow_io/core:lmdb_ops",
+        "//tensorflow_io/core:serialization_ops",
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ] + select({
@@ -464,7 +465,6 @@ cc_binary(
             "//tensorflow_io/core:parquet_ops",
             "//tensorflow_io/core:pcap_ops",
             "//tensorflow_io/core:pubsub_ops",
-            "//tensorflow_io/core:serialization_ops",
             "//tensorflow_io/core:text_ops",
             "//tensorflow_io/core/azure:azfs_ops",
             "//tensorflow_io/core/oss:oss_ops",

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -442,6 +442,7 @@ cc_binary(
     deps = [
         "//tensorflow_io/core:image_ops",
         "//tensorflow_io/core:lmdb_ops",
+        "//tensorflow_io/core:numpy_ops",
         "//tensorflow_io/core:serialization_ops",
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
@@ -461,7 +462,6 @@ cc_binary(
             "//tensorflow_io/core:hdf5_ops",
             "//tensorflow_io/core:json_ops",
             "//tensorflow_io/core:kinesis_ops",
-            "//tensorflow_io/core:numpy_ops",
             "//tensorflow_io/core:parquet_ops",
             "//tensorflow_io/core:pcap_ops",
             "//tensorflow_io/core:pubsub_ops",

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -533,7 +533,10 @@ def fixture_numpy_file_tuple(request):
   tmp_path = tempfile.mkdtemp()
   filename = os.path.join(tmp_path, "numpy_file.npz")
 
-  np.savez(filename, np.asarray(d1), np.asarray(d2))
+  np.savez(
+      filename,
+      np.asarray(d1).astype(np.int64),
+      np.asarray(d2).astype(np.int64))
 
   def fin():
     shutil.rmtree(tmp_path)
@@ -555,7 +558,10 @@ def fixture_numpy_file_dict(request):
   tmp_path = tempfile.mkdtemp()
   filename = os.path.join(tmp_path, "numpy_file.npz")
 
-  np.savez(filename, d2=np.asarray(d2), d1=np.asarray(d1))
+  np.savez(
+      filename,
+      d2=np.asarray(d2).astype(np.int64),
+      d1=np.asarray(d1).astype(np.int64))
 
   def fin():
     shutil.rmtree(tmp_path)
@@ -580,7 +586,10 @@ def fixture_numpy_file_tuple_graph(request):
   tmp_path = tempfile.mkdtemp()
   filename = os.path.join(tmp_path, "numpy_file.npz")
 
-  np.savez(filename, np.asarray(d1), np.asarray(d2))
+  np.savez(
+      filename,
+      np.asarray(d1).astype(np.int64),
+      np.asarray(d2).astype(np.int64))
 
   def fin():
     shutil.rmtree(tmp_path)
@@ -604,7 +613,10 @@ def fixture_numpy_file_dict_graph(request):
   tmp_path = tempfile.mkdtemp()
   filename = os.path.join(tmp_path, "numpy_file.npz")
 
-  np.savez(filename, d2=np.asarray(d2), d1=np.asarray(d1))
+  np.savez(
+      filename,
+      d2=np.asarray(d2).astype(np.int64),
+      d1=np.asarray(d1).astype(np.int64))
 
   def fin():
     shutil.rmtree(tmp_path)

--- a/third_party/lmdb.BUILD
+++ b/third_party/lmdb.BUILD
@@ -15,9 +15,7 @@ cc_library(
         "lmdb.h",
         "midl.h",
     ],
-    copts = [
-        "-w",
-    ],
+    copts = [],
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [
             "-DEFAULTLIB:advapi32.lib",

--- a/third_party/rapidjson.BUILD
+++ b/third_party/rapidjson.BUILD
@@ -4,19 +4,10 @@ licenses(["notice"])  # MIT/JSON license
 
 cc_library(
     name = "rapidjson",
-    srcs = glob(
-        [
-        ],
-    ) + [
-    ],
-    hdrs = glob(
-        [
-            "include/**/*.h",
-        ],
-    ) + [
-    ],
-    copts = [
-    ],
+    srcs = glob([
+        "include/**/*.h",
+    ]),
+    copts = [],
     includes = [
         "include",
     ],

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -4,38 +4,18 @@ licenses(["notice"])  # BSD/MIT-like license (for zlib)
 
 cc_library(
     name = "zlib",
-    srcs = [
-        "adler32.c",
-        "compress.c",
+    srcs = glob([
+        "*.c",
+        "*.h",
+    ]) + [
         "contrib/minizip/ioapi.c",
         "contrib/minizip/ioapi.h",
         "contrib/minizip/unzip.c",
         "contrib/minizip/unzip.h",
-        "crc32.c",
-        "crc32.h",
-        "deflate.c",
-        "deflate.h",
-        "gzclose.c",
-        "gzguts.h",
-        "gzlib.c",
-        "gzread.c",
-        "gzwrite.c",
-        "infback.c",
-        "inffast.c",
-        "inffast.h",
-        "inffixed.h",
-        "inflate.c",
-        "inflate.h",
-        "inftrees.c",
-        "inftrees.h",
-        "trees.c",
-        "trees.h",
-        "uncompr.c",
-        "zconf.h",
-        "zutil.c",
-        "zutil.h",
     ],
-    hdrs = ["zlib.h"],
+    hdrs = [
+        "zlib.h",
+    ],
     copts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [


### PR DESCRIPTION
This PR:
1. Update rapidjson to 418331e
   Note rapidjson's versioned release is very old (2016), so use the latest commit instead.
2. Update LMDB to 0.9.24
3. Enable serialization ops support on Windows.
4. Enable test_serialization_eager.py test on Windows.

Update:
5. Enabled Numpy Dataset in Windows and enabled related tests.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>