### PR TITLE
Add support of full access to any offset for KafkaIOTensor

### DIFF
--- a/tensorflow_io/core/kernels/kafka_kernels.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels.cc
@@ -58,10 +58,10 @@ class KafkaEventCb : public RdKafka::EventCb {
   bool run_ GUARDED_BY(mu_) = true;
 };
 
-class KafkaResourceBase : public ResourceBase {
+class KafkaReadableResource : public ResourceBase {
  public:
-  KafkaResourceBase(Env* env) : env_(env) {}
-  virtual ~KafkaResourceBase() {
+  KafkaReadableResource(Env* env) : env_(env) {}
+  virtual ~KafkaReadableResource() {
     if (consumer_.get()) {
       consumer_->unassign();
       consumer_->close();
@@ -69,9 +69,8 @@ class KafkaResourceBase : public ResourceBase {
     }
   }
 
-  virtual Status InitBase(const string& topic, const int32 partition,
-                          const int64 offset,
-                          const std::vector<string>& metadata) {
+  virtual Status Init(const string& topic, const int32 partition,
+                      const int64 offset, const std::vector<string>& metadata) {
     std::unique_ptr<RdKafka::Conf> conf(
         RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
     std::unique_ptr<RdKafka::Conf> conf_topic(
@@ -164,156 +163,7 @@ class KafkaResourceBase : public ResourceBase {
 
     return Status::OK();
   }
-  string DebugString() const override { return "KafkaBaseResource"; }
-
- protected:
-  mutable mutex mu_;
-  Env* env_ GUARDED_BY(mu_);
-  std::unique_ptr<RdKafka::TopicPartition> subscription_ GUARDED_BY(mu_);
-  std::unique_ptr<RdKafka::KafkaConsumer> consumer_ GUARDED_BY(mu_);
-  KafkaEventCb kafka_event_cb_ = KafkaEventCb();
-  static const int timeout_ = 5000;
-};
-
-class KafkaReadableResource : public KafkaResourceBase {
- public:
-  KafkaReadableResource(Env* env) : KafkaResourceBase(env) {}
-  ~KafkaReadableResource() {}
-
-  Status Init(const string& topic, const int32 partition, const int64 start,
-              const int64 stop, const std::vector<string>& metadata) {
-    mutex_lock l(mu_);
-    InitBase(topic, partition, start, metadata);
-
-    // Resolve head message:
-    std::unique_ptr<RdKafka::Message> message;
-    do {
-      message.reset(consumer_->consume(timeout_));
-    } while (message->err() == RdKafka::ERR__TRANSPORT);
-    if (message->err() != RdKafka::ERR_NO_ERROR) {
-      return errors::Internal("failed to consume head message: ",
-                              RdKafka::err2str(message->err()));
-    }
-    start_ = message->offset();
-    LOG(INFO) << "Kafka start: " << start_;
-
-    // Resolve tail message:
-    if (stop == -1) {
-      subscription_->set_offset(RdKafka::Consumer::OffsetTail(1));
-    } else {
-      subscription_->set_offset(stop - 1);
-    }
-    RdKafka::ErrorCode err = consumer_->seek(*subscription_, timeout_);
-    if (err != RdKafka::ERR_NO_ERROR) {
-      return errors::Internal("failed to seek tail -1: ",
-                              RdKafka::err2str(err));
-    }
-    do {
-      message.reset(consumer_->consume(timeout_));
-    } while (message->err() == RdKafka::ERR__TRANSPORT);
-    if (message->err() != RdKafka::ERR_NO_ERROR) {
-      return errors::Internal("failed to consume tail message: ",
-                              RdKafka::err2str(message->err()));
-    }
-    stop_ = message->offset() + 1;
-    LOG(INFO) << "Kafka stop: " << stop_;
-
-    subscription_->set_offset(start_);
-    err = consumer_->seek(*subscription_, timeout_);
-    if (err != RdKafka::ERR_NO_ERROR) {
-      return errors::Internal("failed to seek start: ", RdKafka::err2str(err));
-    }
-
-    return Status::OK();
-  }
-  Status Spec(int64* start, int64* stop) {
-    mutex_lock l(mu_);
-    *start = start_;
-    *stop = stop_;
-    return Status::OK();
-  }
-  Status Read(const int64 start, const int64 stop,
-              std::function<Status(const TensorShape& shape, Tensor** message,
-                                   Tensor** key)>
-                  allocate_func) {
-    mutex_lock l(mu_);
-
-    int64 element_start = start;
-    if (element_start > stop_) {
-      element_start = stop_;
-    }
-    int64 element_stop = stop;
-    if (element_stop > stop_) {
-      element_stop = stop_;
-    }
-
-    std::vector<string> message_value, key_value;
-    message_value.reserve(element_stop - element_start);
-    key_value.reserve(element_stop - element_start);
-
-    subscription_->set_offset(element_start);
-    RdKafka::ErrorCode err = consumer_->seek((*subscription_), timeout_);
-    if (err != RdKafka::ERR_NO_ERROR) {
-      return errors::Internal("failed to seek partition: ",
-                              RdKafka::err2str(err));
-    }
-    LOG(INFO) << "Kafka stream starts with current offset: "
-              << subscription_->offset();
-    int64 index = start;
-    std::unique_ptr<RdKafka::Message> message;
-    while (consumer_.get() != nullptr && index + 1 < element_stop) {
-      if (!kafka_event_cb_.run()) {
-        return errors::Internal("failed to consume due to all brokers down");
-      }
-      message.reset(consumer_->consume(timeout_));
-      if (message->err() == RdKafka::ERR_NO_ERROR) {
-        // Produce the line as output.
-        message_value.emplace_back(string(
-            static_cast<const char*>(message->payload()), message->len()));
-        key_value.emplace_back(
-            (message->key() != nullptr) ? string(*message->key()) : "");
-        index = message->offset();
-        continue;
-      } else if (message->err() == RdKafka::ERR__TRANSPORT) {
-        // Not return error here because consumer will try re-connect.
-        LOG(ERROR) << "Broker transport failure: " << message->errstr();
-      } else if (message->err() != RdKafka::ERR__TIMED_OUT) {
-        LOG(ERROR) << "Failed to consume: " << message->errstr();
-        return errors::Internal("Failed to consume: ", message->errstr());
-      }
-    }
-    TensorShape shape({static_cast<int64>(message_value.size())});
-    Tensor* message_tensor;
-    Tensor* key_tensor;
-    TF_RETURN_IF_ERROR(allocate_func(shape, &message_tensor, &key_tensor));
-    for (size_t i = 0; i < message_value.size(); i++) {
-      message_tensor->flat<string>()(i) = message_value[i];
-      key_tensor->flat<string>()(i) = key_value[i];
-    }
-    return Status::OK();
-  }
-  string DebugString() const override { return "KafkaReadableResource"; }
-
- private:
-  int64 start_ GUARDED_BY(mu_);
-  int64 stop_ GUARDED_BY(mu_);
-};
-
-class KafkaIterableResource : public KafkaResourceBase {
- public:
-  KafkaIterableResource(Env* env) : KafkaResourceBase(env) {}
-  ~KafkaIterableResource() {}
-
-  Status Init(const string& topic, const int32 partition, const int64 offset,
-              const std::vector<string>& metadata) {
-    mutex_lock l(mu_);
-    InitBase(topic, partition, offset, metadata);
-
-    offset_ = offset;
-
-    return Status::OK();
-  }
-  Status Read(const int64 index,
+  Status Next(const int64 index,
               std::function<Status(const TensorShape& shape, Tensor** message,
                                    Tensor** key)>
                   allocate_func) {
@@ -362,10 +212,129 @@ class KafkaIterableResource : public KafkaResourceBase {
     }
     return Status::OK();
   }
-  string DebugString() const override { return "KafkaIterableResource"; }
+  Status Read(const int64 start, const int64 stop,
+              std::function<Status(const TensorShape& shape, Tensor** message,
+                                   Tensor** key)>
+                  allocate_func) {
+    mutex_lock l(mu_);
 
- private:
-  int64 offset_ GUARDED_BY(mu_);
+    std::vector<string> message_value, key_value;
+
+    subscription_->set_offset(start);
+    RdKafka::ErrorCode err = consumer_->seek((*subscription_), timeout_);
+    if (err != RdKafka::ERR_NO_ERROR) {
+      return errors::Internal("failed to seek partition: ",
+                              RdKafka::err2str(err));
+    }
+    LOG(INFO) << "Kafka stream starts with current offset: "
+              << subscription_->offset();
+    int64 index = start;
+    std::unique_ptr<RdKafka::Message> message;
+    while (consumer_.get() != nullptr && index + 1 < stop) {
+      if (!kafka_event_cb_.run()) {
+        return errors::Internal("failed to consume due to all brokers down");
+      }
+      message.reset(consumer_->consume(timeout_));
+      if (message->err() == RdKafka::ERR_NO_ERROR) {
+        // Produce the line as output.
+        message_value.emplace_back(string(
+            static_cast<const char*>(message->payload()), message->len()));
+        key_value.emplace_back(
+            (message->key() != nullptr) ? string(*message->key()) : "");
+        index = message->offset();
+        continue;
+      } else if (message->err() == RdKafka::ERR__TRANSPORT) {
+        // Not return error here because consumer will try re-connect.
+        LOG(ERROR) << "Broker transport failure: " << message->errstr();
+      } else if (message->err() != RdKafka::ERR__TIMED_OUT) {
+        LOG(ERROR) << "Failed to consume: " << message->errstr();
+        return errors::Internal("Failed to consume: ", message->errstr());
+      }
+    }
+    TensorShape shape({static_cast<int64>(message_value.size())});
+    Tensor* message_tensor;
+    Tensor* key_tensor;
+    TF_RETURN_IF_ERROR(allocate_func(shape, &message_tensor, &key_tensor));
+    for (size_t i = 0; i < message_value.size(); i++) {
+      message_tensor->flat<string>()(i) = message_value[i];
+      key_tensor->flat<string>()(i) = key_value[i];
+    }
+    return Status::OK();
+  }
+  Status Spec(const int64 start, const int64 stop, int64* start_offset,
+              int64* stop_offset) {
+    mutex_lock l(mu_);
+
+    if (start >= 0) {
+      *start_offset = start;
+    } else if (start == RdKafka::Topic::OFFSET_END) {
+      *start_offset = RdKafka::Consumer::OffsetTail(0);
+    } else if (start <= RdKafka::Consumer::OffsetTail(0)) {
+      *start_offset = start;
+    } else {
+      return errors::InvalidArgument("start offset ", start, " not supported");
+    }
+
+    if (stop >= 0) {
+      *stop_offset = stop;
+    } else if (stop == RdKafka::Topic::OFFSET_END) {
+      *stop_offset = RdKafka::Consumer::OffsetTail(0);
+    } else if (stop <= RdKafka::Consumer::OffsetTail(0)) {
+      *stop_offset = stop;
+    } else {
+      return errors::InvalidArgument("stop offset ", stop, " not supported");
+    }
+
+    if (*start_offset <= RdKafka::Consumer::OffsetTail(0) ||
+        *stop_offset <= RdKafka::Consumer::OffsetTail(0)) {
+      // Resolve tail message
+      int64 saved = subscription_->offset();
+
+      subscription_->set_offset(RdKafka::Consumer::OffsetTail(1));
+      RdKafka::ErrorCode err = consumer_->seek(*subscription_, timeout_);
+      if (err != RdKafka::ERR_NO_ERROR) {
+        return errors::Internal("failed to seek tail -1: ",
+                                RdKafka::err2str(err));
+      }
+      std::unique_ptr<RdKafka::Message> message;
+      do {
+        message.reset(consumer_->consume(timeout_));
+      } while (message->err() == RdKafka::ERR__TRANSPORT);
+      if (message->err() != RdKafka::ERR_NO_ERROR) {
+        return errors::Internal("failed to consume tail message: ",
+                                RdKafka::err2str(message->err()));
+      }
+      int64 tail_offset = message->offset() + 1;
+      LOG(INFO) << "Kafka tail: " << tail_offset;
+
+      subscription_->set_offset(saved);
+      err = consumer_->seek(*subscription_, timeout_);
+      if (err != RdKafka::ERR_NO_ERROR) {
+        return errors::Internal("failed to seek back saved: ",
+                                RdKafka::err2str(err));
+      }
+
+      if (*start_offset <= RdKafka::Consumer::OffsetTail(0)) {
+        *start_offset =
+            tail_offset + *start_offset - RdKafka::Consumer::OffsetTail(0);
+      }
+      if (*stop_offset <= RdKafka::Consumer::OffsetTail(0)) {
+        *stop_offset =
+            tail_offset + *stop_offset - RdKafka::Consumer::OffsetTail(0);
+      }
+    }
+
+    return Status::OK();
+  }
+  string DebugString() const override { return "KafkaBaseResource"; }
+
+ protected:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+  std::unique_ptr<RdKafka::TopicPartition> subscription_ GUARDED_BY(mu_);
+  std::unique_ptr<RdKafka::KafkaConsumer> consumer_ GUARDED_BY(mu_);
+  KafkaEventCb kafka_event_cb_ = KafkaEventCb();
+  static const int timeout_ = 5000;
 };
 
 class KafkaReadableInitOp : public ResourceOpKernel<KafkaReadableResource> {
@@ -387,13 +356,9 @@ class KafkaReadableInitOp : public ResourceOpKernel<KafkaReadableResource> {
     OP_REQUIRES_OK(context, context->input("partition", &partition_tensor));
     const int32 partition = partition_tensor->scalar<int32>()();
 
-    const Tensor* start_tensor;
-    OP_REQUIRES_OK(context, context->input("start", &start_tensor));
-    const int64 start = start_tensor->scalar<int64>()();
-
-    const Tensor* stop_tensor;
-    OP_REQUIRES_OK(context, context->input("stop", &stop_tensor));
-    const int64 stop = stop_tensor->scalar<int64>()();
+    const Tensor* offset_tensor;
+    OP_REQUIRES_OK(context, context->input("offset", &offset_tensor));
+    const int64 offset = offset_tensor->scalar<int64>()();
 
     const Tensor* metadata_tensor;
     OP_REQUIRES_OK(context, context->input("metadata", &metadata_tensor));
@@ -403,7 +368,7 @@ class KafkaReadableInitOp : public ResourceOpKernel<KafkaReadableResource> {
     }
 
     OP_REQUIRES_OK(context,
-                   resource_->Init(topic, partition, start, stop, metadata));
+                   resource_->Init(topic, partition, offset, metadata));
   }
   Status CreateResource(KafkaReadableResource** resource)
       EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
@@ -416,9 +381,9 @@ class KafkaReadableInitOp : public ResourceOpKernel<KafkaReadableResource> {
   Env* env_ GUARDED_BY(mu_);
 };
 
-class KafkaReadableSpecOp : public OpKernel {
+class KafkaReadableNextOp : public OpKernel {
  public:
-  explicit KafkaReadableSpecOp(OpKernelConstruction* context)
+  explicit KafkaReadableNextOp(OpKernelConstruction* context)
       : OpKernel(context) {
     env_ = context->env();
   }
@@ -429,18 +394,20 @@ class KafkaReadableSpecOp : public OpKernel {
                    GetResourceFromContext(context, "input", &resource));
     core::ScopedUnref unref(resource);
 
-    int64 start, stop;
-    OP_REQUIRES_OK(context, resource->Spec(&start, &stop));
+    const Tensor* index_tensor;
+    OP_REQUIRES_OK(context, context->input("index", &index_tensor));
+    const int64 index = index_tensor->scalar<int64>()();
 
-    Tensor* start_tensor = nullptr;
-    OP_REQUIRES_OK(context,
-                   context->allocate_output(0, TensorShape({}), &start_tensor));
-    start_tensor->scalar<int64>()() = start;
-
-    Tensor* stop_tensor = nullptr;
-    OP_REQUIRES_OK(context,
-                   context->allocate_output(1, TensorShape({}), &stop_tensor));
-    stop_tensor->scalar<int64>()() = stop;
+    OP_REQUIRES_OK(
+        context,
+        resource->Next(
+            index,
+            [&](const TensorShape& shape, Tensor** message,
+                Tensor** key) -> Status {
+              TF_RETURN_IF_ERROR(context->allocate_output(0, shape, message));
+              TF_RETURN_IF_ERROR(context->allocate_output(1, shape, key));
+              return Status::OK();
+            }));
   }
 
  private:
@@ -486,6 +453,47 @@ class KafkaReadableReadOp : public OpKernel {
   Env* env_ GUARDED_BY(mu_);
 };
 
+class KafkaReadableSpecOp : public OpKernel {
+ public:
+  explicit KafkaReadableSpecOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    KafkaReadableResource* resource;
+    OP_REQUIRES_OK(context,
+                   GetResourceFromContext(context, "input", &resource));
+    core::ScopedUnref unref(resource);
+
+    const Tensor* start_tensor;
+    OP_REQUIRES_OK(context, context->input("start", &start_tensor));
+    const int64 start = start_tensor->scalar<int64>()();
+
+    const Tensor* stop_tensor;
+    OP_REQUIRES_OK(context, context->input("stop", &stop_tensor));
+    const int64 stop = stop_tensor->scalar<int64>()();
+
+    int64 start_offset, stop_offset;
+    OP_REQUIRES_OK(context,
+                   resource->Spec(start, stop, &start_offset, &stop_offset));
+
+    Tensor* start_offset_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape({}),
+                                                     &start_offset_tensor));
+    start_offset_tensor->scalar<int64>()() = start_offset;
+
+    Tensor* stop_offset_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(1, TensorShape({}),
+                                                     &stop_offset_tensor));
+    stop_offset_tensor->scalar<int64>()() = stop_offset;
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
+/*
 class KafkaIterableInitOp : public ResourceOpKernel<KafkaIterableResource> {
  public:
   explicit KafkaIterableInitOp(OpKernelConstruction* context)
@@ -529,41 +537,7 @@ class KafkaIterableInitOp : public ResourceOpKernel<KafkaIterableResource> {
   mutable mutex mu_;
   Env* env_ GUARDED_BY(mu_);
 };
-
-class KafkaIterableReadOp : public OpKernel {
- public:
-  explicit KafkaIterableReadOp(OpKernelConstruction* context)
-      : OpKernel(context) {
-    env_ = context->env();
-  }
-
-  void Compute(OpKernelContext* context) override {
-    KafkaIterableResource* resource;
-    OP_REQUIRES_OK(context,
-                   GetResourceFromContext(context, "input", &resource));
-    core::ScopedUnref unref(resource);
-
-    const Tensor* index_tensor;
-    OP_REQUIRES_OK(context, context->input("index", &index_tensor));
-    const int64 index = index_tensor->scalar<int64>()();
-
-    OP_REQUIRES_OK(
-        context,
-        resource->Read(
-            index,
-            [&](const TensorShape& shape, Tensor** message,
-                Tensor** key) -> Status {
-              TF_RETURN_IF_ERROR(context->allocate_output(0, shape, message));
-              TF_RETURN_IF_ERROR(context->allocate_output(1, shape, key));
-              return Status::OK();
-            }));
-  }
-
- private:
-  mutable mutex mu_;
-  Env* env_ GUARDED_BY(mu_);
-};
-
+*/
 class LayerKafkaResource : public ResourceBase {
  public:
   LayerKafkaResource(Env* env) : env_(env) {}
@@ -761,14 +735,12 @@ class LayerKafkaSyncOp : public OpKernel {
 
 REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableInit").Device(DEVICE_CPU),
                         KafkaReadableInitOp);
-REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableSpec").Device(DEVICE_CPU),
-                        KafkaReadableSpecOp);
+REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableNext").Device(DEVICE_CPU),
+                        KafkaReadableNextOp);
 REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableRead").Device(DEVICE_CPU),
                         KafkaReadableReadOp);
-REGISTER_KERNEL_BUILDER(Name("IO>KafkaIterableInit").Device(DEVICE_CPU),
-                        KafkaIterableInitOp);
-REGISTER_KERNEL_BUILDER(Name("IO>KafkaIterableRead").Device(DEVICE_CPU),
-                        KafkaIterableReadOp);
+REGISTER_KERNEL_BUILDER(Name("IO>KafkaReadableSpec").Device(DEVICE_CPU),
+                        KafkaReadableSpecOp);
 REGISTER_KERNEL_BUILDER(Name("IO>LayerKafkaInit").Device(DEVICE_CPU),
                         LayerKafkaInitOp);
 REGISTER_KERNEL_BUILDER(Name("IO>LayerKafkaCall").Device(DEVICE_CPU),

--- a/tensorflow_io/core/ops/kafka_ops.cc
+++ b/tensorflow_io/core/ops/kafka_ops.cc
@@ -24,8 +24,7 @@ namespace {
 REGISTER_OP("IO>KafkaReadableInit")
     .Input("topic: string")
     .Input("partition: int32")
-    .Input("start: int64")
-    .Input("stop: int64")
+    .Input("offset: int64")
     .Input("metadata: string")
     .Output("resource: resource")
     .Attr("container: string = ''")
@@ -35,13 +34,14 @@ REGISTER_OP("IO>KafkaReadableInit")
       return Status::OK();
     });
 
-REGISTER_OP("IO>KafkaReadableSpec")
+REGISTER_OP("IO>KafkaReadableNext")
     .Input("input: resource")
-    .Output("start: int64")
-    .Output("stop: int64")
+    .Input("index: int64")
+    .Output("message: string")
+    .Output("key: string")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
-      c->set_output(0, c->Scalar());
-      c->set_output(1, c->Scalar());
+      c->set_output(0, c->MakeShape({c->UnknownDim()}));
+      c->set_output(1, c->MakeShape({c->UnknownDim()}));
       return Status::OK();
     });
 
@@ -57,6 +57,18 @@ REGISTER_OP("IO>KafkaReadableRead")
       return Status::OK();
     });
 
+REGISTER_OP("IO>KafkaReadableSpec")
+    .Input("input: resource")
+    .Input("start: int64")
+    .Input("stop: int64")
+    .Output("start_offset: int64")
+    .Output("stop_offset: int64")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Scalar());
+      c->set_output(1, c->Scalar());
+      return Status::OK();
+    });
+
 REGISTER_OP("IO>KafkaIterableInit")
     .Input("topic: string")
     .Input("partition: int32")
