### PR TITLE
Add graph mode support for ArrowIOTensor

### DIFF
--- a/tensorflow_io/arrow/ops/dataset_ops.cc
+++ b/tensorflow_io/arrow/ops/dataset_ops.cc
@@ -151,15 +151,14 @@ REGISTER_OP("IO>ArrowReadableFromMemoryInit")
   .Attr("shared_name: string = ''")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
     c->set_output(0, c->Scalar());
-    c->set_output(1, c->MakeShape({}));
     return Status::OK();
    });
 
 REGISTER_OP("IO>ArrowReadableSpec")
   .Input("input: resource")
+  .Input("column_index: int32")
   .Output("shape: int64")
   .Output("dtype: int64")
-  .Attr("column_index: int")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
     c->set_output(0, c->MakeShape({c->UnknownDim()}));
     c->set_output(1, c->MakeShape({}));
@@ -168,18 +167,23 @@ REGISTER_OP("IO>ArrowReadableSpec")
 
 REGISTER_OP("IO>ArrowReadableRead")
   .Input("input: resource")
+  .Input("column_index: int32")
+  .Input("shape: int64")
   .Input("start: int64")
   .Input("stop: int64")
   .Output("value: dtype")
-  .Attr("column_index: int")
-  .Attr("shape: shape")
   .Attr("dtype: type")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
-    PartialTensorShape shape;
-    TF_RETURN_IF_ERROR(c->GetAttr("shape", &shape));
-    shape_inference::ShapeHandle entry;
-    TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(shape, &entry));
-    c->set_output(0, entry);
+    shape_inference::ShapeHandle full;
+    TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(2, &full));
+    if (!(c->RankKnown(full) && c->Rank(full) > 0)) {
+      c->set_output(0, full);
+      return Status::OK();
+    }
+    // TODO: replace dims up until rank(start|stop)
+    shape_inference::ShapeHandle shape;
+    TF_RETURN_IF_ERROR(c->ReplaceDim(full, 0, c->UnknownDim(), &shape));
+    c->set_output(0, shape);
     return Status::OK();
    });
 

--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -333,11 +333,16 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
   @classmethod
   def from_arrow(cls,
                  table,
+                 spec=None,
                  **kwargs):
     """Creates an `IOTensor` from a pyarrow.Table.
 
     Args:
       table: An instance of a `pyarrow.Table`.
+      spec: A dict of `dataset:tf.TensorSpec` or `dataset:dtype`
+        pairs that specify the dataset selected and the tf.TensorSpec
+        or dtype of the dataset. In eager mode the spec is probed
+        automatically. In graph mode spec has to be specified.
       name: A name prefix for the IOTensor (optional).
 
     Returns:
@@ -345,7 +350,7 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
 
     """
     with tf.name_scope(kwargs.get("name", "IOFromArrow")):
-      return arrow_io_tensor_ops.ArrowIOTensor(table, internal=True)
+      return arrow_io_tensor_ops.ArrowIOTensor(table, spec=spec, internal=True)
 
   @classmethod
   def from_lmdb(cls,


### PR DESCRIPTION
This enables graph mode support for `ArrowIOTensor`, e.g. columns from a `pyarrow.Table` can be converted to Tensors inside of a `tf.data.Dataset.map` function.