### PR TITLE
Add tfio.experimental.audio.[decode|encode]_flac support

### DIFF
--- a/tensorflow_io/core/kernels/audio_flac_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_flac_kernels.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow_io/core/kernels/audio_kernels.h"
 
 #include "FLAC/stream_decoder.h"
+#include "FLAC/stream_encoder.h"
 
 namespace tensorflow {
 namespace data {
@@ -159,6 +160,53 @@ class FlacStreamDecoder {
   int64 sample_index;
   int64 sample_start;
   Tensor* sample_value;
+};
+
+class FlacStreamEncoder {
+ public:
+  FlacStreamEncoder(tstring* buffer) : buffer(buffer), offset(0) {}
+  ~FlacStreamEncoder() {}
+
+  static const int64 kSampleBufferCount = 1024;
+
+  static FLAC__StreamEncoderWriteStatus WriteCallback(
+      const FLAC__StreamEncoder* encoder, const FLAC__byte buffer[],
+      size_t bytes, uint32_t samples, uint32_t current_frame,
+      void* client_data) {
+    FlacStreamEncoder* p = static_cast<FlacStreamEncoder*>(client_data);
+    if (p->offset + bytes > p->buffer->size()) {
+      p->buffer->resize(p->offset + bytes);
+    }
+    memcpy(&(*p->buffer)[p->offset], buffer, bytes);
+    p->offset += bytes;
+    return FLAC__STREAM_ENCODER_WRITE_STATUS_OK;
+  }
+
+  static FLAC__StreamEncoderSeekStatus SeekCallback(
+      const FLAC__StreamEncoder* encoder, FLAC__uint64 absolute_byte_offset,
+      void* client_data) {
+    FlacStreamEncoder* p = static_cast<FlacStreamEncoder*>(client_data);
+    if (absolute_byte_offset > p->buffer->size()) {
+      return FLAC__STREAM_ENCODER_SEEK_STATUS_ERROR;
+    }
+    p->offset = absolute_byte_offset;
+    return FLAC__STREAM_ENCODER_SEEK_STATUS_OK;
+  }
+
+  static FLAC__StreamEncoderTellStatus TellCallback(
+      const FLAC__StreamEncoder* encoder, FLAC__uint64* absolute_byte_offset,
+      void* client_data) {
+    FlacStreamEncoder* p = static_cast<FlacStreamEncoder*>(client_data);
+    *absolute_byte_offset = p->offset;
+    return FLAC__STREAM_ENCODER_TELL_STATUS_OK;
+  }
+
+  static void MetadataCallback(const FLAC__StreamEncoder* encoder,
+                               const FLAC__StreamMetadata* metadata,
+                               void* client_data) {}
+
+  tstring* buffer;
+  int64 offset;
 };
 
 class FlacReadableResource : public AudioReadableResourceBase {
@@ -316,9 +364,126 @@ class AudioDecodeFlacOp : public OpKernel {
   mutable mutex mu_;
   Env* env_ GUARDED_BY(mu_);
 };
+class AudioEncodeFlacOp : public OpKernel {
+ public:
+  explicit AudioEncodeFlacOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    const Tensor* rate_tensor;
+    OP_REQUIRES_OK(context, context->input("rate", &rate_tensor));
+
+    const int64 rate = rate_tensor->scalar<int64>()();
+    const int64 samples = input_tensor->shape().dim_size(0);
+    const int64 channels = input_tensor->shape().dim_size(1);
+
+    const int64 bytes_per_sample = DataTypeSize(input_tensor->dtype());
+    // TODO: support more data types
+    switch (input_tensor->dtype()) {
+      case DT_INT16:
+        break;
+      default:
+        OP_REQUIRES(context, false,
+                    errors::InvalidArgument(
+                        "data type ", DataTypeString(input_tensor->dtype()),
+                        " not supported"));
+    }
+
+    std::unique_ptr<FLAC__StreamEncoder, void (*)(FLAC__StreamEncoder*)>
+        encoder(nullptr, [](FLAC__StreamEncoder* p) {
+          if (p != nullptr) {
+            FLAC__stream_encoder_delete(p);
+          }
+        });
+    encoder.reset(FLAC__stream_encoder_new());
+
+    FLAC__bool ok;
+
+    ok = FLAC__stream_encoder_set_verify(encoder.get(), true);
+    OP_REQUIRES(context, ok, errors::InvalidArgument("unable to set verify"));
+
+    // ok = FLAC__stream_encoder_set_compression_level(encoder.get(), 5);
+    // OP_REQUIRES(context, ok, errors::InvalidArgument("unable to set
+    // compression level"));
+
+    ok = FLAC__stream_encoder_set_channels(encoder.get(), channels);
+    OP_REQUIRES(context, ok, errors::InvalidArgument("unable to set channels"));
+
+    ok = FLAC__stream_encoder_set_bits_per_sample(encoder.get(),
+                                                  bytes_per_sample * 8);
+    OP_REQUIRES(context, ok,
+                errors::InvalidArgument("unable to set bits per sample"));
+
+    ok = FLAC__stream_encoder_set_sample_rate(encoder.get(), rate);
+    OP_REQUIRES(context, ok, errors::InvalidArgument("unable to set rate"));
+
+    ok =
+        FLAC__stream_encoder_set_total_samples_estimate(encoder.get(), samples);
+    OP_REQUIRES(
+        context, ok,
+        errors::InvalidArgument("unable to set total samples estimate"));
+
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(
+        context, context->allocate_output(0, TensorShape({}), &output_tensor));
+
+    tstring& output = output_tensor->scalar<tstring>()();
+
+    std::unique_ptr<FlacStreamEncoder> stream_encoder;
+    stream_encoder.reset(new FlacStreamEncoder(&output));
+
+    FLAC__StreamEncoderInitStatus s = FLAC__stream_encoder_init_stream(
+        encoder.get(), FlacStreamEncoder::WriteCallback,
+        FlacStreamEncoder::SeekCallback, FlacStreamEncoder::TellCallback,
+        FlacStreamEncoder::MetadataCallback, stream_encoder.get());
+    OP_REQUIRES(context, (s == FLAC__STREAM_ENCODER_INIT_STATUS_OK),
+                errors::InvalidArgument("unable to initialize stream: ", s));
+
+    std::unique_ptr<FLAC__int32[]> pcm(
+        new FLAC__int32[FlacStreamEncoder::kSampleBufferCount * channels]);
+
+    int64 count = 0;
+    while (count < samples) {
+      int64 chunk = (count + FlacStreamEncoder::kSampleBufferCount < samples)
+                        ? (FlacStreamEncoder::kSampleBufferCount)
+                        : (samples - count);
+      switch (input_tensor->dtype()) {
+        case DT_INT16: {
+          for (int64 i = 0; i < chunk; i++) {
+            for (int64 c = 0; c < channels; c++) {
+              pcm.get()[i * channels + c] =
+                  input_tensor->flat<int16>()((count + i) * channels + c);
+            }
+          }
+        } break;
+      }
+      ok = FLAC__stream_encoder_process_interleaved(encoder.get(), pcm.get(),
+                                                    chunk);
+      OP_REQUIRES(
+          context, ok,
+          errors::InvalidArgument("unable to process interleaved stream"));
+      count += chunk;
+    }
+
+    ok = FLAC__stream_encoder_finish(encoder.get());
+    OP_REQUIRES(context, ok,
+                errors::InvalidArgument("unable to finish stream"));
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
 
 REGISTER_KERNEL_BUILDER(Name("IO>AudioDecodeFlac").Device(DEVICE_CPU),
                         AudioDecodeFlacOp);
+REGISTER_KERNEL_BUILDER(Name("IO>AudioEncodeFlac").Device(DEVICE_CPU),
+                        AudioEncodeFlacOp);
 }  // namespace
 
 Status FlacReadableResourceInit(

--- a/tensorflow_io/core/kernels/audio_flac_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_flac_kernels.cc
@@ -262,6 +262,63 @@ class FlacReadableResource : public AudioReadableResourceBase {
   std::unique_ptr<FlacStreamDecoder> stream_decoder_;
 };
 
+class AudioDecodeFlacOp : public OpKernel {
+ public:
+  explicit AudioDecodeFlacOp(OpKernelConstruction* context)
+      : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    const Tensor* shape_tensor;
+    OP_REQUIRES_OK(context, context->input("shape", &shape_tensor));
+
+    const tstring& input = input_tensor->scalar<tstring>()();
+
+    std::unique_ptr<AudioReadableResourceBase> resource;
+    OP_REQUIRES_OK(context,
+                   FlacReadableResourceInit(env_, "memory", input.data(),
+                                            input.size(), resource));
+
+    int32 rate;
+    DataType dtype;
+    TensorShape shape;
+    OP_REQUIRES_OK(context, resource->Spec(&shape, &dtype, &rate));
+
+    OP_REQUIRES(context, (dtype == context->expected_output_dtype(0)),
+                errors::InvalidArgument(
+                    "dtype mismatch: ", DataTypeString(dtype), " vs. ",
+                    DataTypeString(context->expected_output_dtype(0))));
+
+    PartialTensorShape provided_shape;
+    OP_REQUIRES_OK(context, PartialTensorShape::MakePartialShape(
+                                shape_tensor->flat<int64>().data(),
+                                shape_tensor->NumElements(), &provided_shape));
+    OP_REQUIRES(context, (provided_shape.IsCompatibleWith(shape)),
+                errors::InvalidArgument(
+                    "shape mismatch: ", provided_shape.DebugString(), " vs. ",
+                    shape.DebugString()));
+
+    OP_REQUIRES_OK(
+        context,
+        resource->Read(0, shape.dim_size(0),
+                       [&](const TensorShape& shape, Tensor** value) -> Status {
+                         TF_RETURN_IF_ERROR(
+                             context->allocate_output(0, shape, value));
+                         return Status::OK();
+                       }));
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
+
+REGISTER_KERNEL_BUILDER(Name("IO>AudioDecodeFlac").Device(DEVICE_CPU),
+                        AudioDecodeFlacOp);
 }  // namespace
 
 Status FlacReadableResourceInit(

--- a/tensorflow_io/core/kernels/audio_flac_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_flac_kernels.cc
@@ -407,6 +407,7 @@ class AudioEncodeFlacOp : public OpKernel {
     ok = FLAC__stream_encoder_set_verify(encoder.get(), true);
     OP_REQUIRES(context, ok, errors::InvalidArgument("unable to set verify"));
 
+    // TODO: compression level could be a input tensor node passed in.
     // ok = FLAC__stream_encoder_set_compression_level(encoder.get(), 5);
     // OP_REQUIRES(context, ok, errors::InvalidArgument("unable to set
     // compression level"));

--- a/tensorflow_io/core/kernels/audio_flac_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_flac_kernels.cc
@@ -278,10 +278,10 @@ class AudioDecodeFlacOp : public OpKernel {
 
     const tstring& input = input_tensor->scalar<tstring>()();
 
-    std::unique_ptr<AudioReadableResourceBase> resource;
+    std::unique_ptr<FlacReadableResource> resource(
+        new FlacReadableResource(env_));
     OP_REQUIRES_OK(context,
-                   FlacReadableResourceInit(env_, "memory", input.data(),
-                                            input.size(), resource));
+                   resource->Init("memory", input.data(), input.size()));
 
     int32 rate;
     DataType dtype;

--- a/tensorflow_io/core/kernels/audio_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_kernels.cc
@@ -96,8 +96,8 @@ class AudioReadableInitOp : public ResourceOpKernel<AudioReadableResource> {
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
 
-    OP_REQUIRES_OK(
-        context, resource_->Init(input_tensor->scalar<tstring>()(), nullptr, 0));
+    OP_REQUIRES_OK(context, resource_->Init(input_tensor->scalar<tstring>()(),
+                                            nullptr, 0));
   }
   Status CreateResource(AudioReadableResource** resource)
       EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
@@ -276,60 +276,6 @@ class AudioResampleOp : public OpKernel {
   int64 quality_;
 };
 
-class AudioDecodeWAVOp : public OpKernel {
- public:
-  explicit AudioDecodeWAVOp(OpKernelConstruction* context) : OpKernel(context) {
-    env_ = context->env();
-  }
-
-  void Compute(OpKernelContext* context) override {
-    const Tensor* input_tensor;
-    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
-
-    const Tensor* shape_tensor;
-    OP_REQUIRES_OK(context, context->input("shape", &shape_tensor));
-
-    const string& input = input_tensor->scalar<tstring>()();
-
-    std::unique_ptr<AudioReadableResourceBase> resource;
-    OP_REQUIRES_OK(context,
-                   WAVReadableResourceInit(env_, "memory", input.data(),
-                                           input.size(), resource));
-
-    int32 rate;
-    DataType dtype;
-    TensorShape shape;
-    OP_REQUIRES_OK(context, resource->Spec(&shape, &dtype, &rate));
-
-    OP_REQUIRES(context, (dtype == context->expected_output_dtype(0)),
-                errors::InvalidArgument(
-                    "dtype mismatch: ", DataTypeString(dtype), " vs. ",
-                    DataTypeString(context->expected_output_dtype(0))));
-
-    PartialTensorShape provided_shape;
-    OP_REQUIRES_OK(context, PartialTensorShape::MakePartialShape(
-                                shape_tensor->flat<int64>().data(),
-                                shape_tensor->NumElements(), &provided_shape));
-    OP_REQUIRES(context, (provided_shape.IsCompatibleWith(shape)),
-                errors::InvalidArgument(
-                    "shape mismatch: ", provided_shape.DebugString(), " vs. ",
-                    shape.DebugString()));
-
-    OP_REQUIRES_OK(
-        context,
-        resource->Read(0, shape.dim_size(0),
-                       [&](const TensorShape& shape, Tensor** value) -> Status {
-                         TF_RETURN_IF_ERROR(
-                             context->allocate_output(0, shape, value));
-                         return Status::OK();
-                       }));
-  }
-
- private:
-  mutable mutex mu_;
-  Env* env_ GUARDED_BY(mu_);
-};
-
 REGISTER_KERNEL_BUILDER(Name("IO>AudioReadableInit").Device(DEVICE_CPU),
                         AudioReadableInitOp);
 REGISTER_KERNEL_BUILDER(Name("IO>AudioReadableSpec").Device(DEVICE_CPU),
@@ -339,8 +285,6 @@ REGISTER_KERNEL_BUILDER(Name("IO>AudioReadableRead").Device(DEVICE_CPU),
 
 REGISTER_KERNEL_BUILDER(Name("IO>AudioResample").Device(DEVICE_CPU),
                         AudioResampleOp);
-REGISTER_KERNEL_BUILDER(Name("IO>AudioDecodeWAV").Device(DEVICE_CPU),
-                        AudioDecodeWAVOp);
 }  // namespace
 }  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/core/kernels/audio_wav_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_wav_kernels.cc
@@ -299,6 +299,63 @@ class WAVReadableResource : public AudioReadableResourceBase {
   int64 header_length_;
 };
 
+class AudioDecodeWAVOp : public OpKernel {
+ public:
+  explicit AudioDecodeWAVOp(OpKernelConstruction* context) : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    const Tensor* shape_tensor;
+    OP_REQUIRES_OK(context, context->input("shape", &shape_tensor));
+
+    const string& input = input_tensor->scalar<tstring>()();
+
+    std::unique_ptr<WAVReadableResource> resource(
+        new WAVReadableResource(env_));
+    OP_REQUIRES_OK(context,
+                   resource->Init("memory", input.data(), input.size()));
+
+    int32 rate;
+    DataType dtype;
+    TensorShape shape;
+    OP_REQUIRES_OK(context, resource->Spec(&shape, &dtype, &rate));
+
+    OP_REQUIRES(context, (dtype == context->expected_output_dtype(0)),
+                errors::InvalidArgument(
+                    "dtype mismatch: ", DataTypeString(dtype), " vs. ",
+                    DataTypeString(context->expected_output_dtype(0))));
+
+    PartialTensorShape provided_shape;
+    OP_REQUIRES_OK(context, PartialTensorShape::MakePartialShape(
+                                shape_tensor->flat<int64>().data(),
+                                shape_tensor->NumElements(), &provided_shape));
+    OP_REQUIRES(context, (provided_shape.IsCompatibleWith(shape)),
+                errors::InvalidArgument(
+                    "shape mismatch: ", provided_shape.DebugString(), " vs. ",
+                    shape.DebugString()));
+
+    OP_REQUIRES_OK(
+        context,
+        resource->Read(0, shape.dim_size(0),
+                       [&](const TensorShape& shape, Tensor** value) -> Status {
+                         TF_RETURN_IF_ERROR(
+                             context->allocate_output(0, shape, value));
+                         return Status::OK();
+                       }));
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
+
+REGISTER_KERNEL_BUILDER(Name("IO>AudioDecodeWAV").Device(DEVICE_CPU),
+                        AudioDecodeWAVOp);
+
 }  // namespace
 
 Status WAVReadableResourceInit(

--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -106,6 +106,16 @@ REGISTER_OP("IO>AudioDecodeFlac")
       return Status::OK();
     });
 
+REGISTER_OP("IO>AudioEncodeFlac")
+    .Input("input: dtype")
+    .Input("rate: int64")
+    .Output("value: string")
+    .Attr("dtype: {int16}")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Scalar());
+      return Status::OK();
+    });
+
 }  // namespace
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -86,6 +86,26 @@ REGISTER_OP("IO>AudioDecodeWAV")
       return Status::OK();
     });
 
