### PR TITLE
Add tfio.experimental.audio.decode_wav support

### DIFF
--- a/tensorflow_io/core/kernels/audio_flac_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_flac_kernels.cc
@@ -171,10 +171,11 @@ class FlacReadableResource : public AudioReadableResourceBase {
         }) {}
   ~FlacReadableResource() {}
 
-  Status Init(const string& input) override {
+  Status Init(const string& filename, const void* optional_memory,
+              const size_t optional_length) override {
     mutex_lock l(mu_);
-    const string& filename = input;
-    file_.reset(new SizedRandomAccessFile(env_, filename, nullptr, 0));
+    file_.reset(new SizedRandomAccessFile(env_, filename, optional_memory,
+                                          optional_length));
     TF_RETURN_IF_ERROR(file_->GetFileSize(&file_size_));
 
     decoder_.reset(FLAC__stream_decoder_new());
@@ -264,10 +265,11 @@ class FlacReadableResource : public AudioReadableResourceBase {
 }  // namespace
 
 Status FlacReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource) {
   resource.reset(new FlacReadableResource(env));
-  Status status = resource->Init(input);
+  Status status = resource->Init(filename, optional_memory, optional_length);
   if (!status.ok()) {
     resource.reset(nullptr);
   }

--- a/tensorflow_io/core/kernels/audio_kernels.h
+++ b/tensorflow_io/core/kernels/audio_kernels.h
@@ -21,7 +21,9 @@ namespace data {
 
 class AudioReadableResourceBase : public ResourceBase {
  public:
-  virtual Status Init(const string& input) = 0;
+  virtual Status Init(const string& filename,
+                      const void* optional_memory = nullptr,
+                      size_t optional_length = 0) = 0;
   virtual Status Read(
       const int64 start, const int64 stop,
       std::function<Status(const TensorShape& shape, Tensor** value)>
@@ -30,19 +32,24 @@ class AudioReadableResourceBase : public ResourceBase {
 };
 
 Status WAVReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource);
 Status OggReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource);
 Status FlacReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource);
 Status MP3ReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource);
 Status MP4ReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource);
 
 }  // namespace data

--- a/tensorflow_io/core/kernels/audio_mp3_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_mp3_kernels.cc
@@ -60,10 +60,11 @@ class MP3ReadableResource : public AudioReadableResourceBase {
         }) {}
   ~MP3ReadableResource() {}
 