@@ -67,17 +79,6 @@ REGISTER_OP("IO>KafkaIterableInit")
     .Attr("shared_name: string = ''")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       c->set_output(0, c->Scalar());
-      return Status::OK();
-    });
-
-REGISTER_OP("IO>KafkaIterableRead")
-    .Input("input: resource")
-    .Input("index: int64")
-    .Output("message: string")
-    .Output("key: string")
-    .SetShapeFn([](shape_inference::InferenceContext* c) {
-      c->set_output(0, c->MakeShape({c->UnknownDim()}));
-      c->set_output(1, c->MakeShape({c->UnknownDim()}));
       return Status::OK();
     });
 

--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -283,15 +283,13 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
   @classmethod
   def from_kafka(cls,
                  topic,
-                 partition=0, start=0, stop=-1,
+                 partition=0,
                  servers=None, configuration=None, **kwargs):
     """Creates an `IOTensor` from a Kafka stream.
 
     Args:
       topic: A `tf.string` tensor containing topic subscription.
       partition: A `tf.int64` tensor containing the partition, by default 0.
-      start: A `tf.int64` tensor containing the start offset, by default 0.
-      stop: A `tf.int64` tensor containing the end offset, by default -1.
       servers: An optional list of bootstrap servers, by default
          `localhost:9092`.
       configuration: An optional `tf.string` tensor containing
@@ -312,7 +310,7 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
     """
     with tf.name_scope(kwargs.get("name", "IOFromKafka")):
       return kafka_io_tensor_ops.KafkaIOTensor(
-          topic=topic, partition=partition, start=start, stop=stop,
+          topic=topic, partition=partition,
           servers=servers, configuration=configuration, internal=True)
 
   @classmethod