+REGISTER_OP("IO>AudioDecodeFlac")
+    .Input("input: string")
+    .Input("shape: int64")
+    .Output("value: dtype")
+    .Attr("dtype: {int16, int32}")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle shape;
+      TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(1, &shape));
+      if (!c->RankKnown(shape)) {
+        c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
+        return Status::OK();
+      }
+      if (c->Rank(shape) != 2) {
+        return errors::InvalidArgument("rank must be two, received ",
+                                       c->DebugString(shape));
+      }
+      c->set_output(0, shape);
+      return Status::OK();
+    });
+
 }  // namespace
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -17,4 +17,5 @@
 from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disable=unused-import
     resample,
     decode_wav,
+    decode_flac,
 )

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -18,4 +18,5 @@ from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disabl
     resample,
     decode_wav,
     decode_flac,
+    encode_flac,
 )

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -51,3 +51,22 @@ def decode_wav(input, shape=None, dtype=None, name=None): # pylint: disable=rede
   assert (dtype is not None), "dtype (tf.int16/tf.int32) must be provided"
   return core_ops.io_audio_decode_wav(
       input, shape=shape, dtype=dtype, name=name)
+
+def decode_flac(input, shape=None, dtype=None, name=None): # pylint: disable=redefined-builtin
+  """Decode Flac audio from input string.
+
+  Args:
+    input: A string `Tensor` of the audio input.
+    shape: The shape of the audio.
+    dtype: The data type of the audio, only tf.int16 is supported.
+    name: A name for the operation (optional).
+
+  Returns:
+    output: Decoded audio.
+  """
+  if shape is None:
+    shape = tf.constant([-1, -1], tf.int64)
+  if dtype is None:
+    dtype = tf.int16
+  return core_ops.io_audio_decode_flac(
+      input, shape=shape, dtype=dtype, name=name)

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -70,3 +70,16 @@ def decode_flac(input, shape=None, dtype=None, name=None): # pylint: disable=red
     dtype = tf.int16
   return core_ops.io_audio_decode_flac(
       input, shape=shape, dtype=dtype, name=name)
