### PR TITLE
Add tfio.genome tutorial

### DIFF
--- a/docs/tutorials/_toc.yaml
+++ b/docs/tutorials/_toc.yaml
@@ -20,3 +20,5 @@ toc:
   path: /io/tutorials/dicom
 - title: "Azure blob storage with TensorFlow"
   path: /io/tutorials/azure
+- title: "Genomics IO"
+  path: /io/tutorials/genome

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -1,0 +1,238 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Tensorflow IO Genomics Tutorial",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [
+        "Tce3stUlHN0L"
+      ],
+      "toc_visible": true,
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/suyashkumar/io/blob/s%2Fadd-genome-tutorial/docs/tutorials/genome.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Tce3stUlHN0L"
+      },
+      "source": [
+        "##### Copyright 2020 The TensorFlow Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "cellView": "form",
+        "colab_type": "code",
+        "id": "tuOe1ymfHZPu",
+        "colab": {}
+      },
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "qFdPvlXBOdUN"
+      },
+      "source": [
+        "# Tensorflow IO Genomics Tutorial\n",
+        "_by [suyashkumar@](https://github.com/suyashkumar)_"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "MfBg1C5NB3X0"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/io/genome\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/io/docs/tutorials/genome.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/io/blob/master/docs/tutorials/genome.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "xHxb-dlhMIzW"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "This tutorial demonstrates the `tfio.genome` package functionality (which is currently a work in progress--contributions are welcome). The goal of this package is to provide commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "MUXex9ctTuDB"
+      },
+      "source": [
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "IqR2PQG4ZaZ0",
+        "colab": {}
+      },
+      "source": [
+        "%tensorflow_version 2.x\n",
+        "!pip install tensorflow-io"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bkF2WtCMaJ-3",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import tensorflow_io as tfio\n",
+        "import tensorflow as tf"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6wkjlql3cOy0",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Read in FASTQ Data\n",
+        "FASTQ is a common genomics file format that stores both sequence information in addition to base quality information.\n",
+        "\n",
+        "First, let's download a sample `fastq` file."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yASvppCxceBu",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Download some sample data:\n",
+        "!curl -OL https://raw.githubusercontent.com/tensorflow/io/97acfce1445c0ccd172deab4f540c4d970573aca/tests/test_genome/test.fastq"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3zekWXlVdprb",
+        "colab_type": "text"
+      },
+      "source": [
+        "Now, let's use `tfio.genome.read_fastq` to read this file (note a `tf.data` API coming soon)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vl761cHTc7N1",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "fastq_data = tfio.genome.read_fastq(filename=\"test.fastq\")\n",
+        "print(fastq_data.sequences)\n",
+        "print(fastq_data.raw_quality)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qxHjVKXzdx5W",
+        "colab_type": "text"
+      },
+      "source": [
+        "As you see, the returned `fastq_data` has `fastq_data.sequences` which is a string tensor of all sequences in the fastq file (which can each be a different size) along with `fastq_data.raw_quality` which includes Phred encoded quality information about the quality of each base read in the sequence.\n",
+        "\n",
+        "We can use a helper op to convert this quality information into probabilities if we are interested."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6IYxfFI4eQTM",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "quality = tfio.genome.phred_sequences_to_probability(fastq_data.raw_quality)\n",
+        "print(quality)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
+}

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -115,7 +115,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates the `tfio.genome` package functionality (which is currently a work in progress--contributions are welcome). The goal of this package is to provide commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). "
+        "This tutorial demonstrates the `tfio.genome` package functionality (which is currently __a work in progress__--contributions are welcome). The goal of this package is to provide commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). "
       ]
     },
     {
@@ -163,7 +163,7 @@
         "colab_type": "text"
       },
       "source": [
-        "## Read in FASTQ Data\n",
+        "## FASTQ Data\n",
         "FASTQ is a common genomics file format that stores both sequence information in addition to base quality information.\n",
         "\n",
         "First, let's download a sample `fastq` file."
@@ -190,6 +190,7 @@
         "colab_type": "text"
       },
       "source": [
+        "### Read FASTQ Data\n",
         "Now, let's use `tfio.genome.read_fastq` to read this file (note a `tf.data` API coming soon)."
       ]
     },
@@ -217,6 +218,7 @@
       "source": [
         "As you see, the returned `fastq_data` has `fastq_data.sequences` which is a string tensor of all sequences in the fastq file (which can each be a different size) along with `fastq_data.raw_quality` which includes Phred encoded quality information about the quality of each base read in the sequence.\n",
         "\n",
+        "### Quality\n",
         "We can use a helper op to convert this quality information into probabilities if we are interested."
       ]
     },
