### PR TITLE
Update Prometheus Tutorial to use tensorflow-io instead of tensorflow-io-nightly

### DIFF
--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -154,7 +154,7 @@
         "  %tensorflow_version 2.x\n",
         "except Exception:\n",
         "  pass\n",
-        "!pip install tensorflow-io-nightly"
+        "!pip install tensorflow-io"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Update Prometheus Tutorial to use tensorflow-io instead of tensorflow-io-nightly, as it is part of the 0.12.0 release now.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>