### PR TITLE
Add ArrowIOTensor with input from a pyarrow.Table

### DIFF
--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -6,7 +6,7 @@ run_test() {
   entry=$1
   CPYTHON_VERSION=$($entry -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
   (cd wheelhouse && $entry -m pip install tensorflow_io-*-cp${CPYTHON_VERSION}-*.whl)
-  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.14.1 pandas==0.24.2 scikit-learn==0.20.4 gast==0.2.2 google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
+  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.16.0 pandas==0.24.2 scikit-learn==0.20.4 gast==0.2.2 google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*.py" ! \( -iname "test_*_eager.py" -o -iname "test_gcs_config_ops.py" \) \)))
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \)))
   # GRPC and test_bigquery_eager tests have to be executed separately because of https://github.com/grpc/grpc/issues/20034

--- a/tensorflow_io/arrow/kernels/arrow_kernels.h
+++ b/tensorflow_io/arrow/kernels/arrow_kernels.h
@@ -25,9 +25,6 @@ limitations under the License.
 namespace tensorflow {
 namespace data {
 
-Status GetTensorFlowType(std::shared_ptr<::arrow::DataType> dtype, ::tensorflow::DataType* out);
-Status GetArrowType(::tensorflow::DataType dtype, std::shared_ptr<::arrow::DataType>* out);
-
 // NOTE: Both SizedRandomAccessFile and ArrowRandomAccessFile overlap
 // with another PR. Will remove duplicate once PR merged
 

--- a/tensorflow_io/arrow/kernels/arrow_stream_client.h
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "arrow/io/api.h"
 
 namespace tensorflow {
+namespace data {
 
 // Class to wrap a socket as a readable Arrow InputStream
 class ArrowStreamClient : public arrow::io::InputStream {
@@ -39,6 +40,7 @@ class ArrowStreamClient : public arrow::io::InputStream {
   int64_t pos_;
 };
 
+}  // namespace data
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_IO_ARROW_STREAM_CLIENT_H_

--- a/tensorflow_io/arrow/kernels/arrow_stream_client_unix.cc
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client_unix.cc
@@ -21,11 +21,13 @@ limitations under the License.
 #include "arrow/api.h"
 #include "arrow/io/api.h"
 
+#include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow_io/arrow/kernels/arrow_stream_client.h"
 #include "tensorflow_io/arrow/kernels/arrow_util.h"
 
 namespace tensorflow {
+namespace data {
 
 ArrowStreamClient::ArrowStreamClient(const std::string& endpoint)
   : endpoint_(endpoint), sock_(-1), pos_(0) {}
@@ -41,7 +43,7 @@ arrow::Status ArrowStreamClient::Connect() {
   string host;
   Status status;
 
-  status = ParseEndpoint(endpoint_, &socket_family, &host);
+  status = ArrowUtil::ParseEndpoint(endpoint_, &socket_family, &host);
   if (!status.ok()) {
     return arrow::Status::Invalid(
         "Error parsing endpoint string: " + endpoint_);
@@ -50,7 +52,7 @@ arrow::Status ArrowStreamClient::Connect() {
   if (socket_family.empty() || socket_family == "tcp") {
     std::string addr_str;
     std::string port_str;
-    status = ParseHost(host, &addr_str, &port_str);
+    status = ArrowUtil::ParseHost(host, &addr_str, &port_str);
     if (!status.ok()) {
       return arrow::Status::Invalid("Error parsing host string: " + host);
     }
@@ -144,4 +146,5 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> ArrowStreamClient::Read(int64_t nb
   return buffer;
 }
 
+}  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/arrow/kernels/arrow_stream_client_windows.cc
+++ b/tensorflow_io/arrow/kernels/arrow_stream_client_windows.cc
@@ -28,10 +28,12 @@ limitations under the License.
 #include "arrow/io/api.h"
 
 #include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/framework/types.h"
 #include "tensorflow_io/arrow/kernels/arrow_stream_client.h"
 #include "tensorflow_io/arrow/kernels/arrow_util.h"
 
 namespace tensorflow {
+namespace data {
 
 ArrowStreamClient::ArrowStreamClient(const std::string& endpoint)
     : endpoint_(endpoint), sock_(-1), pos_(0) {}
@@ -47,7 +49,7 @@ arrow::Status ArrowStreamClient::Connect() {
   string host;
   Status status;
 
-  status = ParseEndpoint(endpoint_, &socket_family, &host);
+  status = ArrowUtil::ParseEndpoint(endpoint_, &socket_family, &host);
   if (!status.ok()) {
     return arrow::Status::Invalid(
         "Error parsing endpoint string: " + endpoint_);
@@ -59,7 +61,7 @@ arrow::Status ArrowStreamClient::Connect() {
 
   string addr_str;
   string port_str;
-  status = ParseHost(host, &addr_str, &port_str);
+  status = ArrowUtil::ParseHost(host, &addr_str, &port_str);
   if (!status.ok()) {
     return arrow::Status::Invalid("Error parsing host string: " + host);
   }
@@ -163,4 +165,6 @@ arrow::Result<std::shared_ptr<arrow::Buffer>> ArrowStreamClient::Read(int64_t nb
   buffer->ZeroPadding();
   return buffer;
 }
+
+}  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/arrow/kernels/arrow_util.cc
+++ b/tensorflow_io/arrow/kernels/arrow_util.cc
@@ -13,11 +13,386 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "arrow/api.h"
+#include "arrow/adapters/tensorflow/convert.h"
+#include "arrow/ipc/api.h"
+#include "arrow/util/io_util.h"
+#include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow_io/arrow/kernels/arrow_util.h"
 
 namespace tensorflow {
+namespace data {
+namespace ArrowUtil {
+
+Status GetTensorFlowType(std::shared_ptr<::arrow::DataType> dtype, ::tensorflow::DataType* out) {
+  ::arrow::Status status = ::arrow::adapters::tensorflow::GetTensorFlowType(dtype, out);
+  if (!status.ok()) {
+    return errors::InvalidArgument("arrow data type ", dtype, " is not supported: ", status);
+  }
+  return Status::OK();
+}
+
+Status GetArrowType(::tensorflow::DataType dtype, std::shared_ptr<::arrow::DataType>* out) {
+  ::arrow::Status status = ::arrow::adapters::tensorflow::GetArrowType(dtype, out);
+  if (!status.ok()) {
+    return errors::InvalidArgument("tensorflow data type ", dtype, " is not supported: ", status);
+  }
+  return Status::OK();
+}
+
+class ArrowAssignSpecImpl : public arrow::ArrayVisitor {
+ public:
+  ArrowAssignSpecImpl() : i_(0), batch_size_(0) {}
+
+  Status AssignDataType(std::shared_ptr<arrow::Array> array, ::tensorflow::DataType* out_dtype) {
+    return AssignSpec(array, 0, 0, out_dtype, nullptr);
+  }
+
+  Status AssignShape(std::shared_ptr<arrow::Array> array, int64 i, int64 batch_size,
+                     TensorShape* out_shape) {
+    return AssignSpec(array, i, batch_size, nullptr, out_shape);
+  }
+
+  // Get the DataType and equivalent TensorShape for a given Array, taking into
+  // account possible batch size
+  Status AssignSpec(std::shared_ptr<arrow::Array> array, int64 i, int64 batch_size,
+                     ::tensorflow::DataType* out_dtype, TensorShape* out_shape) {
+    i_ = i;
+    batch_size_ = batch_size;
+    out_shape_ = out_shape;
+    out_dtype_ = out_dtype;
+
+    // batch_size of 0 indicates 1 record at a time, no batching
+    if (batch_size_ > 0) {
+      out_shape_->AddDim(batch_size_);
+   }
+
+    CHECK_ARROW(array->Accept(this));
+    return Status::OK();
+  }
+
+ protected:
+  template <typename ArrayType>
+  arrow::Status VisitPrimitive(const ArrayType& array) {
+    if (out_dtype_ != nullptr) {
+      return ::arrow::adapters::tensorflow::GetTensorFlowType(array.type(), out_dtype_);
+    }
+    return arrow::Status::OK();
+  }
+
+#define VISIT_PRIMITIVE(TYPE)                               \
+  virtual arrow::Status Visit(const TYPE& array) override { \
+    return VisitPrimitive(array);                           \
+  }
+
+  VISIT_PRIMITIVE(arrow::BooleanArray)
+  VISIT_PRIMITIVE(arrow::Int8Array)
+  VISIT_PRIMITIVE(arrow::Int16Array)
+  VISIT_PRIMITIVE(arrow::Int32Array)
+  VISIT_PRIMITIVE(arrow::Int64Array)
+  VISIT_PRIMITIVE(arrow::UInt8Array)
+  VISIT_PRIMITIVE(arrow::UInt16Array)
+  VISIT_PRIMITIVE(arrow::UInt32Array)
+  VISIT_PRIMITIVE(arrow::UInt64Array)
+  VISIT_PRIMITIVE(arrow::HalfFloatArray)
+  VISIT_PRIMITIVE(arrow::FloatArray)
+  VISIT_PRIMITIVE(arrow::DoubleArray)
+#undef VISIT_PRIMITIVE
+
+  virtual arrow::Status Visit(const arrow::ListArray& array) override {
+    int32 values_offset = array.value_offset(i_);
+    int32 array_length = array.value_length(i_);
+    int32 num_arrays = 1;
+
+    // If batching tensors, arrays must be same length
+    if (batch_size_ > 0) {
+      num_arrays = batch_size_;
+      for (int64 j = i_; j < i_ + num_arrays; ++j) {
+        if (array.value_length(j) != array_length) {
+          return arrow::Status::Invalid(
+              "Batching variable-length arrays is unsupported");
+        }
+      }
+    }
+
+    // Add diminsion for array
+    if (out_shape_ != nullptr) {
+      out_shape_->AddDim(array_length);
+    }
+
+    // Prepare the array data buffer and visit the array slice
+    std::shared_ptr<arrow::Array> values = array.values();
+    std::shared_ptr<arrow::Array> element_values =
+        values->Slice(values_offset, array_length * num_arrays);
+    return element_values->Accept(this);
+  }
+
+ private:
+  int64 i_;
+  int64 batch_size_;
+  DataType* out_dtype_;
+  TensorShape* out_shape_;
+};
+
+Status AssignShape(std::shared_ptr<arrow::Array> array, int64 i, int64 batch_size, TensorShape* out_shape) {
+  ArrowAssignSpecImpl visitor;
+  return visitor.AssignShape(array, i, batch_size, out_shape);
+}
+
+Status AssignSpec(std::shared_ptr<arrow::Array> array, int64 i, int64 batch_size, ::tensorflow::DataType* out_dtype, TensorShape* out_shape) {
+    ArrowAssignSpecImpl visitor;
+    return visitor.AssignSpec(array, i, batch_size, out_dtype, out_shape);
+}
+
+// Assign elements of an Arrow Array to a Tensor
+class ArrowAssignTensorImpl : public arrow::ArrayVisitor {
+ public:
+  ArrowAssignTensorImpl() : i_(0), out_tensor_(nullptr) {}
+
+  Status AssignTensor(std::shared_ptr<arrow::Array> array, int64 i, Tensor* out_tensor) {
+    i_ = i;
+    out_tensor_ = out_tensor;
+    if (array->null_count() != 0) {
+      return errors::Internal("Arrow arrays with null values not currently supported");
+    }
+    CHECK_ARROW(array->Accept(this));
+    return Status::OK();
+  }
+
+ protected:
+  virtual arrow::Status Visit(const arrow::BooleanArray& array) {
+
+    // Must copy one value at a time because Arrow stores values as bits
+    auto shape = out_tensor_->shape();
+    for (int64 j = 0; j < shape.num_elements(); ++j) {
+      // NOTE: for Array ListArray, curr_row_idx_ is 0 for element array
+      bool value = array.Value(i_ + j);
+      void* dst = const_cast<char*>(out_tensor_->tensor_data().data()) + j * sizeof(value);
+      memcpy(dst, &value, sizeof(value));
+    }
+
+    return arrow::Status::OK();
+  }
+
+  template <typename ArrayType>
+  arrow::Status VisitFixedWidth(const ArrayType& array) {
+    const auto& fw_type =
+        static_cast<const arrow::FixedWidthType&>(*array.type());
+    const int64_t type_width = fw_type.bit_width() / 8;
+
+    // TODO: verify tensor is correct shape, arrow array is within bounds
+
+    // Primitive Arrow arrays have validity and value buffers, currently
+    // only arrays with null count == 0 are supported, so only need values here
+    static const int VALUE_BUFFER = 1;
+    auto values = array.data()->buffers[VALUE_BUFFER];
+    if (values == NULLPTR) {
+      return arrow::Status::Invalid(
+          "Received an Arrow array with a NULL value buffer");
+    }
+
+    const void* src = (values->data() + array.data()->offset * type_width) +
+                      i_ * type_width;
+    void* dst = const_cast<char*>(out_tensor_->tensor_data().data());
+    std::memcpy(dst, src, out_tensor_->NumElements() * type_width);
+
+    return arrow::Status::OK();
+  }
+
+#define VISIT_FIXED_WIDTH(TYPE)                             \
+  virtual arrow::Status Visit(const TYPE& array) override { \
+    return VisitFixedWidth(array);                          \
+  }
+
+  VISIT_FIXED_WIDTH(arrow::Int8Array)
+  VISIT_FIXED_WIDTH(arrow::Int16Array)
+  VISIT_FIXED_WIDTH(arrow::Int32Array)
+  VISIT_FIXED_WIDTH(arrow::Int64Array)
+  VISIT_FIXED_WIDTH(arrow::UInt8Array)
+  VISIT_FIXED_WIDTH(arrow::UInt16Array)
+  VISIT_FIXED_WIDTH(arrow::UInt32Array)
+  VISIT_FIXED_WIDTH(arrow::UInt64Array)
+  VISIT_FIXED_WIDTH(arrow::HalfFloatArray)
+  VISIT_FIXED_WIDTH(arrow::FloatArray)
+  VISIT_FIXED_WIDTH(arrow::DoubleArray)
+#undef VISIT_FIXED_WITH
+
+  virtual arrow::Status Visit(const arrow::ListArray& array) override {
+    int32 values_offset = array.value_offset(i_);
+    int32 curr_array_length = array.value_length(i_);
+    int32 num_arrays = 1;
+    auto shape = out_tensor_->shape();
+
+    // If batching tensors, arrays must be same length
+    if (shape.dims() > 1) {
+      num_arrays = shape.dim_size(0);
+      for (int64_t j = i_; j < i_ + num_arrays; ++j) {
+        if (array.value_length(j) != curr_array_length) {
+          return arrow::Status::Invalid(
+              "Batching variable-length arrays is unsupported");
+        }
+      }
+    }
+
+    // Save current index and swap after array is copied
+    int32 tmp_index = i_;
+    i_ = 0;
+
+    // Prepare the array data buffer and visit the array slice
+    std::shared_ptr<arrow::Array> values = array.values();
+    std::shared_ptr<arrow::Array> element_values =
+        values->Slice(values_offset, curr_array_length * num_arrays);
+    auto result = element_values->Accept(this);
+
+    // Reset state variables for next time
+    i_ = tmp_index;
+    return result;
+  }
+
+ private:
+  int64 i_;
+  int32 curr_array_length_;
+  Tensor* out_tensor_;
+};
+
+Status AssignTensor(std::shared_ptr<arrow::Array> array, int64 i, Tensor* out_tensor) {
+  ArrowAssignTensorImpl visitor;
+  return visitor.AssignTensor(array, i, out_tensor);
+}
+
+// Check the type of an Arrow array matches expected tensor type
+class ArrowArrayTypeCheckerImpl : public arrow::TypeVisitor {
+ public:
+  Status CheckArrayType(std::shared_ptr<arrow::DataType> type,
+                        ::tensorflow::DataType expected_type) {
+    expected_type_ = expected_type;
+
+    // First see if complex type handled by visitor
+    arrow::Status visit_status = type->Accept(this);
+    if (visit_status.ok()) {
+      return Status::OK();
+    }
+
+    // Check type as a scalar type
+    CHECK_ARROW(CheckScalarType(type));
+    return Status::OK();
+  }
+
+ protected:
+  virtual arrow::Status Visit(const arrow::ListType& type) {
+    return CheckScalarType(type.value_type());
+  }
+
+  // Check scalar types with arrow::adapters::tensorflow
+  arrow::Status CheckScalarType(std::shared_ptr<arrow::DataType> scalar_type) {
+    DataType converted_type;
+    ::tensorflow::Status status = GetTensorFlowType(scalar_type, &converted_type);
+    if (!status.ok()) {
+      return ::arrow::Status::Invalid(status);
+    }
+    if (converted_type != expected_type_) {
+      return arrow::Status::TypeError(
+          "Arrow type mismatch: expected dtype=" +
+          std::to_string(expected_type_) + ", but got dtype=" +
+          std::to_string(converted_type));
+    }
+    return arrow::Status::OK();
+  }
+
+ private:
+  DataType expected_type_;
+};
+
+Status CheckArrayType(std::shared_ptr<arrow::DataType> type,
+                      ::tensorflow::DataType expected_type) {
+  ArrowArrayTypeCheckerImpl visitor;
+  return visitor.CheckArrayType(type, expected_type);
+}
+
+class ArrowMakeArrayDataImpl : public arrow::TypeVisitor {
+ public:
+  Status Make(std::shared_ptr<arrow::DataType> type,
+              std::vector<int64> array_lengths,
+              std::vector<std::shared_ptr<arrow::Buffer>> buffers,
+              std::shared_ptr<arrow::ArrayData>* out_data) {
+    type_ = type;
+    lengths_ = array_lengths;
+    buffers_ = buffers;
+    out_data_ = out_data;
+    CHECK_ARROW(type->Accept(this));
+    return Status::OK();
+  }
+
+ protected:
+  template <typename DataTypeType>
+  arrow::Status VisitPrimitive(const DataTypeType& type) {
+    // TODO null count == 0
+    *out_data_ = arrow::ArrayData::Make(type_, lengths_[0], std::move(buffers_), 0);
+    return arrow::Status::OK();
+  }
+
+#define VISIT_PRIMITIVE(TYPE)                             \
+  virtual arrow::Status Visit(const TYPE& type) override { \
+    return VisitPrimitive(type);                           \
+  }
+
+  VISIT_PRIMITIVE(arrow::BooleanType)
+  VISIT_PRIMITIVE(arrow::Int8Type)
+  VISIT_PRIMITIVE(arrow::Int16Type)
+  VISIT_PRIMITIVE(arrow::Int32Type)
+  VISIT_PRIMITIVE(arrow::Int64Type)
+  VISIT_PRIMITIVE(arrow::UInt8Type)
+  VISIT_PRIMITIVE(arrow::UInt16Type)
+  VISIT_PRIMITIVE(arrow::UInt32Type)
+  VISIT_PRIMITIVE(arrow::UInt64Type)
+  VISIT_PRIMITIVE(arrow::HalfFloatType)
+  VISIT_PRIMITIVE(arrow::FloatType)
+  VISIT_PRIMITIVE(arrow::DoubleType)
+#undef VISIT_PRIMITIVE
+
+  virtual arrow::Status Visit(const arrow::ListType& type) override {
+
+    // TODO assert buffers and lengths size
+
+    // Copy first 2 buffers, which are validity and offset buffers for the list
+    std::vector<std::shared_ptr<arrow::Buffer>> list_bufs(buffers_.begin(), buffers_.begin() + 2);
+    buffers_.erase(buffers_.begin(), buffers_.begin() + 2);
+
+    // Copy first array length for length of list
+    int64 list_length = lengths_[0];
+    lengths_.erase(lengths_.begin(), lengths_.begin() + 1);
+
+    // Make array data for the child type
+    type_ = type.value_type();
+    type.value_type()->Accept(this);
+    auto child_data = *out_data_;
+
+    // Make array data for the list TODO null count == 0
+    auto list_type = std::make_shared<arrow::ListType>(type.value_type());
+    *out_data_ = arrow::ArrayData::Make(
+        list_type, list_length, std::move(list_bufs), {child_data}, 0);
+
+    return arrow::Status::OK();
+  }
+
+ private:
+  std::shared_ptr<arrow::DataType> type_;
+  std::vector<std::shared_ptr<arrow::Buffer>> buffers_;
+  std::vector<int64> lengths_;
+  std::shared_ptr<arrow::ArrayData>* out_data_;
+};
+
+
+Status MakeArrayData(std::shared_ptr<arrow::DataType> type,
+                     std::vector<int64> array_lengths,
+                     std::vector<std::shared_ptr<arrow::Buffer>> buffers,
+                     std::shared_ptr<arrow::ArrayData>* out_data) {
+  ArrowMakeArrayDataImpl visitor;
+  return visitor.Make(type, array_lengths, buffers, out_data);
+}
+
 
 Status ParseEndpoint(std::string endpoint, std::string* endpoint_type,
                      std::string* endpoint_value) {
@@ -57,4 +432,6 @@ Status ParseHost(std::string host, std::string* host_address, std::string* host_
   return Status::OK();
 }
 
+}  // namespace ArrowUtil
+}  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/arrow/kernels/arrow_util.h
+++ b/tensorflow_io/arrow/kernels/arrow_util.h
@@ -18,13 +18,63 @@ limitations under the License.
 
 namespace tensorflow {
 
+// Forward declaration
+class Tensor;
+class TensorShape;
+
+namespace data {
+
+#define CHECK_ARROW(arrow_status)             \
+  do {                                        \
+    arrow::Status _s = (arrow_status);        \
+    if (!_s.ok()) {                           \
+      return errors::Internal(_s.ToString()); \
+    }                                         \
+  } while (false)
+
+namespace ArrowUtil {
+
+// Convert Arrow Data Type to TensorFlow
+Status GetTensorFlowType(std::shared_ptr<::arrow::DataType> dtype, ::tensorflow::DataType* out);
+
+// Convert TensorFlow Data Type to Arrow
+Status GetArrowType(::tensorflow::DataType dtype, std::shared_ptr<::arrow::DataType>* out);
+
+// Assign equivalent TensorShape for the given Arrow Array
+Status AssignShape(std::shared_ptr<arrow::Array> array,
+                   int64 i,
+                   int64 batch_size,
+                   TensorShape* out_shape);
+
+// Assign DataType and equivalent TensorShape for the given Arrow Array
+Status AssignSpec(std::shared_ptr<arrow::Array> array,
+                  int64 i,
+                  int64 batch_size,
+                  ::tensorflow::DataType* out_dtype,
+                  TensorShape* out_shape);
+
+// Assign elements of an Arrow Array to a Tensor
+Status AssignTensor(std::shared_ptr<arrow::Array> array, int64 i, Tensor* out_tensor);
+
+// Checks the Arrow Array datatype matches the expected TF datatype
+Status CheckArrayType(std::shared_ptr<arrow::DataType> type, ::tensorflow::DataType expected_type);
+
+// Make list and primitive array data
+Status MakeArrayData(std::shared_ptr<arrow::DataType> type,
+                     std::vector<int64> array_lengths,
+                     std::vector<std::shared_ptr<arrow::Buffer>> buffers,
+                     std::shared_ptr<arrow::ArrayData>* out_data);
+
 // Parse the given endpoint to extract type and value strings
-Status ParseEndpoint(std::string endpoint, std::string* endpoint_type,
+Status ParseEndpoint(std::string endpoint,
+                     std::string* endpoint_type,
                      std::string* endpoint_value);
 
 // Parse the given IPv4 host string to get address and port
 Status ParseHost(std::string host, std::string* host_address, std::string* host_port);
 
+}  // namespace ArrowUtil
+}  // namespace data
 }  // namespace tensorflow
 
 #endif

--- a/tensorflow_io/arrow/ops/dataset_ops.cc
+++ b/tensorflow_io/arrow/ops/dataset_ops.cc
@@ -140,4 +140,47 @@ REGISTER_OP("IO>FeatherReadableRead")
     return Status::OK();
    });
 
+REGISTER_OP("IO>ArrowReadableFromMemoryInit")
+  .Input("schema_buffer_address: uint64")
+  .Input("schema_buffer_size: int64")
+  .Input("array_buffer_addresses: uint64")
+  .Input("array_buffer_sizes: int64")
+  .Input("array_lengths: int64")
+  .Output("resource: resource")
+  .Attr("container: string = ''")
+  .Attr("shared_name: string = ''")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->Scalar());
+    c->set_output(1, c->MakeShape({}));
+    return Status::OK();
+   });
+
+REGISTER_OP("IO>ArrowReadableSpec")
+  .Input("input: resource")
+  .Output("shape: int64")
+  .Output("dtype: int64")
+  .Attr("column_index: int")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    c->set_output(0, c->MakeShape({c->UnknownDim()}));
+    c->set_output(1, c->MakeShape({}));
+    return Status::OK();
+   });
+
+REGISTER_OP("IO>ArrowReadableRead")
+  .Input("input: resource")
+  .Input("start: int64")
+  .Input("stop: int64")
+  .Output("value: dtype")
+  .Attr("column_index: int")
+  .Attr("shape: shape")
+  .Attr("dtype: type")
+  .SetShapeFn([](shape_inference::InferenceContext* c) {
+    PartialTensorShape shape;
+    TF_RETURN_IF_ERROR(c->GetAttr("shape", &shape));
+    shape_inference::ShapeHandle entry;
+    TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(shape, &entry));
+    c->set_output(0, entry);
+    return Status::OK();
+   });
+
 }  // namespace tensorflow

--- a/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
@@ -125,7 +125,6 @@ class ArrowBaseDataset(dataset_ops.DatasetV2):
       self._structure = nest.map_structure(
           lambda component_spec: component_spec._batch(spec_batch_size),
           self._structure)
-      print(self._flat_structure)
     variant_tensor = make_variant_fn(
         columns=self._columns,
         batch_size=self._batch_size,

--- a/tensorflow_io/core/kernels/json_kernels.cc
+++ b/tensorflow_io/core/kernels/json_kernels.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/core/lib/io/buffered_inputstream.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow_io/arrow/kernels/arrow_kernels.h"
+#include "tensorflow_io/arrow/kernels/arrow_util.h"
 #include "tensorflow_io/core/kernels/io_interface.h"
 #include "tensorflow_io/core/kernels/io_stream.h"
 
@@ -123,7 +124,7 @@ class JSONReadable : public IOReadableInterface {
     for (int i = 0; i < table_->num_columns(); i++) {
       shapes_.push_back(TensorShape({static_cast<int64>(table_->num_rows())}));
       ::tensorflow::DataType dtype;
-      TF_RETURN_IF_ERROR(GetTensorFlowType(table_->column(i)->type(), &dtype));
+      TF_RETURN_IF_ERROR(ArrowUtil::GetTensorFlowType(table_->column(i)->type(), &dtype));
       dtypes_.push_back(dtype);
       columns_.push_back(table_->ColumnNames()[i]);
       columns_index_[table_->ColumnNames()[i]] = i;

--- a/tensorflow_io/core/python/ops/arrow_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/arrow_io_tensor_ops.py
@@ -1,0 +1,176 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""FeatherIOTensor"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import uuid
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import io_tensor_ops
+from tensorflow_io.core.python.ops import core_ops
+
+class _ArrowIOTensorComponentFunction(io_tensor_ops._IOTensorComponentFunction): # pylint: disable=protected-access
+  """_ArrowIOTensorComponentFunction will translate call"""
+  def __init__(self,
+               function,
+               resource,
+               component, column_index, shape, dtype):
+    super(_ArrowIOTensorComponentFunction, self).__init__(
+        function, resource, component, shape, dtype)
+    self._column_index = column_index
+  def __call__(self, start, stop):
+    start, stop, _ = slice(start, stop).indices(self._length)
+    return self._function(
+        self._resource,
+        start=start, stop=stop,
+        column_index=self._column_index,
+        shape=self._shape, dtype=self._dtype)
+
+
+def _extract_table_arrays(table):
+  """Get buffer info from arrays in table, outputs are padded so dim sizes
+     are rectangular.
+
+     Args:
+       table: A pyarrow.Table
+     Return:
+       tuple of:
+         array_buffer_addrs: 3-dim list of buffer addresses where dims are
+                             columns, chunks, buffer addresses
+         array_buffer_sizes: 3-dim list of buffer sizes, follows addrs layout
+         array_lengths: 3-dim list of array lengths where dims are columns,
+                        chunks, length of array followed by child array lengths
+  """
+  array_buffer_addrs = []
+  array_buffer_sizes = []
+  array_lengths = []
+  max_num_bufs = 0
+  max_num_chunks = 0
+  max_num_lengths = 0
+
+  # Iterate over each column in the Table
+  for chunked_array in table:
+    array_chunk_buffer_addrs = []
+    array_chunk_buffer_sizes = []
+    array_chunk_lengths = []
+
+    # Iterate over each data chunk in the column
+    for arr in chunked_array.iterchunks():
+      bufs = arr.buffers()
+      array_chunk_buffer_addrs.append(
+          [b.address if b is not None else 0 for b in bufs])
+      array_chunk_buffer_sizes.append(
+          [b.size if b is not None else 0 for b in bufs])
+
+      # Get the total length of the array followed by lenghts of children
+      array_and_child_lengths = [len(arr)]
+
+      # Check if has child array, e.g. list type
+      if arr.type.num_children > 0:
+        if hasattr(arr, 'values'):
+          array_and_child_lengths.append(len(arr.values))
+        else:
+          raise ValueError("Only nested type currently supported is ListType")
+
+      array_chunk_lengths.append(array_and_child_lengths)
+      if len(bufs) > max_num_bufs:
+        max_num_bufs = len(bufs)
+      if len(array_and_child_lengths) > max_num_lengths:
+        max_num_lengths = len(array_and_child_lengths)
+
+    array_buffer_addrs.append(array_chunk_buffer_addrs)
+    array_buffer_sizes.append(array_chunk_buffer_sizes)
+    array_lengths.append(array_chunk_lengths)
+    if len(array_chunk_lengths) > max_num_chunks:
+      max_num_chunks = len(array_chunk_lengths)
+
+  # Pad buffer addrs, sizes and array lengths so inputs are rectangular
+  num_columns = len(array_buffer_sizes)
+  for i in range(num_columns):
+
+    # pad chunk list with empty lists that will be padded with null bufs
+    if len(array_buffer_sizes[i]) < max_num_chunks:
+      array_buffer_sizes[i].extend([[]] * (max_num_chunks -
+                                           len(array_buffer_sizes[i])))
+    if len(array_lengths[i]) < max_num_chunks:
+      array_lengths[i].extend([-1] * (max_num_chunks - len(array_lengths[i])))
+
+    num_chunks = len(array_buffer_sizes[i])
+    for j in range(num_chunks):
+
+      # pad buffer addr, size, and array length lists
+      if len(array_buffer_sizes[i][j]) < max_num_bufs:
+        array_buffer_sizes[i][j].extend([-1] * (max_num_bufs -
+                                                len(array_buffer_sizes[i][j])))
+        array_buffer_addrs[i][j].extend([0] * (max_num_bufs -
+                                               len(array_buffer_addrs[i][j])))
+      if len(array_lengths[i][j]) < max_num_lengths:
+        array_lengths[i][j].extend([-1] * (max_num_lengths -
+                                           len(array_lengths[i][j])))
+  return array_buffer_addrs, array_buffer_sizes, array_lengths
+
+
+class ArrowIOTensor(io_tensor_ops._TableIOTensor): # pylint: disable=protected-access
+  """ArrowIOTensor"""
+
+  #=============================================================================
+  # Constructor (private)
+  #=============================================================================
+  def __init__(self,
+               table,
+               internal=False):
+    with tf.name_scope("ArrowIOTensor") as scope:
+
+      # Hold reference to table and schema buffer for life of this op
+      self._table = table
+      self._schema_buffer = table.schema.serialize()
+
+      # Get buffer addresses as long ints
+      schema_buffer_addr = self._schema_buffer.address
+      schema_buffer_size = self._schema_buffer.size
+      array_buffer_addrs, array_buffer_sizes, array_lengths = \
+          _extract_table_arrays(table)
+
+      # Create the Arrow readable resource
+      resource = core_ops.io_arrow_readable_from_memory_init(
+          schema_buffer_addr,
+          schema_buffer_size,
+          array_buffer_addrs,
+          array_buffer_sizes,
+          array_lengths,
+          container=scope,
+          shared_name="pyarrow.Table%s/%s" % (
+              table.schema.names, uuid.uuid4().hex))
+
+      # Create a BaseIOTensor for each column
+      elements = []
+      columns = table.column_names
+      for column_index, column in enumerate(columns):
+        shape, dtype = core_ops.io_arrow_readable_spec(resource, column_index)
+        shape = tf.TensorShape(shape.numpy())
+        dtype = tf.as_dtype(dtype.numpy())
+        spec = tf.TensorSpec(shape, dtype, column)
+        function = _ArrowIOTensorComponentFunction( # pylint: disable=protected-access
+            core_ops.io_arrow_readable_read,
+            resource, column, column_index, shape, dtype)
+        elements.append(
+            io_tensor_ops.BaseIOTensor(
+                spec, function, internal=internal))
+
+      spec = tuple([e.spec for e in elements])
+      super(ArrowIOTensor, self).__init__(
+          spec, columns, elements, internal=internal)

--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -31,6 +31,7 @@ from tensorflow_io.core.python.ops import avro_io_tensor_ops
 from tensorflow_io.core.python.ops import ffmpeg_io_tensor_ops
 from tensorflow_io.core.python.ops import parquet_io_tensor_ops
 from tensorflow_io.core.python.ops import tiff_io_tensor_ops
+from tensorflow_io.core.python.ops import arrow_io_tensor_ops
 
 class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
   """IOTensor
@@ -330,6 +331,23 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
     """
     with tf.name_scope(kwargs.get("name", "IOFromFeather")):
       return feather_io_tensor_ops.FeatherIOTensor(filename, internal=True)
+
+  @classmethod
+  def from_arrow(cls,
+                 table,
+                 **kwargs):
+    """Creates an `IOTensor` from a pyarrow.Table.
+
+    Args:
+      table: An instance of a `pyarrow.Table`.
+      name: A name prefix for the IOTensor (optional).
+
+    Returns:
+      A `IOTensor`.
+
+    """
+    with tf.name_scope(kwargs.get("name", "IOFromArrow")):
+      return arrow_io_tensor_ops.ArrowIOTensor(table, internal=True)
 
   @classmethod
   def from_lmdb(cls,

--- a/tests/test_io_tensor_eager.py
+++ b/tests/test_io_tensor_eager.py
@@ -278,6 +278,25 @@ def fixture_hdf5_scalar(request):
 
   return args, func, expected
 
+
+@pytest.fixture(name="arrow", scope="module")
+def fixture_arrow():
+  """fixture_arrow"""
+  import pyarrow as pa # pylint: disable=import-outside-toplevel
+
+  arr1 = pa.array(list(range(100)), pa.int32())
+  arr2 = pa.array(list(range(100)), pa.int64())
+  arr3 = pa.array([x * 1.1 for x in range(100)], pa.float32())
+  table = pa.Table.from_arrays([arr1, arr2, arr3], ['a', 'b', 'c'])
+
+  args = table
+  column = 'b'
+  func = lambda t: tfio.IOTensor.from_arrow(t)(column)
+  expected = table[column].to_pylist()
+
+  return args, func, expected
+
+
 # scalar is a special IOTensor that is alias to Tensor
 @pytest.mark.parametrize(
     ("io_tensor_fixture"),
@@ -309,6 +328,7 @@ def test_io_tensor_scalar(fixture_lookup, io_tensor_fixture):
         pytest.param("audio_flac"),
         pytest.param("hdf5"),
         pytest.param("kafka"),
+        pytest.param("arrow"),
     ],
     ids=[
         "audio[wav]",
@@ -317,6 +337,7 @@ def test_io_tensor_scalar(fixture_lookup, io_tensor_fixture):
         "audio[flac]",
         "hdf5",
         "kafka",
+        "arrow",
     ],
 )
 def test_io_tensor_slice(fixture_lookup, io_tensor_fixture):
@@ -351,6 +372,18 @@ def test_io_tensor_slice(fixture_lookup, io_tensor_fixture):
         pytest.param("hdf5_graph", 2),
         pytest.param("kafka", None),
         pytest.param("kafka", 2),
+        pytest.param(
+            "arrow", None,
+            marks=[
+                pytest.mark.skip(reason="TODO"),
+            ],
+        ),
+        pytest.param(
+            "arrow", 2,
+            marks=[
+                pytest.mark.skip(reason="TODO"),
+            ],
+        ),
     ],
     ids=[
         "audio[wav]",
@@ -365,6 +398,8 @@ def test_io_tensor_slice(fixture_lookup, io_tensor_fixture):
         "hdf5|2",
         "kafka",
         "kafka|2",
+        "arrow",
+        "arrow|2",
     ],
 )
 def test_io_tensor_slice_in_dataset(
@@ -480,6 +515,7 @@ def test_io_tensor_meta_in_dataset(fixture_lookup, io_tensor_fixture):
         pytest.param("audio_ogg"),
         pytest.param("audio_flac"),
         pytest.param("hdf5"),
+        pytest.param("arrow"),
     ],
     ids=[
         "audio[wav]",
@@ -487,6 +523,7 @@ def test_io_tensor_meta_in_dataset(fixture_lookup, io_tensor_fixture):
         "audio[ogg]",
         "audio[flac]",
         "hdf5",
+        "arrow",
     ],
 )
 def test_io_tensor_benchmark(benchmark, fixture_lookup, io_tensor_fixture):

--- a/tools/dev/Dockerfile
+++ b/tools/dev/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     ffmpeg \
     dnsutils
 
-ARG BAZEL_VERSION=0.29.0
+ARG BAZEL_VERSION=2.0.0
 ARG BAZEL_OS=linux
 
 RUN curl -sL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh -o bazel-install.sh && \
@@ -34,7 +34,7 @@ ARG CONDA_ADD_PACKAGES=""
 
 RUN conda create -y -q -n tfio-dev python=3.6 ${CONDA_ADD_PACKAGES}
 
-ARG ARROW_VERSION=0.14.1
+ARG ARROW_VERSION=0.15.1
 
 RUN echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "source activate tfio-dev" >> ~/.bashrc

--- a/tools/dev/Dockerfile
+++ b/tools/dev/Dockerfile
@@ -34,7 +34,7 @@ ARG CONDA_ADD_PACKAGES=""
 
 RUN conda create -y -q -n tfio-dev python=3.6 ${CONDA_ADD_PACKAGES}
 
-ARG ARROW_VERSION=0.15.1
+ARG ARROW_VERSION=0.16.0
 
 RUN echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "source activate tfio-dev" >> ~/.bashrc

--- a/tools/dev/Dockerfile
+++ b/tools/dev/Dockerfile
@@ -43,6 +43,7 @@ ARG PIP_ADD_PACKAGES=""
 
 RUN /bin/bash -c "source activate tfio-dev && python -m pip install \
     pytest \
+    pytest-benchmark \
     pylint \
     boto3 \
     google-cloud-pubsub==0.39.1 \


### PR DESCRIPTION
This adds an `ArrowIOTensor` based on a `_TableIOTensor` with multiple columns. An `ArrowIOTensor` is create with the factory function `tfio.IOTensor.from_arrow()` with a `pyarrow.Table` as input.