### PR TITLE
expand premetheus.ipynb server startup time.

### DIFF
--- a/docs/tutorials/prometheus.ipynb
+++ b/docs/tutorials/prometheus.ipynb
@@ -271,7 +271,7 @@
         "\n",
         "# Give the server a few seconds to startup.\n",
         "import time\n",
-        "time.sleep(10)"
+        "time.sleep(20)"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
This is still failing, even in Colab with restart-and-run-all.

20s it works in Colab.

For #783