### PR TITLE
Update to libkafka v1.4.0-RC2, and patch to fix the segment fault

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -207,6 +207,7 @@ http_archive(
     build_file = "//third_party:kafka.BUILD",
     patch_cmds = [
         "rm -f src/win32_config.h",
+        # TODO: Remove the fowllowing once librdkafka issue is resolved.
         """sed -i.bak '\|rd_kafka_log(rk,|,/ exceeded);/ s/^/\/\//' src/rdkafka_cgrp.c""",
     ],
     sha256 = "2d14551fd87262ec4917db3ae688ca2574d716faecccb1ac5136a478579cee19",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -207,6 +207,7 @@ http_archive(
     build_file = "//third_party:kafka.BUILD",
     patch_cmds = [
         "rm -f src/win32_config.h",
+        """sed -i.bak '\|rd_kafka_log(rk,|,/ exceeded);/ s/^/\/\//' src/rdkafka_cgrp.c""",
     ],
     sha256 = "2d14551fd87262ec4917db3ae688ca2574d716faecccb1ac5136a478579cee19",
     strip_prefix = "librdkafka-1.4.0-RC2",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -208,10 +208,10 @@ http_archive(
     patch_cmds = [
         "rm -f src/win32_config.h",
     ],
-    sha256 = "9c0afb8b53779d968225edf1e79da48a162895ad557900f75e7978f65e642032",
-    strip_prefix = "librdkafka-0.11.6",
+    sha256 = "2d14551fd87262ec4917db3ae688ca2574d716faecccb1ac5136a478579cee19",
+    strip_prefix = "librdkafka-1.4.0-RC2",
     urls = [
-        "https://github.com/edenhill/librdkafka/archive/v0.11.6.tar.gz",
+        "https://github.com/edenhill/librdkafka/archive/v1.4.0-RC2.tar.gz",
     ],
 )
 

--- a/tensorflow_io/core/kernels/kafka_kernels.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels.cc
@@ -33,7 +33,7 @@ class KafkaEventCb : public RdKafka::EventCb {
         LOG(ERROR) << "EVENT_ERROR: "
                    << "(" << RdKafka::err2str(event.err())
                    << "): " << event.str();
-        { run_ = (event.err() != RdKafka::ERR__ALL_BROKERS_DOWN); }
+        { run_ = !event.fatal(); }
         break;
       case RdKafka::Event::EVENT_STATS:
         LOG(ERROR) << "EVENT_STATS: " << event.str();

--- a/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
@@ -174,7 +174,7 @@ class KafkaDatasetOp : public DatasetOpKernel {
             LOG(ERROR) << "EVENT_ERROR: "
                        << "(" << RdKafka::err2str(event.err())
                        << "): " << event.str();
-            if (event.err() == RdKafka::ERR__ALL_BROKERS_DOWN) run_ = false;
+            { run_ = !event.fatal(); }
             break;
 
           case RdKafka::Event::EVENT_STATS:

--- a/third_party/kafka.BUILD
+++ b/third_party/kafka.BUILD
@@ -100,6 +100,7 @@ genrule(
         "#define ENABLE_DEVEL 0",
         "#define BUILT_WITH \"SSL ZLIB SNAPPY ZSTD LZ4 SASL SASL_SCRAM SASL_OAUTHBEARER HDRHISTOGRAM\"",
         "// maintain the order below",
+        "#include <windows.h>",
         "#include <openssl/x509.h>",
         "#include <wincrypt.h>",
         "EOF",

--- a/third_party/kafka.BUILD
+++ b/third_party/kafka.BUILD
@@ -99,6 +99,9 @@ genrule(
         "#define WITH_PLUGINS 0",
         "#define ENABLE_DEVEL 0",
         "#define BUILT_WITH \"SSL ZLIB SNAPPY ZSTD LZ4 SASL SASL_SCRAM SASL_OAUTHBEARER HDRHISTOGRAM\"",
+        "// maintain the order below",
+        "#include <openssl/x509.h>",
+        "#include <wincrypt.h>",
         "EOF",
     ]),
 )


### PR DESCRIPTION
This PR update to libkafka v1.4.0-RC2, and patch to fix the segment fault.

The patch is pretty ugly, though.
```
sed -i.bak '\|rd_kafka_log(rk,|,/ exceeded);/ s/^/\/\//' src/rdkafka_cgrp.c
```

We will try to remove the patch if the issue could be resolved upstream.

This PR fixes #800 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