@@ -230,6 +232,31 @@
       "source": [
         "quality = tfio.genome.phred_sequences_to_probability(fastq_data.raw_quality)\n",
         "print(quality)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bg3wzTFzhcfS",
+        "colab_type": "text"
+      },
+      "source": [
+        "### One hot encodings\n",
+        "We may also want to encode the genome sequence data (which consists of `A` `T` `C` `G` bases) using a one hot encoder. There's a built in operation that can help with this.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oAiepmy8h32a",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "one_hot = tfio.genome.sequences_to_onehot(fastq_data.sequences)\n",
+        "print(one_hot)"
       ],
       "execution_count": 0,
       "outputs": []

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -232,7 +232,7 @@
       },
       "source": [
         "### One hot encodings\n",
-        "We may also want to encode the genome sequence data (which consists of `A` `T` `C` `G` bases) using a one hot encoder. There's a built in operation that can help with this.\n"
+        "You may also want to encode the genome sequence data (which consists of `A` `T` `C` `G` bases) using a one hot encoder. There's a built in operation that can help with this.\n"
       ]
     },
     {

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -98,7 +98,7 @@
         "\n",
         "This tutorial demonstrates the `tfio.genome` package that provides commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). \n",
         "\n",
-        "This package uses [Google Nucleus](https://github.com/google/nucleus) library to provide some of the core functionality. "
+        "This package uses the [Google Nucleus](https://github.com/google/nucleus) library to provide some of the core functionality. "
       ]
     },
     {

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -68,29 +68,21 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "qFdPvlXBOdUN"
-      },
-      "source": [
-        "# Tensorflow IO Genomics Tutorial\n",
-        "_by [suyashkumar@](https://github.com/suyashkumar)_"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
         "id": "MfBg1C5NB3X0"
       },
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/io/genome\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/io/tutorials/genome\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/io/docs/tutorials/genome.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/io/blob/master/docs/tutorials/genome.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/io/blob/master/docs/tutorials/genome.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "      <td>\n",
+        "    <a href=\"https://raw.githubusercontent.com/tensorflow/io/master/docs/tutorials/dicom.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
         "  </td>\n",
         "</table>"
       ]
@@ -127,7 +119,10 @@
         "colab": {}
       },
       "source": [
-        "%tensorflow_version 2.x\n",
+        "try:\n",
+        "  %tensorflow_version 2.x\n",
+        "except Exception:\n",
+        "  pass\n",
         "!pip install tensorflow-io"
       ],
       "execution_count": 0,
@@ -169,7 +164,7 @@
       },
       "source": [
         "# Download some sample data:\n",
-        "!curl -OL https://raw.githubusercontent.com/tensorflow/io/97acfce1445c0ccd172deab4f540c4d970573aca/tests/test_genome/test.fastq"
+        "!curl -OL https://raw.githubusercontent.com/tensorflow/io/master/tests/test_genome/test.fastq"
       ],
       "execution_count": 0,
       "outputs": []
@@ -222,6 +217,8 @@
       },
       "source": [
         "quality = tfio.genome.phred_sequences_to_probability(fastq_data.raw_quality)\n",
+        "print(quality.shape)\n",
+        "print(quality.row_lengths().numpy())\n",
         "print(quality)"
       ],
       "execution_count": 0,
@@ -248,6 +245,19 @@
       "source": [
         "one_hot = tfio.genome.sequences_to_onehot(fastq_data.sequences)\n",
         "print(one_hot)\n",
+        "print(one_hot.shape)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oAiepmy8h32a",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "print(tfio.genome.sequences_to_onehot.__doc__)"
       ],
       "execution_count": 0,

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -9,8 +9,7 @@
       "collapsed_sections": [
         "Tce3stUlHN0L"
       ],
-      "toc_visible": true,
-      "include_colab_link": true
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -31,16 +30,6 @@
     }
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/suyashkumar/io/blob/s%2Fadd-genome-tutorial/docs/tutorials/genome.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -115,7 +104,9 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates the `tfio.genome` package functionality (which is currently __a work in progress__--contributions are welcome). The goal of this package is to provide commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). "
+        "This tutorial demonstrates the `tfio.genome` package functionality (which is currently __a work in progress__--contributions are welcome). The goal of this package is to provide commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). \n",
+        "\n",
+        "We use the [Google Nucleus](https://github.com/google/nucleus) library to provide some of the core functionality. "
       ]
     },
     {

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -247,7 +247,8 @@
       },
       "source": [
         "one_hot = tfio.genome.sequences_to_onehot(fastq_data.sequences)\n",
-        "print(one_hot)"
+        "print(one_hot)\n",
+        "print(tfio.genome.sequences_to_onehot.__doc__)"
       ],
       "execution_count": 0,
       "outputs": []

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -96,7 +96,7 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial demonstrates the `tfio.genome` package functionality (which is currently __a work in progress__--contributions are welcome). The goal of this package is to provide commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). \n",
+        "This tutorial demonstrates the `tfio.genome` package that provides commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). \n",
         "\n",
         "We use the [Google Nucleus](https://github.com/google/nucleus) library to provide some of the core functionality. "
       ]

--- a/docs/tutorials/genome.ipynb
+++ b/docs/tutorials/genome.ipynb
@@ -98,7 +98,7 @@
         "\n",
         "This tutorial demonstrates the `tfio.genome` package that provides commonly used genomics IO functionality--namely reading several genomics file formats and also providing some common operations for preparing the data (for example--one hot encoding or parsing Phred quality into probabilities). \n",
         "\n",
-        "We use the [Google Nucleus](https://github.com/google/nucleus) library to provide some of the core functionality. "
+        "This package uses [Google Nucleus](https://github.com/google/nucleus) library to provide some of the core functionality. "
       ]
     },
     {
@@ -205,7 +205,7 @@
         "As you see, the returned `fastq_data` has `fastq_data.sequences` which is a string tensor of all sequences in the fastq file (which can each be a different size) along with `fastq_data.raw_quality` which includes Phred encoded quality information about the quality of each base read in the sequence.\n",
         "\n",
         "### Quality\n",
-        "We can use a helper op to convert this quality information into probabilities if we are interested."
+        "You can use a helper op to convert this quality information into probabilities if we are interested."
       ]
     },
     {


### PR DESCRIPTION
This adds an initial tutorial of the `tfio.genome` functionality. [Here's a link to the colab](https://colab.research.google.com/drive/1YQRJ1_v1lxJT7IVvwnRWJUoHAHgwjJ_N). 

It's pretty barebones right now, as there's a fair bit more that needs to be added to the genome package (including a `tf.data` API). Let me know if you think we should proceed as this is for now, or if we would want to wait to build out some of the genome API farther first--either way seems reasonable to me! 