### PR TITLE
Add --plat-name macosx_10_13_x86_64 on macos wheel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
           set -x -e
           python -m pip install -U wheel setuptools
           python --version
-          python setup.py --data bazel-bin -q bdist_wheel
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
           set -x -e
@@ -411,7 +411,7 @@ jobs:
           set -x -e
           python -m pip install -U wheel setuptools
           python --version
-          python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64 --nightly $BUILD_NUMBER
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
           set -x -e


### PR DESCRIPTION
Add --plat-name macosx_10_13_x86_64 on macos wheel build

This is part of the effort to resolve the issue raised in https://github.com/tensorflow/addons/issues/1108

We still need to find out a way to sanity check for OSX 10.13

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>