-  Status Init(const string& input) override {
+  Status Init(const string& filename, const void* optional_memory,
+              const size_t optional_length) override {
     mutex_lock l(mu_);
-    const string& filename = input;
-    file_.reset(new SizedRandomAccessFile(env_, filename, nullptr, 0));
+    file_.reset(new SizedRandomAccessFile(env_, filename, optional_memory,
+                                          optional_length));
     TF_RETURN_IF_ERROR(file_->GetFileSize(&file_size_));
 
     stream_.reset(new MP3Stream(file_.get(), file_size_));
@@ -147,10 +148,11 @@ class MP3ReadableResource : public AudioReadableResourceBase {
 }  // namespace
 
 Status MP3ReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource) {
   resource.reset(new MP3ReadableResource(env));
-  Status status = resource->Init(input);
+  Status status = resource->Init(filename, optional_memory, optional_length);
   if (!status.ok()) {
     resource.reset(nullptr);
   }

--- a/tensorflow_io/core/kernels/audio_ogg_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_ogg_kernels.cc
@@ -85,10 +85,11 @@ class OggReadableResource : public AudioReadableResourceBase {
   OggReadableResource(Env* env) : env_(env) {}
   ~OggReadableResource() {}
 
-  Status Init(const string& input) override {
+  Status Init(const string& filename, const void* optional_memory,
+              const size_t optional_length) override {
     mutex_lock l(mu_);
-    const string& filename = input;
-    file_.reset(new SizedRandomAccessFile(env_, filename, nullptr, 0));
+    file_.reset(new SizedRandomAccessFile(env_, filename, optional_memory,
+                                          optional_length));
     TF_RETURN_IF_ERROR(file_->GetFileSize(&file_size_));
 
     stream_.reset(new OggVorbisStream(file_.get(), file_size_));
@@ -172,10 +173,11 @@ class OggReadableResource : public AudioReadableResourceBase {
 }  // namespace
 
 Status OggReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource) {
   resource.reset(new OggReadableResource(env));
-  Status status = resource->Init(input);
+  Status status = resource->Init(filename, optional_memory, optional_length);
   if (!status.ok()) {
     resource.reset(nullptr);
   }

--- a/tensorflow_io/core/kernels/audio_wav_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_wav_kernels.cc
@@ -80,10 +80,12 @@ class WAVReadableResource : public AudioReadableResourceBase {
   WAVReadableResource(Env* env) : env_(env) {}
   ~WAVReadableResource() {}
 
-  Status Init(const string& input) override {
+  Status Init(const string& input, const void* optional_memory,
+              const size_t optional_length) override {
     mutex_lock l(mu_);
     const string& filename = input;
-    file_.reset(new SizedRandomAccessFile(env_, filename, nullptr, 0));
+    file_.reset(new SizedRandomAccessFile(env_, filename, optional_memory,
+                                          optional_length));
     TF_RETURN_IF_ERROR(file_->GetFileSize(&file_size_));
 
     StringPiece result;
@@ -300,10 +302,11 @@ class WAVReadableResource : public AudioReadableResourceBase {
 }  // namespace
 
 Status WAVReadableResourceInit(
-    Env* env, const string& input,
+    Env* env, const string& filename, const void* optional_memory,
+    const size_t optional_length,
     std::unique_ptr<AudioReadableResourceBase>& resource) {
   resource.reset(new WAVReadableResource(env));
-  Status status = resource->Init(input);
+  Status status = resource->Init(filename, optional_memory, optional_length);
   if (!status.ok()) {
     resource.reset(nullptr);
   }

--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -66,6 +66,26 @@ REGISTER_OP("IO>AudioResample")
       return Status::OK();
     });
 
+REGISTER_OP("IO>AudioDecodeWAV")
+    .Input("input: string")
+    .Input("shape: int64")
+    .Output("value: dtype")
+    .Attr("dtype: {int16, int32}")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle shape;
+      TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(1, &shape));
+      if (!c->RankKnown(shape)) {
+        c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
+        return Status::OK();
+      }
+      if (c->Rank(shape) != 2) {
+        return errors::InvalidArgument("rank must be two, received ",
+                                       c->DebugString(shape));
+      }
+      c->set_output(0, shape);
+      return Status::OK();
+    });
+
 }  // namespace
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -15,3 +15,4 @@
 """tensorflow_io.experimental.audio"""
 
 from tensorflow_io.core.python.experimental.audio_ops import resample # pylint: disable=unused-import
+from tensorflow_io.core.python.experimental.audio_ops import decode_wav # pylint: disable=unused-import

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """audio"""
 
+import tensorflow as tf
+
 from tensorflow_io.core.python.ops import core_ops
 
 def resample(input, rate_in, rate_out, quality, name=None): # pylint: disable=redefined-builtin
@@ -31,3 +33,21 @@ def resample(input, rate_in, rate_out, quality, name=None): # pylint: disable=re
   """
   return core_ops.io_audio_resample(
       input, rate_in=rate_in, rate_out=rate_out, quality=quality, name=name)
+
+def decode_wav(input, shape=None, dtype=None, name=None): # pylint: disable=redefined-builtin
+  """Decode WAV audio from input string.
+
+  Args:
+    input: A string `Tensor` of the audio input.
+    shape: The shape of the audio.
+    dtype: The data type of the audio, only tf.int16 and tf.int32 are supported.
+    name: A name for the operation (optional).
+
+  Returns:
+    output: Decoded audio.
+  """
+  if shape is None:
+    shape = tf.constant([-1, -1], tf.int64)
+  assert (dtype is not None), "dtype (tf.int16/tf.int32) must be provided"
+  return core_ops.io_audio_decode_wav(
+      input, shape=shape, dtype=dtype, name=name)

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -106,7 +106,7 @@ def test_audio_ops_in_graph(fixture_lookup, io_data_fixture):
 
   dataset = tf.data.Dataset.from_tensor_slices([args])
   dataset = dataset.map(func)
-  entries = [e for e in dataset]
+  entries = list(dataset)
   assert len(entries) == 1
   entries = entries[0]
   assert np.array_equal(entries, expected)

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -50,18 +50,63 @@ def fixture_resample():
 
   return args, func, expected
 
+@pytest.fixture(name="decode_wav", scope="module")
+def fixture_decode_wav():
+  """fixture_decode_wav"""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "ZASFX_ADSR_no_sustain.wav")
+  content = tf.io.read_file(path)
+
+  audio = tf.audio.decode_wav(tf.io.read_file(path))
+  value = audio.audio * (1 << 15)
+  value = tf.cast(value, tf.int16)
+
+  args = content
+  func = lambda e: tfio.experimental.audio.decode_wav(content, dtype=tf.int16)
+  expected = value
+
+  return args, func, expected
+
+# By default, operations runs in eager mode,
+# Note as of now shape inference is skipped in eager mode
 @pytest.mark.parametrize(
     ("io_data_fixture"),
     [
         pytest.param("resample"),
+        pytest.param("decode_wav"),
     ],
     ids=[
         "resample",
+        "decode_wav",
     ],
 )
 def test_audio_ops(fixture_lookup, io_data_fixture):
-  """test_io_dataset_to_in_dataset"""
+  """test_audio_ops"""
   args, func, expected = fixture_lookup(io_data_fixture)
 
   entries = func(args)
+  assert np.array_equal(entries, expected)
+
+# A tf.data pipeline runs in graph mode and shape inference is invoked.
+@pytest.mark.parametrize(
+    ("io_data_fixture"),
+    [
+        pytest.param("resample"),
+        pytest.param("decode_wav"),
+    ],
+    ids=[
+        "resample",
+        "decode_wav",
+    ],
+)
+def test_audio_ops_in_graph(fixture_lookup, io_data_fixture):
+  """test_audio_ops_in_graph"""
+  args, func, expected = fixture_lookup(io_data_fixture)
+
+  dataset = tf.data.Dataset.from_tensor_slices([args])
+  dataset = dataset.map(func)
+  entries = [e for e in dataset]
+  assert len(entries) == 1
+  entries = entries[0]
   assert np.array_equal(entries, expected)


### PR DESCRIPTION
This is part of the discussion in #839 by adding
tfio.experimental.audio.decode_wav support. It relies
on existing implementation with additional shape inference.

Test cases for both eager mode and graph mode has been added (
note graph mode is invoked inside a tf.data pipeline).

/cc @jjedele 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>