+
+def encode_flac(input, rate, name=None): # pylint: disable=redefined-builtin
+  """Encode Flac audio into string.
+
+  Args:
+    input: A `Tensor` of the audio input.
+    rate: The sample rate of the audio.
+    name: A name for the operation (optional).
+
+  Returns:
+    output: Encoded audio.
+  """
+  return core_ops.io_audio_encode_flac(input, rate, name=name)

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -68,6 +68,27 @@ def fixture_decode_wav():
 
   return args, func, expected
 
+@pytest.fixture(name="decode_flac", scope="module")
+def fixture_decode_flac():
+  """fixture_decode_flac"""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "ZASFX_ADSR_no_sustain.flac")
+  content = tf.io.read_file(path)
+
+  wav_path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "ZASFX_ADSR_no_sustain.wav")
+  audio = tf.audio.decode_wav(tf.io.read_file(wav_path))
+  value = audio.audio * (1 << 15)
+  value = tf.cast(value, tf.int16)
+
+  args = path
+  func = lambda e: tfio.experimental.audio.decode_flac(content, dtype=tf.int16)
+  expected = value
+
+  return args, func, expected
+
 # By default, operations runs in eager mode,
 # Note as of now shape inference is skipped in eager mode
 @pytest.mark.parametrize(
@@ -75,10 +96,14 @@ def fixture_decode_wav():
     [
         pytest.param("resample"),
         pytest.param("decode_wav"),
+        pytest.param("decode_flac"),
+        pytest.param("decode_flac"),
     ],
     ids=[
         "resample",
         "decode_wav",
+        "decode_flac",
+        "encode_flac",
     ],
 )
 def test_audio_ops(fixture_lookup, io_data_fixture):
