### PR TITLE
Add additional patch on grpc to allow using python3 only

### DIFF
--- a/.github/workflows/build.instruction.py
+++ b/.github/workflows/build.instruction.py
@@ -1,7 +1,11 @@
 import sys
 
-source = sys.argv[1]
-section = sys.argv[2]
+sudo = False
+if sys.argv[1].startswith("--sudo="):
+  sudo = (sys.argv[1][7:].lower() == "true")
+
+source = sys.argv[len(sys.argv) - 2]
+section = sys.argv[len(sys.argv) - 1]
 with open (source, "r") as f:
     lines = [line.rstrip() for line in list(f)]
 
@@ -12,6 +16,7 @@ lines = lines[lines.index(section):]
 lines = lines[lines.index("```sh")+1:lines.index("```")]
 
 # Remove sudo
-lines = [(line[len("sudo "):] if line.startswith("sudo ") else line) for line in lines]
+if not sudo:
+  lines = [(line[len("sudo "):] if line.startswith("sudo ") else line) for line in lines]
 
 print("\n".join(lines))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,18 @@ jobs:
           docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
             bash -x -e source.sh
 
+  centos-8:
+    name: CentOS 8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          set -x -e
+          python3 .github/workflows/build.develop.py README.md "##### CentOS 8" > source.sh
+          cat source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host centos:8 \
+            bash -x -e source.sh
+
   centos-7:
     name: CentOS 7
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: |
           set -x -e
-          python3 .github/workflows/build.develop.py README.md "##### Ubuntu 18.04" > source.sh
+          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04" > source.sh
           cat source.sh
           docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
             bash -x -e source.sh
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: |
           set -x -e
-          python3 .github/workflows/build.develop.py README.md "##### CentOS 8" > source.sh
+          python3 .github/workflows/build.instruction.py README.md "##### CentOS 8" > source.sh
           cat source.sh
           docker run -i --rm -v $PWD:/v -w /v --net=host centos:8 \
             bash -x -e source.sh
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: |
           set -x -e
-          python3 .github/workflows/build.develop.py README.md "##### CentOS 7" > source.sh
+          python3 .github/workflows/build.instruction.py README.md "##### CentOS 7" > source.sh
           cat source.sh
           docker run -i --rm -v $PWD:/v -w /v --net=host centos:7 \
             bash -x -e source.sh

--- a/README.md
+++ b/README.md
@@ -163,7 +163,35 @@ sudo bash -x -e bazel-2.0.0-installer-linux-x86_64.sh
 # Upgrade pip
 sudo python3 -m pip install -U pip
 
-# Install tensorflow and configure bazel with rh-python36
+# Install tensorflow and configure bazel
+./configure.sh
+
+# Build shared libraries
+bazel build -s --verbose_failures //tensorflow_io/...
+
+# Once build is complete, shared libraries will be available in
+# `bazel-bin/tensorflow_io/core/python/ops/` and it is possible
+# to run tests with `pytest`, e.g.:
+sudo python3 -m pip install pytest
+TFIO_DATAPATH=bazel-bin python3 -m pytest -s -v tests/test_serialization_eager.py
+```
+
+##### CentOS 8
+
+CentOS 8 requires gcc/g++, git, and python 3. The following will install dependencies and build
+the shared libraries on Ubuntu 18.04:
+```sh
+# Install gcc/g++, git, unzip/which (for bazel), and python3
+sudo yum install -y python3 gcc gcc-c++ git unzip which
+
+# Install Bazel 2.0.0
+curl -sSOL https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh
+sudo bash -x -e bazel-2.0.0-installer-linux-x86_64.sh
+
+# Upgrade pip
+sudo python3 -m pip install -U pip
+
+# Install tensorflow and configure bazel
 ./configure.sh
 
 # Build shared libraries

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ CentOS 8 requires gcc/g++, git, and python 3. The following will install depende
 the shared libraries on Ubuntu 18.04:
 ```sh
 # Install gcc/g++, git, unzip/which (for bazel), and python3
-sudo yum install -y python3 gcc gcc-c++ git unzip which
+sudo yum install -y python3 python3-devel gcc gcc-c++ git unzip which
 
 # Install Bazel 2.0.0
 curl -sSOL https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh

--- a/README.md
+++ b/README.md
@@ -149,20 +149,19 @@ versions might be required though.
 
 ##### Ubuntu 18.04
 
-Ubuntu 18.04 requires gcc/g++, git, and python 3. However, due to a dependency of grpc, python-dev
-is also needed. As such the following will install dependencies and build the shared libraries on
-Ubuntu 18.04:
+Ubuntu 18.04 requires gcc/g++, git, and python 3. The following will install dependencies and build
+the shared libraries on Ubuntu 18.04:
 ```sh
 # Install gcc/g++, git, unzip/curl (for bazel), and python3
 sudo apt-get -y -qq update
