### PR TITLE
Add lint option for pyupgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ version of TensorFlow I/O according to the table below:
 
 ### Lint
 
-TensorFlow I/O's code conforms through Pylint, Bazel Buildifier, and Clang Format. The following will check the source code and report any lint issues:
+TensorFlow I/O's code conforms through Pylint, Bazel Buildifier, Clang Format, Black, and Pyupgrade. The following will check the source code and report any lint issues:
 ```sh
 bazel run //tools/lint:check
 ```
@@ -133,6 +133,12 @@ Fix with Bazel Buildifier or Clang Format could be done with:
 ```
 bazel run //tools/lint:lint -- bazel clang
 ```
+
+Check lint with Black or Pyupgrade for an individual python file could be done with:
+```
+bazel run //tools/lint:check -- black pyupgrade -- tensorflow_io/core/python/ops/version_ops.py
+```
+
 
 ### Python
 

--- a/tensorflow_io/core/python/experimental/serialization_ops.py
+++ b/tensorflow_io/core/python/experimental/serialization_ops.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Serialization Ops."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -16,6 +16,27 @@ lint(
 exports_files(["lint.tpl"])
 
 py_binary(
+    name = "pyupgrade_py",
+    srcs = ["pyupgrade_python.py"],
+    main = "pyupgrade_python.py",
+    deps = [
+        requirement("pyupgrade"),
+        requirement("tokenize-rt"),
+    ],
+)
+
+genrule(
+    name = "pyupgrade",
+    srcs = [],
+    outs = ["pyupgrade"],
+    cmd = "echo '$(location :pyupgrade_py) \"$$@\"' > $@",
+    executable = True,
+    tools = [
+        ":pyupgrade_py",
+    ],
+)
+
+py_binary(
     name = "black_py",
     srcs = ["black_python.py"],
     main = "black_python.py",

--- a/tools/lint/defs.bzl
+++ b/tools/lint/defs.bzl
@@ -8,6 +8,7 @@ def _lint_impl(ctx):
         "@@PYLINT_PATH@@": shell.quote(ctx.executable._pylint.short_path),
         "@@BUILDIFIER_PATH@@": shell.quote(ctx.executable._buildifier.short_path),
         "@@CLANG_FORMAT_PATH@@": shell.quote(ctx.executable._clang_format.short_path),
+        "@@PYUPGRADE_PATH@@": shell.quote(ctx.executable._pyupgrade.short_path),
     }
     ctx.actions.expand_template(
         template = ctx.file._runner,
@@ -15,7 +16,7 @@ def _lint_impl(ctx):
         substitutions = substitutions,
         is_executable = True,
     )
-    runfiles = ctx.runfiles(files = [ctx.executable._buildifier, ctx.executable._clang_format, ctx.executable._pylint, ctx.executable._black])
+    runfiles = ctx.runfiles(files = [ctx.executable._buildifier, ctx.executable._clang_format, ctx.executable._pylint, ctx.executable._black, ctx.executable._pyupgrade])
     return [DefaultInfo(
         files = depset([bash_file]),
         runfiles = runfiles,
@@ -47,6 +48,11 @@ _lint = rule(
         ),
         "_clang_format": attr.label(
             default = "//tools/lint:clang_format",
+            cfg = "host",
+            executable = True,
+        ),
+        "_pyupgrade": attr.label(
+            default = "//tools/lint:pyupgrade",
             cfg = "host",
             executable = True,
         ),

--- a/tools/lint/pyupgrade_python.py
+++ b/tools/lint/pyupgrade_python.py
@@ -1,0 +1,20 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""pyupgrade"""
+import sys
+import pyupgrade
+
+print("pyupgrade: ", sys.argv)
+sys.exit(pyupgrade.main(sys.argv[1:]))

--- a/tools/lint/requirements.txt
+++ b/tools/lint/requirements.txt
@@ -1,2 +1,3 @@
 pylint==2.4.4
 black==19.10b0
+pyupgrade==2.1.0


### PR DESCRIPTION

Now it is possible to run lint auto format with:
```
bazel run //tools/lint:lint -- pyupgrade -- file.py
```

and run lint check with:
```
bazel run //tools/lint:check -- pyupgrade -- file.py
```

Or full check for every python file
```
bazel run //tools/lint:check -- pyupgrade
```

This PR is part of #824

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>