@@ -94,10 +119,14 @@ def test_audio_ops(fixture_lookup, io_data_fixture):
     [
         pytest.param("resample"),
         pytest.param("decode_wav"),
+        pytest.param("decode_flac"),
+        pytest.param("decode_flac"),
     ],
     ids=[
         "resample",
         "decode_wav",
+        "decode_flac",
+        "encode_flac",
     ],
 )
 def test_audio_ops_in_graph(fixture_lookup, io_data_fixture):

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -45,7 +45,7 @@ def fixture_resample():
   expected_value = tf.cast(expected_value, tf.int16)
 
   args = value
-  func = lambda e: tfio.experimental.audio.resample(value, 44100, 4410, 1)
+  func = lambda e: tfio.experimental.audio.resample(e, 44100, 4410, 1)
   expected = expected_value
 
   return args, func, expected
@@ -63,7 +63,7 @@ def fixture_decode_wav():
   value = tf.cast(value, tf.int16)
 
   args = content
-  func = lambda e: tfio.experimental.audio.decode_wav(content, dtype=tf.int16)
+  func = lambda e: tfio.experimental.audio.decode_wav(e, dtype=tf.int16)
   expected = value
 
   return args, func, expected
@@ -83,8 +83,8 @@ def fixture_decode_flac():
   value = audio.audio * (1 << 15)
   value = tf.cast(value, tf.int16)
 