--- a/tensorflow_io/core/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_dataset_ops.py
@@ -37,8 +37,8 @@ class KafkaIODataset(tf.data.Dataset):
       if servers is not None:
         metadata.append("bootstrap.servers=%s" % servers)
       resource = core_ops.io_kafka_readable_init(
-          topic, partition, start, stop, metadata=metadata)
-      start, stop = core_ops.io_kafka_readable_spec(resource)
+          topic, partition, offset=0, metadata=metadata)
+      start, stop = core_ops.io_kafka_readable_spec(resource, start, stop)
 
       self._resource = resource
 
@@ -78,14 +78,14 @@ class KafkaStreamIODataset(tf.data.Dataset):
       metadata = list(configuration or [])
       if servers is not None:
         metadata.append("bootstrap.servers=%s" % servers)
-      resource = core_ops.io_kafka_iterable_init(
+      resource = core_ops.io_kafka_readable_init(
           topic, partition, offset, metadata=metadata)
 
       self._resource = resource
 
       dataset = tf.data.experimental.Counter()
       dataset = dataset.map(
-          lambda i: core_ops.io_kafka_iterable_read(self._resource, i))
+          lambda i: core_ops.io_kafka_readable_next(self._resource, i))
       dataset = dataset.apply(
           tf.data.experimental.take_while(
               lambda v: tf.greater(tf.shape(v.message)[0], 0)))

