### PR TITLE
Add a tutorial to load metrics from prometheus server

### DIFF
--- a/docs/tutorials/_toc.yaml
+++ b/docs/tutorials/_toc.yaml
@@ -20,5 +20,7 @@ toc:
   path: /io/tutorials/dicom
 - title: "Azure blob storage with TensorFlow"
   path: /io/tutorials/azure
+- title: "Prometheus metrics"
+  path: /io/tutorials/prometheus
 - title: "Genomics IO"
   path: /io/tutorials/genome

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -288,7 +288,7 @@
         "\n",
         "Create a Dataset for CoreDNS metrics that is available from PostgreSQL server, could be done with `tfio.experimental.IODataset.from_prometheus`. At the minimium two arguments are needed. `query` is passed to Prometheus server to select the metrics and `length` is the period we want to load into Dataset.\n",
         "\n",
-        "You can start with \"coredns_dns_request_count_total\" and \"5\" (secs) to create the Dataset below. Since earlier in the tutorial two DNS queries were sent, it is expected that the metrics for \"coredns_dns_request_count_total\" will be \"2.0\" at the end of the time series:"
+        "You can start with `\"coredns_dns_request_count_total\"` and `\"5\"` (secs) to create the Dataset below. Since earlier in the tutorial two DNS queries were sent, it is expected that the metrics for `\"coredns_dns_request_count_total\"` will be `\"2.0\"` at the end of the time series:"
       ]
     },
     {

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -104,7 +104,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial will show how to load CoreDNS metrics into  `tf.data.Dataset` from a [Prometheus](https://prometheus.io) server, so that the loaded metrics could be represented as a `tf.data.Dataset` and passed to `tf.keras` for training or inference purposes.\n",
+        "This tutorial loads CoreDNS metrics from a [Prometheus](https://prometheus.io) server into a `tf.data.Dataset`, then uses `tf.keras` for training and inference.\n",
         "\n",
         "[CoreDNS](https://github.com/coredns/coredns) is a DNS server with a focus on service discovery, and is widely deployed as a part of the [Kubernetes](https://kubernetes.io) cluster. For that reason it is often closely monitoring by devops operations.\n",
         "\n",

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -5,6 +5,7 @@
     "colab": {
       "name": "prometheus.ipynb",
       "provenance": [],
+      "private_outputs": true,
       "collapsed_sections": [
         "Tce3stUlHN0L"
       ],

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -167,7 +167,7 @@
       "source": [
         "### Install and setup CoreDNS and Prometheus\n",
         "\n",
-        "For demo purposes, a CoreDNS server locally with port `9053` open to receive DNS queries and port `9153` (defult) open to expose metrics for scraping. The following is a basic Corefile configuration for CoreDNS iand is available to [download](https://github.com/tensorflow/io/blob/master/docs/tutorials/prometheus/Corefile):\n",
+        "For demo purposes, a CoreDNS server locally with port `9053` open to receive DNS queries and port `9153` (defult) open to expose metrics for scraping. The following is a basic Corefile configuration for CoreDNS and is available to [download](https://github.com/tensorflow/io/blob/master/docs/tutorials/prometheus/Corefile):\n",
         "```\n",
         ".:9053 {\n",
         "  prometheus\n",

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -1,0 +1,471 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "prometheus.ipynb",
+      "provenance": [],
+      "collapsed_sections": [
+        "Tce3stUlHN0L"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Tce3stUlHN0L"
+      },
+      "source": [
+        "##### Copyright 2020 The TensorFlow IO Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "tuOe1ymfHZPu",
+        "colab": {}
+      },
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "qFdPvlXBOdUN"
+      },
+      "source": [
+        "# Load metrics from Prometheus server"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "MfBg1C5NB3X0"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/io/tutorials/prometheus\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/io/blob/master/docs/tutorials/prometheus.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/io/blob/master/docs/tutorials/prometheus.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "      <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/io/docs/tutorials/prometheus.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "xHxb-dlhMIzW"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This tutorial will show how to load CoreDNS metrics into  `tf.data.Dataset` from a [Prometheus](https://prometheus.io) server, so that the loaded metrics could be represented as a `tf.data.Dataset` and passed to `tf.keras` for training or inference purposes.\n",
+        "\n",
+        "[CoreDNS](https://github.com/coredns/coredns) is a DNS server with a focus on service discovery, and is widely deployed as a part of the [Kubernetes](https://kubernetes.io) cluster. For that reason it is often closely monitoring by devops operations.\n",
+        "\n",
+        "This tutorial is an example that could be used by devops looking for automation in their operations through machine learning."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "MUXex9ctTuDB"
+      },
+      "source": [
+        "## Setup and usage"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "upgCc3gXybsA",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Install required tensorflow-io package, and restart runtime"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "uUDYyMZRfkX4",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "try:\n",
+        "  %tensorflow_version 2.x\n",
+        "except Exception:\n",
+        "  pass\n",
+        "!pip install tensorflow-io-nightly"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yZmI7l_GykcW",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Install and setup CoreDNS and Prometheus\n",
+        "\n",
+        "For demo purposes, a CoreDNS server locally with port `9053` open to receive DNS queries and port `9153` (defult) open to expose metrics for scraping. A simple Corefile configuration of CoreDNS is as follows and is available to be [downloaded](https://github.com/tensorflow/io/blob/master/docs/tutorials/prometheus/Corefile):\n",
+        "```\n",
+        ".:9053 {\n",
+        "  prometheus\n",
+        "  whoami\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "More details about installation could be found on CoreDNS's [documentation](https://coredns.io).\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "YUj0878jPyz7",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!curl -s -OL https://github.com/coredns/coredns/releases/download/v1.6.7/coredns_1.6.7_linux_amd64.tgz\n",
+        "!tar -xzf coredns_1.6.7_linux_amd64.tgz\n",
+        "\n",
+        "!curl -s -OL https://raw.githubusercontent.com/tensorflow/io/master/docs/tutorials/prometheus/Corefile\n",
+        "\n",
+        "!cat Corefile\n",
+        "\n",
+        "# Run `./coredns` as a background process.\n",
+        "# IPython doesn't recognize `&` in inline bash cells.\n",
+        "get_ipython().system_raw('./coredns &')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rXji6aQdPQ-a",
+        "colab_type": "text"
+      },
+      "source": [
+        "In order to show some activity, `dig` command could be used to generate a few DNS queries against the CoreDNS server that has been setup:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "7XLuWyE3Pgg0",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!apt-get install -y -qq dnsutils\n",
+        "\n",
+        "!dig @127.0.0.1 -p 9053 demo1.example.org\n",
+        "!dig @127.0.0.1 -p 9053 demo2.example.org"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Afb01zkACsuW",
+        "colab_type": "text"
+      },
+      "source": [
+        "The next step is to setup Prometheus server and use Prometheus to scrape CoreDNS metrics that are exposed on port `9153` from above. The `prometheus.yml` file for configuration is also available for [download](https://github.com/tensorflow/io/blob/master/docs/tutorials/prometheus/prometheus.yml):\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3HHfVdv9D3Jv",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!curl -s -OL https://github.com/prometheus/prometheus/releases/download/v2.15.2/prometheus-2.15.2.linux-amd64.tar.gz\n",
+        "!tar -xzf prometheus-2.15.2.linux-amd64.tar.gz --strip-components=1\n",
+        "\n",
+        "!curl -s -OL https://raw.githubusercontent.com/tensorflow/io/master/docs/tutorials/prometheus/prometheus.yml\n",
+        "\n",
+        "# Run `./prometheus` as a background process.\n",
+        "# IPython doesn't recognize `&` in inline bash cells.\n",
+        "get_ipython().system_raw('./prometheus &')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f61fK3bXQH4N",
+        "colab_type": "text"
+      },
+      "source": [
+        "Now a CoreDNS server whose metrics are scraped by a Prometheus server and ready to be consumed by TensorFlow."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "acEST3amdyDI",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Create Dataset for CoreDNS metrics and use it in TensorFlow\n",
+        "\n",
+        "Create a Dataset for CoreDNS metrics that is available from PostgreSQL server, could be done with `tfio.experimental.IODataset.from_prometheus`. At the minimium two arguments are needed. `query` is passed to Prometheus server to select the metrics and `length` is the period we want to load into Dataset.\n",
+        "\n",
+        "You can start with \"coredns_dns_request_count_total\" and \"5\" (secs) to create the Dataset below. Since earlier in the tutorial two DNS queries were sent, it is expected that the metrics for \"coredns_dns_request_count_total\" will be \"2.0\" at the end of the time series:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "h21RdP7meGzP",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from datetime import datetime\n",
+        "import tensorflow_io as tfio\n",
+        "\n",
+        "dataset = tfio.experimental.IODataset.from_prometheus(\n",
+        "    \"coredns_dns_request_count_total\", 5)\n",
+        "\n",
+        "print(\"Dataset Spec:\\n{}\\n\".format(dataset.element_spec))\n",
+        "\n",
+        "print(\"CoreDNS Time Series:\")\n",
+        "for (time, value) in dataset:\n",
+        "  # time is milli second, convert to data time:\n",
+        "  time = datetime.fromtimestamp(time // 1000)\n",
+        "  print(\"{}: {}\".format(time, value['coredns']['localhost:9153']['coredns_dns_request_count_total']))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8y-VpwcWNYTF",
+        "colab_type": "text"
+      },
+      "source": [
+        "Further looking into the spec of the Dataset:\n",
+        "```\n",
+        "(\n",
+        "  TensorSpec(shape=(), dtype=tf.int64, name=None),\n",
+        "  {\n",
+        "    'coredns': {\n",
+        "      'localhost:9153': {\n",
+        "        'coredns_dns_request_count_total': TensorSpec(shape=(), dtype=tf.float64, name=None)\n",
+        "      }\n",
+        "    }\n",
+        "  }\n",
+        ")\n",
+        "\n",
+        "```\n",
+        "\n",
+        "It is obvious that the dataset consists of a `(time, values)` tuple where the `values` field is a python dict expanded into:\n",
+        "```\n",
+        "\"job_name\": {\n",
+        "  \"instance_name\": {\n",
+        "    \"metric_name\": value,\n",
+        "  },\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "In the above example, 'coredns' is the job name, 'localhost:9153' is the instance name, and 'coredns_dns_request_count_total' is the metric name. Note that depending on the Prometheus query used, it is possible that multiple jobs/instances/metrics could be returned. This is also the reason why python dict has been used in the structure of the Dataset.\n",
+        "\n",
+        "Take another query \"go_memstats_gc_sys_bytes\" as an example. Since both CoreDNS and Prometheus are written in Golang, \"go_memstats_gc_sys_bytes\" metric is available for both \"coredns\" job and \"prometheus\" job:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qCoueXYZOvqZ",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from datetime import datetime\n",
+        "import tensorflow_io as tfio\n",
+        "\n",
+        "dataset = tfio.experimental.IODataset.from_prometheus(\n",
+        "    \"go_memstats_gc_sys_bytes\", 5)\n",
+        "\n",
+        "print(\"Time Series CoreDNS/Prometheus Comparision:\")\n",
+        "for (time, value) in dataset:\n",
+        "  # time is milli second, convert to data time:\n",
+        "  time = datetime.fromtimestamp(time // 1000)\n",
+        "  print(\"{}: {}/{}\".format(\n",
+        "      time,\n",
+        "      value['coredns']['localhost:9153']['go_memstats_gc_sys_bytes'],\n",
+        "      value['prometheus']['localhost:9090']['go_memstats_gc_sys_bytes']))"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xO2pheWEPQSU",
+        "colab_type": "text"
+      },
+      "source": [
+        "The created `Dataset` is ready to be passed to `tf.keras` directly for either training or inference purposes now."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DhVm2fGaoyuA",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Use Dataset for model training\n",
+        "\n",
+        "With metrics Dataset created, it is possible to directly pass the Dataset to `tf.keras` for model training or inference.\n",
+        "\n",
+        "For demo purposes, this tutorial will just use a very simple LSTM model with 1 feature and 2 steps as input:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "fxObBtlvr6n_",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import tensorflow as tf\n",
+        "\n",
+        "n_steps, n_features = 2, 1\n",
+        "simple_lstm_model = tf.keras.models.Sequential([\n",
+        "    tf.keras.layers.LSTM(8, input_shape=(n_steps, n_features)),\n",
+        "    tf.keras.layers.Dense(1)\n",
+        "])\n",
+        "\n",
+        "simple_lstm_model.compile(optimizer='adam', loss='mae')\n"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Moh_tEGZu-3_",
+        "colab_type": "text"
+      },
+      "source": [
+        "The dataset to be used is the value of 'go_memstats_sys_bytes' for CoreDNS with 10 samples. However, since a sliding window of `window=n_steps` and `shift=1` are formed, additional samples are needed (for any two consecute elements, the first is taken as `x` and the second is taken as `y` for training). The total is `10 + n_steps - 1 + 1 = 12` seconds.\n",
+        "\n",
+        "The data value is also scaled to `[0, 1]`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CZmStrvFvJLN",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import tensorflow_io as tfio\n",
+        "\n",
+        "n_samples = 10\n",
+        "\n",
+        "dataset = tfio.experimental.IODataset.from_prometheus(\n",
+        "    \"go_memstats_sys_bytes\", n_samples + n_steps - 1 + 1)\n",
+        "\n",
+        "# take go_memstats_gc_sys_bytes from coredns job \n",
+        "dataset = dataset.map(lambda _, v: v['coredns']['localhost:9153']['go_memstats_sys_bytes'])\n",
+        "\n",
+        "# find the max value and scale the value to [0, 1]\n",
+        "v_max = dataset.reduce(tf.constant(0.0, tf.float64), tf.math.maximum)\n",
+        "dataset = dataset.map(lambda v: (v / v_max))\n",
+        "\n",
+        "# expand the dimension by 1 to fit n_features=1\n",
+        "dataset = dataset.map(lambda v: tf.expand_dims(v, -1))\n",
+        "\n",
+        "# take a sliding window\n",
+        "dataset = dataset.window(n_steps, shift=1, drop_remainder=True)\n",
+        "dataset = dataset.flat_map(lambda d: d.batch(n_steps))\n",
+        "\n",
+        "\n",
+        "# the first value is x and the next value is y, only take 10 samples\n",
+        "x = dataset.take(n_samples)\n",
+        "y = dataset.skip(1).take(n_samples)\n",
+        "\n",
+        "dataset = tf.data.Dataset.zip((x, y))\n",
+        "\n",
+        "# pass the final dataset to model.fit for training\n",
+        "simple_lstm_model.fit(dataset.batch(1).repeat(10),  epochs=5, steps_per_epoch=10)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Df7wrNx2BTWW",
+        "colab_type": "text"
+      },
+      "source": [
+        "The trained model above is not very useful in reality, as the CoreDNS server that has been setup in this tutorial does not have any workload. However, this is a working pipeline that could be used to load metrics from true production servers. The model could then be improved to solve the real-world problem of devops automation."
+      ]
+    }
+  ]
+}

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -159,6 +159,21 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from datetime import datetime\n",
+        "\n",
+        "import tensorflow as tf\n",
+        "import tensorflow_io as tfio"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "yZmI7l_GykcW",
@@ -192,8 +207,18 @@
         "\n",
         "!curl -s -OL https://raw.githubusercontent.com/tensorflow/io/master/docs/tutorials/prometheus/Corefile\n",
         "\n",