-  args = path
-  func = lambda e: tfio.experimental.audio.decode_flac(content)
+  args = content
+  func = tfio.experimental.audio.decode_flac
   expected = value
 
   return args, func, expected
@@ -92,11 +92,6 @@ def fixture_decode_flac():
 @pytest.fixture(name="encode_flac", scope="module")
 def fixture_encode_flac():
   """fixture_encode_flac"""
-  path = os.path.join(
-      os.path.dirname(os.path.abspath(__file__)),
-      "test_audio", "ZASFX_ADSR_no_sustain.flac")
-  content = tf.io.read_file(path)
-
   wav_path = os.path.join(
       os.path.dirname(os.path.abspath(__file__)),
       "test_audio", "ZASFX_ADSR_no_sustain.wav")
@@ -104,9 +99,11 @@ def fixture_encode_flac():
   value = audio.audio * (1 << 15)
   value = tf.cast(value, tf.int16)
 
-  args = path
-  func = lambda e: tfio.experimental.audio.encode_flac(value, rate=44100)
-  expected = content
+  args = value
+  def func(e):
+    v = tfio.experimental.audio.encode_flac(e, rate=44100)
+    return tfio.experimental.audio.decode_flac(v)
+  expected = value
 
   return args, func, expected
 
@@ -155,6 +152,7 @@ def test_audio_ops_in_graph(fixture_lookup, io_data_fixture):
   args, func, expected = fixture_lookup(io_data_fixture)
 
   dataset = tf.data.Dataset.from_tensor_slices([args])