--- a/tensorflow_io/core/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_dataset_ops.py
@@ -41,6 +41,7 @@ class KafkaIODataset(tf.data.Dataset):
       start, stop = core_ops.io_kafka_readable_spec(resource, start, stop)
 
       self._resource = resource
+      self._start, self._stop = start, stop
 
       step = 1024
       indices_start = tf.data.Dataset.range(0, stop, step)

--- a/tensorflow_io/core/python/ops/kafka_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_io_tensor_ops.py
@@ -28,7 +28,7 @@ class KafkaIOTensor():
   #=============================================================================
   def __init__(self,
                topic,
-               partition, start, stop,
+               partition,
                servers, configuration, internal=True):
     with tf.name_scope("KafkaIOTensor"):
       assert internal
@@ -37,11 +37,9 @@ class KafkaIOTensor():
       if servers is not None:
         metadata.append("bootstrap.servers=%s" % servers)
       resource = core_ops.io_kafka_readable_init(
-          topic, partition, start, stop, metadata=metadata)
-      start, stop = core_ops.io_kafka_readable_spec(resource)
+          topic, partition, offset=0, metadata=metadata)
 
       self._resource = resource
-      self._start, self._stop = start, stop
       super(KafkaIOTensor, self).__init__()
 
   #=============================================================================
