### PR TITLE
Update tf_configure.bzl to allow centos 7 build, and add README.md section

### DIFF
--- a/.github/workflows/build.develop.py
+++ b/.github/workflows/build.develop.py
@@ -1,0 +1,17 @@
+import sys
+
+source = sys.argv[1]
+section = sys.argv[2]
+with open (source, "r") as f:
+    lines = [line.rstrip() for line in list(f)]
+
+# Remove lines before section title
+lines = lines[lines.index(section):]
+
+# Remove lines outside (including) "```sh" and "```"
+lines = lines[lines.index("```sh")+1:lines.index("```")]
+
+# Remove sudo
+lines = [(line[len("sudo "):] if line.startswith("sudo ") else line) for line in lines]
+
+print("\n".join(lines))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,30 @@ jobs:
           sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
           bazel run -s --verbose_failures //tools/lint:check
 
+  ubuntu-1804:
+    name: Ubuntu 18.04
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          set -x -e
+          python3 .github/workflows/build.develop.py README.md "##### Ubuntu 18.04" > source.sh
+          cat source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
+            bash -x -e source.sh
+
+  centos-7:
+    name: CentOS 7
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          set -x -e
+          python3 .github/workflows/build.develop.py README.md "##### CentOS 7" > source.sh
+          cat source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host centos:7 \
+            bash -x -e source.sh
+
   macos-bazel:
     name: Bazel macOS
     runs-on: macos-latest

--- a/third_party/toolchains/tf/tf_configure.bzl
+++ b/third_party/toolchains/tf/tf_configure.bzl
@@ -156,6 +156,7 @@ def _symlink_genrule_for_dir(
         else:
             dest_files = files.replace(src_dir, "").splitlines()
         src_files = files.splitlines()
+
         # Centos may have header files in both lib and lib64:
         if src_dir.count("/lib64/"):
             extra_src_dir = src_dir.replace("/lib64/", "/lib/")

--- a/third_party/toolchains/tf/tf_configure.bzl
+++ b/third_party/toolchains/tf/tf_configure.bzl
@@ -156,6 +156,14 @@ def _symlink_genrule_for_dir(
         else:
             dest_files = files.replace(src_dir, "").splitlines()
         src_files = files.splitlines()
+        # Centos may have header files in both lib and lib64:
+        if src_dir.count("/lib64/"):
+            extra_src_dir = src_dir.replace("/lib64/", "/lib/")
+            extra_files = "\n".join(sorted(_read_dir(repository_ctx, extra_src_dir).splitlines()))
+            extra_dest_files = extra_files.replace(extra_src_dir, "").splitlines()
+            extra_src_files = extra_files.splitlines()
+            src_files = src_files + extra_src_files
+            dest_files = dest_files + extra_dest_files
     command = []
     outs = []
 


### PR DESCRIPTION
This PR fixes the issue raised in #722 where tensorflow-io could not be compiled on CentOS 7.

The issue was that, CentOS 7's gcc version is too old, the libstdc++ version is also too old. In addition, CentOS's tensorflow header and libs are both `/lib64/` and `/lib/`, which is not captured in tf_configure.bzl.

This PR updates several places:
1. Add special handling in tf_configure.bzl to capture `/lib64/` and `/lib/`
2. Use devtoolset-9 to build .so on CentOS
3. Use static libs linkage for libstdc++ through:
   ```
   BAZEL_LINKOPTS="-static-libstdc++ -static-libgcc" \
      BAZEL_LINKLIBS="-lm -l%:libstdc++.a"
   ```

Additional sections in README.md have been added to show the complete shell to build on CentOS 7 and Ubuntu 18.04. Two GitHub CI workflow have been added as well to validate the build on CentOS 7 and Ubuntu 18.04.

This PR fixes #722 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