+
   dataset = dataset.map(func)
   entries = list(dataset)
   assert len(entries) == 1

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -84,8 +84,29 @@ def fixture_decode_flac():
   value = tf.cast(value, tf.int16)
 
   args = path
-  func = lambda e: tfio.experimental.audio.decode_flac(content, dtype=tf.int16)
+  func = lambda e: tfio.experimental.audio.decode_flac(content)
   expected = value
+
+  return args, func, expected
+
+@pytest.fixture(name="encode_flac", scope="module")
+def fixture_encode_flac():
+  """fixture_encode_flac"""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "ZASFX_ADSR_no_sustain.flac")
+  content = tf.io.read_file(path)
+
+  wav_path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "ZASFX_ADSR_no_sustain.wav")
+  audio = tf.audio.decode_wav(tf.io.read_file(wav_path))
+  value = audio.audio * (1 << 15)
+  value = tf.cast(value, tf.int16)
+
+  args = path
+  func = lambda e: tfio.experimental.audio.encode_flac(value, rate=44100)
+  expected = content
 
   return args, func, expected
 
@@ -97,7 +118,7 @@ def fixture_decode_flac():
         pytest.param("resample"),
         pytest.param("decode_wav"),
         pytest.param("decode_flac"),
-        pytest.param("decode_flac"),
+        pytest.param("encode_flac"),
     ],
     ids=[
         "resample",
@@ -120,7 +141,7 @@ def test_audio_ops(fixture_lookup, io_data_fixture):
         pytest.param("resample"),
         pytest.param("decode_wav"),
         pytest.param("decode_flac"),
-        pytest.param("decode_flac"),
+        pytest.param("encode_flac"),
     ],
     ids=[
         "resample",


### PR DESCRIPTION
This PR adds Add tfio.experimental.audio.[decode|encode]_flac support, as part of the effort to revisit audio APIs.

This PR is part of #839

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>