### PR TITLE
Define ArrowIOResource to initialize Arrow Table in a graph

### DIFF
--- a/tensorflow_io/arrow/ops/dataset_ops.cc
+++ b/tensorflow_io/arrow/ops/dataset_ops.cc
@@ -157,6 +157,7 @@ REGISTER_OP("IO>ArrowReadableFromMemoryInit")
 REGISTER_OP("IO>ArrowReadableSpec")
   .Input("input: resource")
   .Input("column_index: int32")
+  .Input("column_name: string")
   .Output("shape: int64")
   .Output("dtype: int64")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
@@ -168,6 +169,7 @@ REGISTER_OP("IO>ArrowReadableSpec")
 REGISTER_OP("IO>ArrowReadableRead")
   .Input("input: resource")
   .Input("column_index: int32")
+  .Input("column_name: string")
   .Input("shape: int64")
   .Input("start: int64")
   .Input("stop: int64")
@@ -175,7 +177,7 @@ REGISTER_OP("IO>ArrowReadableRead")
   .Attr("dtype: type")
   .SetShapeFn([](shape_inference::InferenceContext* c) {
     shape_inference::ShapeHandle full;
-    TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(2, &full));
+    TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(3, &full));
     if (!(c->RankKnown(full) && c->Rank(full) > 0)) {
       c->set_output(0, full);
       return Status::OK();

--- a/tensorflow_io/core/python/ops/arrow_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/arrow_io_tensor_ops.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""FeatherIOTensor"""
+"""ArrowIOTensor"""
 
 import uuid
 
@@ -34,7 +34,7 @@ def _extract_table_arrays(table):
          array_buffer_sizes: 3-dim list of buffer sizes, follows addrs layout
          array_lengths: 3-dim list of array lengths where dims are columns,
                         chunks, length of array followed by child array lengths
-  """
+    """
     array_buffer_addrs = []
     array_buffer_sizes = []
     array_lengths = []
@@ -110,14 +110,74 @@ def _extract_table_arrays(table):
     return array_buffer_addrs, array_buffer_sizes, array_lengths
 
 
+class ArrowIOResource:
+    """ArrowIOResource holds resources for ArrowIOTensor"""
+
+    def __init__(self):
+        self.resource_op = None
+        self.arrow_data_refs = None
+
+    @classmethod
+    def from_table(cls, table):
+        """Make the resource from a pyarrow.Table instance"""
+        arrow_resource = cls()
+        arrow_resource.resource_op = arrow_resource.init_resource_op(table)
+        return arrow_resource
+
+    @classmethod
+    def from_py_function(cls, gen_table_func, func_inp):
+        """Make the resource with a tf.py_function that inits a pyarrow.Table"""
+        arrow_resource = cls()
+
+        def wrap_func(inp):
+            table = gen_table_func(inp)
+            return arrow_resource.init_resource_op(table)
+
+        py_func = tf.py_function(func=wrap_func, inp=func_inp, Tout=tf.resource)
+        arrow_resource.resource_op = py_func
+        return arrow_resource
+
+    def init_resource_op(self, table):
+        """Initialize the resource op with a pyarrow.Table"""
+        with tf.name_scope("ArrowIOTensor") as scope:
+
+            # Serialize the schema to send to the kernel
+            schema_buffer = table.schema.serialize()
+
+            # References to prevent data from being freed until op is evaluated
+            self.arrow_data_refs = [table, schema_buffer]
+
+            # Get buffer addresses as long ints
+            schema_buffer_addr = schema_buffer.address
+            schema_buffer_size = schema_buffer.size
+            array_tuple = _extract_table_arrays(table)
+            array_buffer_addrs, array_buffer_sizes, array_lengths = array_tuple
+
+            # Create the Arrow readable resource op
+            resource_op = core_ops.io_arrow_readable_from_memory_init(
+                schema_buffer_addr,
+                schema_buffer_size,
+                array_buffer_addrs,
+                array_buffer_sizes,
+                array_lengths,
+                container=scope,
+                shared_name="pyarrow.Table{}/{}".format(
+                    table.schema.names, uuid.uuid4().hex
+                ),
+            )
+
+            return resource_op
+
+
 class _ArrowIOTensorComponentFunction:
     """_ArrowIOTensorComponentFunction will translate call"""
 
-    def __init__(self, function, resource, column_index, shape, dtype):
+    def __init__(self, function, resource, column_index, column_name, shape, dtype):
         super().__init__()
         self._function = function
         self._resource = resource
         self._column_index = column_index
+        self._column_name = column_name
         self._shape = shape
         self._dtype = dtype
 
@@ -128,6 +188,7 @@ class _ArrowIOTensorComponentFunction:
         return self._function(
             self._resource,
             self._column_index,
+            self._column_name,
             self._shape,
             start,
             stop,
@@ -142,12 +203,12 @@ class _ArrowIOTensorComponentFunction:
 class ArrowBaseIOTensor(io_tensor_ops.BaseIOTensor):
     """ArrowBaseIOTensor"""
 
-    def __init__(self, shape, dtype, spec, function, arrow_data_refs, internal=False):
+    def __init__(self, shape, dtype, spec, function, arrow_resource, internal=False):
         super().__init__(spec, function, internal=internal)
         self._shape = shape
         self._dtype = dtype
         self._spec = spec
-        self._arrow_data_refs = arrow_data_refs
+        self._arrow_resource = arrow_resource
 
     @property
     def spec(self):
@@ -169,7 +230,7 @@ class ArrowBaseIOTensor(io_tensor_ops.BaseIOTensor):
         result = super().__getitem__(key)
         if not tf.executing_eagerly():
             # Insert refs into tf.Tensor result so data is valid until evaluated
-            result._arrow_data_refs = self._arrow_data_refs
+            result._arrow_resource = self._arrow_resource
         return result
 
 
@@ -180,106 +241,98 @@ class ArrowIOTensor(io_tensor_ops._TableIOTensor):  # pylint: disable=protected-
     # Constructor (private)
     # =============================================================================
     def __init__(self, table, spec=None, internal=False):
-        with tf.name_scope("ArrowIOTensor") as scope:
 
-            # Serialize the schema to send to the kernel
-            schema_buffer = table.schema.serialize()
+        # Get or build a new ArrowIOResource
+        if isinstance(table, ArrowIOResource):
+            arrow_resource = table
+        else:
+            arrow_resource = ArrowIOResource.from_table(table)
 
-            # References to prevent data from being freed until op is evaluated
-            arrow_data_refs = [table, schema_buffer]
+        # Get the ArrowIOTensor init resource op
+        resource = arrow_resource.resource_op
 
-            # Get buffer addresses as long ints
-            schema_buffer_addr = schema_buffer.address
-            schema_buffer_size = schema_buffer.size
-            (
-                array_buffer_addrs,
-                array_buffer_sizes,
-                array_lengths,
-            ) = _extract_table_arrays(table)
-
-            # Create the Arrow readable resource
-            resource = core_ops.io_arrow_readable_from_memory_init(
-                schema_buffer_addr,
-                schema_buffer_size,
-                array_buffer_addrs,
-                array_buffer_sizes,
-                array_lengths,
-                container=scope,
-                shared_name="pyarrow.Table{}/{}".format(
-                    table.schema.names, uuid.uuid4().hex
-                ),
-            )
-
-            if tf.executing_eagerly():
-                # Create a BaseIOTensor for each column
-                elements = []
-                columns = table.column_names
-                for column_index, column in enumerate(columns):
-                    shape, dtype = core_ops.io_arrow_readable_spec(
-                        resource, column_index
+        if tf.executing_eagerly():
+            # Create a BaseIOTensor for each column
+            elements = []
+            columns = table.column_names
+            for column_index, column in enumerate(columns):
+                shape, dtype = core_ops.io_arrow_readable_spec(
+                    resource, column_index, column
+                )
+                shape = tf.TensorShape(shape.numpy())
+                dtype = tf.as_dtype(dtype.numpy())
+                spec = tf.TensorSpec(shape, dtype, column)
+                function = _ArrowIOTensorComponentFunction(  # pylint: disable=protected-access
+                    core_ops.io_arrow_readable_read,
+                    resource,
+                    column_index,
+                    column,
+                    shape,
+                    dtype,
+                )
+                elements.append(
+                    ArrowBaseIOTensor(
+                        shape, dtype, spec, function, arrow_resource, internal=internal
                     )
-                    shape = tf.TensorShape(shape.numpy())
-                    dtype = tf.as_dtype(dtype.numpy())
-                    spec = tf.TensorSpec(shape, dtype, column)
-                    function = _ArrowIOTensorComponentFunction(  # pylint: disable=protected-access
-                        core_ops.io_arrow_readable_read,
-                        resource,
-                        column_index,
-                        shape,
-                        dtype,
-                    )
-                    elements.append(
-                        ArrowBaseIOTensor(
-                            shape,
-                            dtype,
-                            spec,
-                            function,
-                            arrow_data_refs,
-                            internal=internal,
-                        )
-                    )
-                spec = tuple([e.spec for e in elements])
-            else:
-                assert spec is not None
-                columns, entries = zip(*spec.items())
-                dtypes = [
-                    entry if isinstance(entry, tf.dtypes.DType) else entry.dtype
-                    for entry in entries
-                ]
+                )
+            spec = tuple([e.spec for e in elements])
+        else:
+            assert spec is not None
+            columns, entries = zip(*spec.items())
+            # Column could be specified by index or name
+            columns = [
+                (column, "") if isinstance(column, int) else (-1, column)
+                for column in columns
+            ]
+            dtypes = [
+                entry if isinstance(entry, tf.dtypes.DType) else entry.dtype
+                for entry in entries
+            ]
 
-                col_to_idx = {column: i for i, column in enumerate(table.column_names)}
+            shapes = []
+            for (column_index, column) in columns:
+                shape, _ = core_ops.io_arrow_readable_spec(
+                    resource, column_index, column
+                )
+                shapes.append(shape)
 
-                shapes = []
-                for col in columns:
-                    shape, _ = core_ops.io_arrow_readable_spec(
-                        resource, col_to_idx[col]
-                    )
-                    shapes.append(shape)
+            entries = [
+                tf.TensorSpec(
+                    None, dtype, str(column_index) if column_index >= 0 else column
+                )
+                for (dtype, (column_index, column)) in zip(dtypes, columns)
+            ]
 
-                entries = [
-                    tf.TensorSpec(None, dtype, column)
-                    for (dtype, column) in zip(dtypes, columns)
-                ]
-
-                elements = []
-                for (entry, shape) in zip(entries, shapes):
-                    function = _ArrowIOTensorComponentFunction(
-                        core_ops.io_arrow_readable_read,
-                        resource,
-                        col_to_idx[entry.name],
+            elements = []
+            for ((column_index, column), entry, shape) in zip(columns, entries, shapes):
+                function = _ArrowIOTensorComponentFunction(
+                    core_ops.io_arrow_readable_read,
+                    resource,
+                    column_index,
+                    column,
+                    shape,
+                    entry.dtype,
+                )
+                elements.append(
+                    ArrowBaseIOTensor(
                         shape,
                         entry.dtype,
+                        entry,
+                        function,
+                        arrow_resource,
+                        internal=internal,
                     )
-                    elements.append(
-                        ArrowBaseIOTensor(
-                            shape,
-                            entry.dtype,
-                            entry,
-                            function,
-                            arrow_data_refs,
-                            internal=internal,
-                        )
-                    )
-                spec = tuple(entries)
+                )
+            spec = tuple(entries)
+            columns = [
+                str(column_index) if column_index >= 0 else column
+                for (column_index, column) in columns
+            ]
 
-            super().__init__(spec, columns, elements, internal=internal)
+        super().__init__(spec, columns, elements, internal=internal)
+
+    def __call__(self, column):
+        """Return a ArrowBaseIOTensor given `column` as name or index"""
+        if isinstance(column, int):
+            column = str(column)
+        return super().__call__(column)

--- a/tensorflow_io/core/python/ops/io_tensor.py
+++ b/tensorflow_io/core/python/ops/io_tensor.py
@@ -332,7 +332,8 @@ class IOTensor(io_tensor_ops._IOTensor):  # pylint: disable=protected-access
           spec: A dict of `dataset:tf.TensorSpec` or `dataset:dtype`
             pairs that specify the dataset selected and the tf.TensorSpec
             or dtype of the dataset. In eager mode the spec is probed
-            automatically. In graph mode spec has to be specified.
+            automatically. In graph mode `spec` is required and columns
+            in the `pyarrow.Table` can be keyed by column name or index.
           name: A name prefix for the IOTensor (optional).
 
         Returns:


### PR DESCRIPTION
It could be useful to be able to initialize a `pyarrow.Table` inside a `tf.data.Dataset.map` function, e.g. reading a list of files and loading each one at a time into a table.

This creates a `ArrowIOResource` that allows for a function returning a pyarrow.Table to be used to initialize an `ArrowIOTensor` inside a map operation. The function becomes wrapped in a tf.py_function, where it will be eagerly executed to initialize the table that can then be input into the graph.