### PR TITLE
Update to use short TOC titles

### DIFF
--- a/docs/tutorials/_toc.yaml
+++ b/docs/tutorials/_toc.yaml
@@ -16,9 +16,9 @@
 toc:
 - title: "BigQuery"
   path: /io/tutorials/bigquery
-- title: "Decode DICOM files for medical imaging"
+- title: "Decode DICOM files"
   path: /io/tutorials/dicom
-- title: "Azure blob storage with TensorFlow"
+- title: "Azure blob storage"
   path: /io/tutorials/azure
 - title: "Prometheus metrics"
   path: /io/tutorials/prometheus


### PR DESCRIPTION
Given most of the tutorials uses short TOC titles (like `BigQuery`,
`Prometheus metrics`), this PR proposes to stay with short TOC titles
for all entries to make it consistent, and make appearance aligned in the page.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>