-sudo apt-get -y -qq install gcc g++ git unzip curl python3-pip python-dev
+sudo apt-get -y -qq install gcc g++ git unzip curl python3-pip
 
 # Install Bazel 2.0.0
 curl -sSOL https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh
 sudo bash -x -e bazel-2.0.0-installer-linux-x86_64.sh
 
 # Upgrade pip
-python3 -m pip install -U pip
+sudo python3 -m pip install -U pip
 
 # Install tensorflow and configure bazel with rh-python36
 ./configure.sh
@@ -173,7 +172,7 @@ bazel build -s --verbose_failures //tensorflow_io/...
 # Once build is complete, shared libraries will be available in
 # `bazel-bin/tensorflow_io/core/python/ops/` and it is possible
 # to run tests with `pytest`, e.g.:
-python3 -m pip install pytest
+sudo python3 -m pip install pytest
 TFIO_DATAPATH=bazel-bin python3 -m pytest -s -v tests/test_serialization_eager.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,30 +116,33 @@ version of TensorFlow I/O according to the table below:
 On macOS Catalina or higher, it is possible to build tensorflow-io with
 system provided python 3 (3.7.3). Both `tensorflow` and `bazel` are needed.
 
-To install latest tensorflow:
+Note there is a bug in macOS's native python 3.7.3 that could be fixed
+with https://github.com/tensorflow/tensorflow/issues/33183#issuecomment-554701214
+
 ```sh
-% sudo python3 -m pip install tensorflow
+# Install bazel 2.0.0:
+curl -OL https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-darwin-x86_64.sh
+sudo bash -x -e bazel-2.0.0-installer-darwin-x86_64.sh
+
+# Install latest tensorflow
+sudo python3 -m pip install tensorflow
+
+# Configure bazel
+./configure.sh
+
+# Build shared libraries
+bazel build -s --verbose_failures //tensorflow_io/...
+
+# Once build is complete, shared libraries will be available in
+# `bazel-bin/tensorflow_io/core/python/ops/` and it is possible
+# to run tests with `pytest`, e.g.:
+sudo python3 -m pip install pytest
+TFIO_DATAPATH=bazel-bin python3 -m pytest -s -v tests/test_serialization_eager.py
 ```
 
-Note there is a bug in macOS's native python 3.7.3 that could be fixed with https://github.com/tensorflow/tensorflow/issues/33183#issuecomment-554701214
-
-To install bazel 2.0.0:
-```sh
-% curl -OL https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-darwin-x86_64.sh
-% sudo bash -x -e bazel-2.0.0-installer-darwin-x86_64.sh
-```
-
-Then use the following to configure the bazel and build C++:
-```sh
-% ./configure.sh
-% bazel build -s --verbose_failures //tensorflow_io/...
-```
-
-The generated shared libraries (.so) are located in bazel-bin directory. With shared libraries
-available, it is possible to run tests with pytest, e.g.:
-```sh
-% TFIO_DATAPATH=bazel-bin python3 -m pytest -s -v tests/test_serialization_eager.py
-```
+Note from the above the generated shared libraries (.so) are located in bazel-bin directory.
+When running pytest, `TFIO_DATAPATH=bazel-bin` has to be passed for shared libraries to
+be located by python.
 
 #### Linux
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -372,6 +372,10 @@ pip_install()
 
 http_archive(
     name = "com_github_grpc_grpc",
+    patch_cmds = [
+        """sed -i.bak 's/"python",/"python3",/g' third_party/py/python_configure.bzl""",
+        """sed -i.bak 's/PYTHONHASHSEED=0/PYTHONHASHSEED=0 python3/g' bazel/cython_library.bzl""",
+    ],
     sha256 = "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81",
     strip_prefix = "grpc-1.26.0",
     urls = [


### PR DESCRIPTION
This PR add additional patch on grpc to allow using python3 without python2 dependency. Previously, due to the dependency of grpc, both python2 and python3 has to be available in the system to build tensorflow-io.

This PR patches grpc source code to remove the need for python2.

This PR also adds an additional section in README with instructions to build on CentOS 8.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>