@@ -79,7 +77,7 @@ class KafkaIOTensor():
       A `Tensor` with value obtained from this `IOTensor`.
     """
     item, _ = core_ops.io_kafka_readable_read(
-        self._resource, self._start, self._stop)
+        self._resource, start=0, stop=-1)
     return item
 
   #=============================================================================


### PR DESCRIPTION
In the past KafkaIOTensor indexing/slicing access is based on the query of kafka offset: when KafkaIOTensor is created, it will first get the range of `[offset_start, offset_stop]` (note offset could be logical like 20 from end), then the indexing/slicing is based on the block of the data presented in the range: `offset - offset_start`.

There are several limitations of the above approach. The biggest one is that Kafka offset could be empty (as certain messages could be pruned). So the range may be different at the time of the creation and the time of the query. That causes the indexing skewing (`offset - offset_start` is not definitive in case some message are pruned)

However, as Kafka itself is offset based and offset is definitive (in any partition), we could directly use kafka as the index base. If we want to access any data in any range of `[offset_start, offset_stop]`, we could just do a `kafka_io_tensor[offset_start, offset_stop]`. In this way, slicing and indexing of KafkaIOTensor is actually a offset query against Kafka server.

This should greatly help ease the usage of Kafka with Tensorflow.

On a side node, the same approach could be applied to some other IOTensor's as well. For example, in case of video/audio, we could just use timestamp as a query and return result of the query in a similar fashion.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>