### PR TITLE
Add `tfio.experimental.audio.info(content)` support

### DIFF
--- a/tensorflow_io/core/kernels/audio_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_kernels.cc
@@ -96,8 +96,8 @@ class AudioReadableInitOp : public ResourceOpKernel<AudioReadableResource> {
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
 
-    OP_REQUIRES_OK(
-        context, resource_->Init(input_tensor->scalar<tstring>()(), nullptr, 0));
+    OP_REQUIRES_OK(context, resource_->Init(input_tensor->scalar<tstring>()(),
+                                            nullptr, 0));
   }
   Status CreateResource(AudioReadableResource** resource)
       EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
@@ -196,7 +196,7 @@ class AudioInfoOp : public OpKernel {
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
 
-    const string& input = input_tensor->scalar<string>()();
+    const tstring& input = input_tensor->scalar<tstring>()();
 
     // TODO: expand to all supported types
     std::unique_ptr<AudioReadableResourceBase> resource;
@@ -228,7 +228,7 @@ class AudioInfoOp : public OpKernel {
     Tensor* encoding_tensor = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(3, TensorShape({}),
                                                      &encoding_tensor));
-    encoding_tensor->scalar<string>()() = "wav";
+    encoding_tensor->scalar<tstring>()() = "wav";
   }
 
  private:

--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -54,6 +54,20 @@ REGISTER_OP("IO>AudioReadableRead")
       return Status::OK();
     });
 
+REGISTER_OP("IO>AudioInfo")
+    .Input("input: string")
+    .Output("shape: int64")
+    .Output("dtype: int64")
+    .Output("rate: int64")
+    .Output("encoding: string")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->MakeShape({2}));
+      c->set_output(1, c->Scalar());
+      c->set_output(2, c->Scalar());
+      c->set_output(3, c->Scalar());
+      return Status::OK();
+    });
+
 REGISTER_OP("IO>AudioResample")
     .Input("input: T")
     .Input("rate_in: int64")

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -14,5 +14,6 @@
 # ==============================================================================
 """tensorflow_io.experimental.audio"""
 
+from tensorflow_io.core.python.experimental.audio_ops import info # pylint: disable=unused-import
 from tensorflow_io.core.python.experimental.audio_ops import resample # pylint: disable=unused-import
 from tensorflow_io.core.python.experimental.audio_ops import decode_wav # pylint: disable=unused-import

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -18,6 +18,22 @@ import tensorflow as tf
 
 from tensorflow_io.core.python.ops import core_ops
 
+def info(input, name=None): # pylint: disable=redefined-builtin
+  """Gets metadata from content of an audio file.
+
+  Args:
+    input: A string `Tensor` of the audio input.
+    name: A name for the operation (optional).
+
+  Returns:
+    shape: The shape `[samples, channels]` of the audio.
+    dtype: The dtype of the audio.
+    rate: The sample rate.
+    encoding: The format of the audio (e.g., "wav").
+  """
+  shape, dtype, rate, encoding = core_ops.io_audio_info(input, name=name)
+  return shape, dtype, rate, encoding
+
 def resample(input, rate_in, rate_out, quality, name=None): # pylint: disable=redefined-builtin
   """Resample audio.
 


### PR DESCRIPTION
This PR adds `tfio.experimental.audio.info(content)` support
which takes an input of audio buffer and outputs
`shape`, `dtype`, `rate`, and `encoding` of the audio.

This is useful in situations where the meta information of the input need to be checked to figure out the next step.

At the moment only wav is supported. However, other formats
will be added once the equivalent decode_format is in place.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>