### PR TITLE
Add link to reference of Kafka usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Note:
 
 ## More Information
 
+* [Streaming Machine Learning with Tiered Storage and Without a Data Lake](https://www.confluent.io/blog/streaming-machine-learning-with-tiered-storage/) - [Kai Waehner](https://github.com/kaiwaehner)
 * [TensorFlow with Apache Arrow Datasets](https://medium.com/tensorflow/tensorflow-with-apache-arrow-datasets-cdbcfe80a59f) - [Bryan Cutler](https://github.com/BryanCutler)
 * [How to build a custom Dataset for Tensorflow](https://towardsdatascience.com/how-to-build-a-custom-dataset-for-tensorflow-1fe3967544d8) - [Ivelin Ivanov](https://github.com/ivelin)
 * [TensorFlow on Apache Ignite](https://medium.com/tensorflow/tensorflow-on-apache-ignite-99f1fc60efeb) - [Anton Dmitriev](https://github.com/dmitrievanthony)


### PR DESCRIPTION
This PR adds a link to the excellent blog:
`Streaming Machine Learning with Tiered Storage and Without a Data Lake` 
https://www.confluent.io/blog/streaming-machine-learning-with-tiered-storage/


courtesy Kai Waehner (@kaiwaehner).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>