### PR TITLE
Allows clang format check with `bazel run -s --verbose_failures //tools/lint:check -- clang`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
           sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          bazel run -s --verbose_failures //tools/lint:check
+          bazel run -s --verbose_failures //tools/lint:check -- bazel pylint
 
   macos:
     name: macOS

--- a/tools/lint/lint.tpl
+++ b/tools/lint/lint.tpl
@@ -67,7 +67,6 @@ buildifier_func() {
 
 clang_format_func() {
   echo $1 $2
-  return # TODO: enable after TF 2.1
   if [[ "$1" == "lint" ]]; then
     $clang_format_path --style=google -i $2
   else


### PR DESCRIPTION
This PR removes the comment and allows clang format check with
`bazel run -s --verbose_failures //tools/lint:check -- clang`

In the past we skipped clang as we want to gradually format it,
however, as clang-format was commented out so it is not possible
to check it without modifying `tools/lint/lint.tpl`.

This PR updates `tools/lint/lint.tpl` so that
`bazel run -s --verbose_failures //tools/lint:check -- clang`
is working.

At the same time, we temporarily disables clang check in CI (will
enable once all files are formated)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>