-        "!cat Corefile\n",
-        "\n",
+        "!cat Corefile"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "# Run `./coredns` as a background process.\n",
         "# IPython doesn't recognize `&` in inline bash cells.\n",
         "get_ipython().system_raw('./coredns &')"
@@ -223,10 +248,11 @@
       "execution_count": 0,
       "outputs": []
     },
-        {
+    {
       "cell_type": "code",
       "metadata": {
         "colab_type": "code",
+        "id": "uebJbYsbUObO",
         "colab": {}
       },
       "source": [
@@ -235,7 +261,7 @@
       "execution_count": 0,
       "outputs": []
     },
-        {
+    {
       "cell_type": "code",
       "metadata": {
         "colab_type": "code",
@@ -270,6 +296,18 @@
         "\n",
         "!curl -s -OL https://raw.githubusercontent.com/tensorflow/io/master/docs/tutorials/prometheus/prometheus.yml\n",
         "\n",
+        "!cat prometheus.yml"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "# Run `./prometheus` as a background process.\n",
         "# IPython doesn't recognize `&` in inline bash cells.\n",
         "get_ipython().system_raw('./prometheus &')"
@@ -309,9 +347,6 @@
         "colab": {}
       },
       "source": [
-        "from datetime import datetime\n",
-        "import tensorflow_io as tfio\n",
-        "\n",
         "dataset = tfio.experimental.IODataset.from_prometheus(\n",
         "    \"coredns_dns_request_count_total\", 5)\n",
         "\n",
@@ -370,9 +405,6 @@
         "colab": {}
       },
       "source": [
-        "from datetime import datetime\n",
-        "import tensorflow_io as tfio\n",
-        "\n",
         "dataset = tfio.experimental.IODataset.from_prometheus(\n",
         "    \"go_memstats_gc_sys_bytes\", 5)\n",
         "\n",
@@ -420,8 +452,6 @@
         "colab": {}
       },
       "source": [
-        "import tensorflow as tf\n",
-        "\n",
         "n_steps, n_features = 2, 1\n",
         "simple_lstm_model = tf.keras.models.Sequential([\n",
         "    tf.keras.layers.LSTM(8, input_shape=(n_steps, n_features)),\n",
@@ -453,8 +483,6 @@
         "colab": {}
       },
       "source": [
-        "import tensorflow_io as tfio\n",
-        "\n",
         "n_samples = 10\n",
         "\n",
         "dataset = tfio.experimental.IODataset.from_prometheus(\n",

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -99,6 +99,15 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
+      },
+      "source": [
+        "Caution: In addition to python packages this notebook uses `sudo apt-get install` to install third party packages."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
         "id": "xHxb-dlhMIzW"
       },
       "source": [

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -347,7 +347,7 @@
         "}\n",
         "```\n",
         "\n",
-        "In the above example, 'coredns' is the job name, 'localhost:9153' is the instance name, and 'coredns_dns_request_count_total' is the metric name. Note that depending on the Prometheus query used, it is possible that multiple jobs/instances/metrics could be returned. This is also the reason why python dict has been used in the structure of the Dataset.\n",
+        "In the above example, `'coredns'` is the job name, `'localhost:9153'` is the instance name, and `'coredns_dns_request_count_total'` is the metric name. Note that depending on the Prometheus query used, it is possible that multiple jobs/instances/metrics could be returned. This is also the reason why python dict has been used in the structure of the Dataset.\n",
         "\n",
         "Take another query \"go_memstats_gc_sys_bytes\" as an example. Since both CoreDNS and Prometheus are written in Golang, \"go_memstats_gc_sys_bytes\" metric is available for both \"coredns\" job and \"prometheus\" job:"
       ]

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -349,7 +349,7 @@
         "\n",
         "In the above example, `'coredns'` is the job name, `'localhost:9153'` is the instance name, and `'coredns_dns_request_count_total'` is the metric name. Note that depending on the Prometheus query used, it is possible that multiple jobs/instances/metrics could be returned. This is also the reason why python dict has been used in the structure of the Dataset.\n",
         "\n",
-        "Take another query \"go_memstats_gc_sys_bytes\" as an example. Since both CoreDNS and Prometheus are written in Golang, \"go_memstats_gc_sys_bytes\" metric is available for both \"coredns\" job and \"prometheus\" job:"
+        "Take another query `\"go_memstats_gc_sys_bytes\"` as an example. Since both CoreDNS and Prometheus are written in Golang, `\"go_memstats_gc_sys_bytes\"` metric is available for both `\"coredns\"` job and `\"prometheus\"` job:"
       ]
     },
     {

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -229,54 +229,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "rXji6aQdPQ-a",
-        "colab_type": "text"
-      },
-      "source": [
-        "In order to show some activity, `dig` command could be used to generate a few DNS queries against the CoreDNS server that has been setup:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "!sudo apt-get install -y -qq dnsutils"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "uebJbYsbUObO",
-        "colab": {}
-      },
-      "source": [
-        "!dig @127.0.0.1 -p 9053 demo1.example.org"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "!dig @127.0.0.1 -p 9053 demo2.example.org"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Afb01zkACsuW",
         "colab_type": "text"
       },
       "source": [
@@ -286,7 +238,6 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "3HHfVdv9D3Jv",
         "colab_type": "code",
         "colab": {}
       },
@@ -311,6 +262,52 @@
         "# Run `./prometheus` as a background process.\n",
         "# IPython doesn't recognize `&` in inline bash cells.\n",
         "get_ipython().system_raw('./prometheus &')"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text"
+      },
+      "source": [
+        "In order to show some activity, `dig` command could be used to generate a few DNS queries against the CoreDNS server that has been setup:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "FN0YNdstBl8M",
+        "colab": {}
+      },
+      "source": [
+        "!sudo apt-get install -y -qq dnsutils"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!dig @127.0.0.1 -p 9053 demo1.example.org"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!dig @127.0.0.1 -p 9053 demo2.example.org"
       ],
       "execution_count": 0,
       "outputs": []
@@ -348,7 +345,7 @@
       },
       "source": [
         "dataset = tfio.experimental.IODataset.from_prometheus(\n",
-        "    \"coredns_dns_request_count_total\", 5)\n",
+        "    \"coredns_dns_request_count_total\", 5, endpoint=\"http://localhost:9090\")\n",
         "\n",
         "print(\"Dataset Spec:\\n{}\\n\".format(dataset.element_spec))\n",
         "\n",
@@ -406,7 +403,7 @@
       },
       "source": [
         "dataset = tfio.experimental.IODataset.from_prometheus(\n",
-        "    \"go_memstats_gc_sys_bytes\", 5)\n",
+        "    \"go_memstats_gc_sys_bytes\", 5, endpoint=\"http://localhost:9090\")\n",
         "\n",
         "print(\"Time Series CoreDNS/Prometheus Comparision:\")\n",
         "for (time, value) in dataset:\n",
@@ -486,7 +483,7 @@
         "n_samples = 10\n",
         "\n",
         "dataset = tfio.experimental.IODataset.from_prometheus(\n",
-        "    \"go_memstats_sys_bytes\", n_samples + n_steps - 1 + 1)\n",
+        "    \"go_memstats_sys_bytes\", n_samples + n_steps - 1 + 1, endpoint=\"http://localhost:9090\")\n",
         "\n",
         "# take go_memstats_gc_sys_bytes from coredns job \n",
         "dataset = dataset.map(lambda _, v: v['coredns']['localhost:9153']['go_memstats_sys_bytes'])\n",

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -204,14 +204,34 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "7XLuWyE3Pgg0",
         "colab_type": "code",
         "colab": {}
       },
       "source": [
-        "!apt-get install -y -qq dnsutils\n",
-        "\n",
-        "!dig @127.0.0.1 -p 9053 demo1.example.org\n",
+        "!sudo apt-get install -y -qq dnsutils"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+        {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "!dig @127.0.0.1 -p 9053 demo1.example.org"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+        {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "!dig @127.0.0.1 -p 9053 demo2.example.org"
       ],
       "execution_count": 0,

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -157,7 +157,7 @@
       "source": [
         "### Install and setup CoreDNS and Prometheus\n",
         "\n",
-        "For demo purposes, a CoreDNS server locally with port `9053` open to receive DNS queries and port `9153` (defult) open to expose metrics for scraping. A simple Corefile configuration of CoreDNS is as follows and is available to be [downloaded](https://github.com/tensorflow/io/blob/master/docs/tutorials/prometheus/Corefile):\n",
+        "For demo purposes, a CoreDNS server locally with port `9053` open to receive DNS queries and port `9153` (defult) open to expose metrics for scraping. The following is a basic Corefile configuration for CoreDNS iand is available to [download](https://github.com/tensorflow/io/blob/master/docs/tutorials/prometheus/Corefile):\n",
         "```\n",
         ".:9053 {\n",
         "  prometheus\n",

--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -99,7 +99,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
+        "colab_type": "text"
       },
       "source": [
         "Caution: In addition to python packages this notebook uses `sudo apt-get install` to install third party packages."


### PR DESCRIPTION
This PR adds tutorial to load metrics from prometheus server
into tf.data.Dataset, so that it could be used for tf.keras
and model training.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>