### PR TITLE
Add tfio.experimental.audio.[decode|encode]_ogg support

### DIFF
--- a/tensorflow_io/core/kernels/audio_ogg_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_ogg_kernels.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow_io/core/kernels/audio_kernels.h"
 
 #include "vorbis/codec.h"
+#include "vorbis/vorbisenc.h"
 #include "vorbis/vorbisfile.h"
 
 namespace tensorflow {
@@ -224,8 +225,180 @@ class AudioDecodeOggOp : public OpKernel {
   Env* env_ GUARDED_BY(mu_);
 };
 
+Status OggEncodeStreamProcess(vorbis_dsp_state& vd, vorbis_block& vb,
+                              ogg_stream_state& os, ogg_page& og,
+                              ogg_packet& op, tstring* output) {
+  int s;
+  while (vorbis_analysis_blockout(&vd, &vb) == 1) {
+    vorbis_analysis(&vb, NULL);
+    vorbis_bitrate_addblock(&vb);
+
+    while (vorbis_bitrate_flushpacket(&vd, &op) == 1) {
+      // weld the packet into the bitstream
+      ogg_stream_packetin(&os, &op);
+
+      // write out pages (if any)
+      while ((s = ogg_stream_flush(&os, &og)) != 0) {
+        output->append((const char*)og.header, og.header_len);
+        output->append((const char*)og.body, og.body_len);
+        if (ogg_page_eos(&og) != 0) {
+          break;
+        }
+      }
+    }
+  }
+  return Status::OK();
+}
+
+class AudioEncodeOggOp : public OpKernel {
+ public:
+  explicit AudioEncodeOggOp(OpKernelConstruction* context) : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    const Tensor* rate_tensor;
+    OP_REQUIRES_OK(context, context->input("rate", &rate_tensor));
+
+    const int64 rate = rate_tensor->scalar<int64>()();
+    const int64 samples = input_tensor->shape().dim_size(0);
+    const int64 channels = input_tensor->shape().dim_size(1);
+
+    const int64 bytes_per_sample = DataTypeSize(input_tensor->dtype());
+    // TODO: support more data types
+    switch (input_tensor->dtype()) {
+      case DT_INT16:
+        break;
+      default:
+        OP_REQUIRES(context, false,
+                    errors::InvalidArgument(
+                        "data type ", DataTypeString(input_tensor->dtype()),
+                        " not supported"));
+    }
+
+    vorbis_info vi;
+    vorbis_info_init(&vi);
+    std::unique_ptr<vorbis_info, void (*)(vorbis_info*)> vi_scope(
+        &vi, [](vorbis_info* p) {
+          if (p != nullptr) {
+            vorbis_info_clear(p);
+          }
+        });
+
+    int s;
+
+    s = vorbis_encode_init(&vi, channels, rate, -1, 128000, -1);
+    OP_REQUIRES(context, (s == 0),
+                errors::InvalidArgument("unable to init encode: ", s));
+
+    // add a comment
+    vorbis_comment vc;
+    vorbis_comment_init(&vc);
+    std::unique_ptr<vorbis_comment, void (*)(vorbis_comment*)> vc_scope(
+        &vc, [](vorbis_comment* p) {
+          if (p != nullptr) {
+            vorbis_comment_clear(p);
+          }
+        });
+    vorbis_comment_add_tag(&vc, "ENCODER", "tensorflow-io");
+
+    // set up the analysis state
+    vorbis_dsp_state vd;
+    vorbis_analysis_init(&vd, &vi);
+    std::unique_ptr<vorbis_dsp_state, void (*)(vorbis_dsp_state*)> vd_scope(
+        &vd, [](vorbis_dsp_state* p) {
+          if (p != nullptr) {
+            vorbis_dsp_clear(p);
+          }
+        });
+
+    // auxiliary encoding storage
+    vorbis_block vb;
+    vorbis_block_init(&vd, &vb);
+    std::unique_ptr<vorbis_block, void (*)(vorbis_block*)> vb_scope(
+        &vb, [](vorbis_block* p) {
+          if (p != nullptr) {
+            vorbis_block_clear(p);
+          }
+        });
+
+    // srand(time(NULL));
+    ogg_stream_state os;
+    s = ogg_stream_init(&os, rand());
+    OP_REQUIRES(context, (s == 0),
+                errors::InvalidArgument("unable to init ogg stream: ", s));
+    std::unique_ptr<ogg_stream_state, void (*)(ogg_stream_state*)> os_scope(
+        &os, [](ogg_stream_state* p) {
+          if (p != nullptr) {
+            ogg_stream_clear(p);
+          }
+        });
+
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(
+        context, context->allocate_output(0, TensorShape({}), &output_tensor));
+
+    tstring& output = output_tensor->scalar<tstring>()();
+
+    ogg_page og;
+
+    {
+      ogg_packet header;
+      ogg_packet header_comm;
+      ogg_packet header_code;
+
+      vorbis_analysis_headerout(&vd, &vc, &header, &header_comm, &header_code);
+      ogg_stream_packetin(&os, &header);
+      ogg_stream_packetin(&os, &header_comm);
+      ogg_stream_packetin(&os, &header_code);
+
+      // ensures the actual audio data will start on a new page, as per spec
+      while ((s = ogg_stream_flush(&os, &og)) != 0) {
+        output.append((const char*)og.header, og.header_len);
+        output.append((const char*)og.body, og.body_len);
+      }
+    }
+
+    // expose the buffer to submit data
+    float** buffer = vorbis_analysis_buffer(&vd, samples);
+
+    // uninterleave samples
+    switch (input_tensor->dtype()) {
+      case DT_INT16:
+        for (int64 i = 0; i < samples; i++) {
+          for (int64 c = 0; c < channels; c++) {
+            buffer[c][i] =
+                float(input_tensor->flat<int16>()(i * channels + c)) / 32768.f;
+          }
+        }
+        break;
+    }
+
+    ogg_packet op;
+
+    // tell the library how much we actually submitted
+    vorbis_analysis_wrote(&vd, samples);
+    OP_REQUIRES_OK(context,
+                   OggEncodeStreamProcess(vd, vb, os, og, op, &output));
+
+    // end of file
+    vorbis_analysis_wrote(&vd, 0);
+    OP_REQUIRES_OK(context,
+                   OggEncodeStreamProcess(vd, vb, os, og, op, &output));
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
+
 REGISTER_KERNEL_BUILDER(Name("IO>AudioDecodeOgg").Device(DEVICE_CPU),
                         AudioDecodeOggOp);
+REGISTER_KERNEL_BUILDER(Name("IO>AudioEncodeOgg").Device(DEVICE_CPU),
+                        AudioEncodeOggOp);
 
 }  // namespace
 

--- a/tensorflow_io/core/kernels/audio_ogg_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_ogg_kernels.cc
@@ -170,6 +170,63 @@ class OggReadableResource : public AudioReadableResourceBase {
   std::unique_ptr<OggVorbisStream> stream_;
 };
 
+class AudioDecodeOggOp : public OpKernel {
+ public:
+  explicit AudioDecodeOggOp(OpKernelConstruction* context) : OpKernel(context) {
+    env_ = context->env();
+  }
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor* input_tensor;
+    OP_REQUIRES_OK(context, context->input("input", &input_tensor));
+
+    const Tensor* shape_tensor;
+    OP_REQUIRES_OK(context, context->input("shape", &shape_tensor));
+
+    const tstring& input = input_tensor->scalar<tstring>()();
+
+    std::unique_ptr<OggReadableResource> resource(
+        new OggReadableResource(env_));
+    OP_REQUIRES_OK(context,
+                   resource->Init("memory", input.data(), input.size()));
+
+    int32 rate;
+    DataType dtype;
+    TensorShape shape;
+    OP_REQUIRES_OK(context, resource->Spec(&shape, &dtype, &rate));
+
+    OP_REQUIRES(context, (dtype == context->expected_output_dtype(0)),
+                errors::InvalidArgument(
+                    "dtype mismatch: ", DataTypeString(dtype), " vs. ",
+                    DataTypeString(context->expected_output_dtype(0))));
+
+    PartialTensorShape provided_shape;
+    OP_REQUIRES_OK(context, PartialTensorShape::MakePartialShape(
+                                shape_tensor->flat<int64>().data(),
+                                shape_tensor->NumElements(), &provided_shape));
+    OP_REQUIRES(context, (provided_shape.IsCompatibleWith(shape)),
+                errors::InvalidArgument(
+                    "shape mismatch: ", provided_shape.DebugString(), " vs. ",
+                    shape.DebugString()));
+
+    OP_REQUIRES_OK(
+        context,
+        resource->Read(0, shape.dim_size(0),
+                       [&](const TensorShape& shape, Tensor** value) -> Status {
+                         TF_RETURN_IF_ERROR(
+                             context->allocate_output(0, shape, value));
+                         return Status::OK();
+                       }));
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ GUARDED_BY(mu_);
+};
+
+REGISTER_KERNEL_BUILDER(Name("IO>AudioDecodeOgg").Device(DEVICE_CPU),
+                        AudioDecodeOggOp);
+
 }  // namespace
 
 Status OggReadableResourceInit(

--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -116,6 +116,26 @@ REGISTER_OP("IO>AudioEncodeFlac")
       return Status::OK();
     });
 
+REGISTER_OP("IO>AudioDecodeOgg")
+    .Input("input: string")
+    .Input("shape: int64")
+    .Output("value: dtype")
+    .Attr("dtype: {int16, int32}")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle shape;
+      TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(1, &shape));
+      if (!c->RankKnown(shape)) {
+        c->set_output(0, c->MakeShape({c->UnknownDim(), c->UnknownDim()}));
+        return Status::OK();
+      }
+      if (c->Rank(shape) != 2) {
+        return errors::InvalidArgument("rank must be two, received ",
+                                       c->DebugString(shape));
+      }
+      c->set_output(0, shape);
+      return Status::OK();
+    });
+
 }  // namespace
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -136,6 +136,16 @@ REGISTER_OP("IO>AudioDecodeOgg")
       return Status::OK();
     });
 
+REGISTER_OP("IO>AudioEncodeOgg")
+    .Input("input: dtype")
+    .Input("rate: int64")
+    .Output("value: string")
+    .Attr("dtype: {int16}")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Scalar());
+      return Status::OK();
+    });
+
 }  // namespace
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -19,4 +19,5 @@ from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disabl
     decode_wav,
     decode_flac,
     encode_flac,
+    decode_ogg,
 )

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -20,4 +20,5 @@ from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disabl
     decode_flac,
     encode_flac,
     decode_ogg,
+    encode_ogg,
 )

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -89,3 +89,16 @@ def decode_ogg(input, shape=None, dtype=None, name=None): # pylint: disable=rede
   assert (dtype is not None), "dtype (tf.int16) must be provided"
   return core_ops.io_audio_decode_ogg(
       input, shape=shape, dtype=dtype, name=name)
+
+def encode_ogg(input, rate, name=None): # pylint: disable=redefined-builtin
+  """Encode Ogg audio into string.
+
+  Args:
+    input: A `Tensor` of the audio input.
+    rate: The sample rate of the audio.
+    name: A name for the operation (optional).
+
+  Returns:
+    output: Encoded audio.
+  """
+  return core_ops.io_audio_encode_ogg(input, rate, name=name)

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -54,18 +54,6 @@ def decode_wav(input, shape=None, dtype=None, name=None): # pylint: disable=rede
 
 def decode_flac(input, shape=None, dtype=None, name=None): # pylint: disable=redefined-builtin
   """Decode Flac audio from input string.
-
-  Args:
-    input: A string `Tensor` of the audio input.
-    shape: The shape of the audio.
-    dtype: The data type of the audio, only tf.int16 is supported.
-    name: A name for the operation (optional).
-
-  Returns:
-    output: Decoded audio.
-  """
-  if shape is None:
-    shape = tf.constant([-1, -1], tf.int64)
   if dtype is None:
     dtype = tf.int16
   return core_ops.io_audio_decode_flac(
@@ -83,3 +71,21 @@ def encode_flac(input, rate, name=None): # pylint: disable=redefined-builtin
     output: Encoded audio.
   """
   return core_ops.io_audio_encode_flac(input, rate, name=name)
+
+def decode_ogg(input, shape=None, dtype=None, name=None): # pylint: disable=redefined-builtin
+  """Decode OGG audio from input string.
+
+  Args:
+    input: A string `Tensor` of the audio input.
+    shape: The shape of the audio.
+    dtype: The data type of the audio, only tf.int16 is supported.
+    name: A name for the operation (optional).
+
+  Returns:
+    output: Decoded audio.
+  """
+  if shape is None:
+    shape = tf.constant([-1, -1], tf.int64)
+  assert (dtype is not None), "dtype (tf.int16) must be provided"
+  return core_ops.io_audio_decode_ogg(
+      input, shape=shape, dtype=dtype, name=name)

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -54,8 +54,19 @@ def decode_wav(input, shape=None, dtype=None, name=None): # pylint: disable=rede
 
 def decode_flac(input, shape=None, dtype=None, name=None): # pylint: disable=redefined-builtin
   """Decode Flac audio from input string.
-  if dtype is None:
-    dtype = tf.int16
+
+  Args:
+    input: A string `Tensor` of the audio input.
+    shape: The shape of the audio.
+    dtype: The data type of the audio, only tf.int16 is supported.
+    name: A name for the operation (optional).
+
+  Returns:
+    output: Decoded audio.
+  """
+  if shape is None:
+    shape = tf.constant([-1, -1], tf.int64)
+  assert (dtype is not None), "dtype (tf.int16) must be provided"
   return core_ops.io_audio_decode_flac(
       input, shape=shape, dtype=dtype, name=name)
 

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -107,6 +107,27 @@ def fixture_encode_flac():
 
   return args, func, expected
 
+@pytest.fixture(name="decode_ogg", scope="module")
+def fixture_decode_ogg():
+  """fixture_decode_ogg"""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "ZASFX_ADSR_no_sustain.ogg")
+  content = tf.io.read_file(path)
+
+  wav_path = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      "test_audio", "ZASFX_ADSR_no_sustain.wav")
+  audio = tf.audio.decode_wav(tf.io.read_file(wav_path))
+  value = audio.audio * (1 << 15)
+  value = tf.cast(value, tf.int16)
+
+  args = content
+  func = lambda e: tfio.experimental.audio.decode_ogg(e, dtype=tf.int16)
+  expected = value
+
+  return args, func, expected
+
 # By default, operations runs in eager mode,
 # Note as of now shape inference is skipped in eager mode
 @pytest.mark.parametrize(
@@ -116,12 +137,16 @@ def fixture_encode_flac():
         pytest.param("decode_wav"),
         pytest.param("decode_flac"),
         pytest.param("encode_flac"),
+        pytest.param("decode_ogg"),
+        pytest.param("decode_ogg"),
     ],
     ids=[
         "resample",
         "decode_wav",
         "decode_flac",
         "encode_flac",
+        "decode_ogg",
+        "encode_ogg",
     ],
 )
 def test_audio_ops(fixture_lookup, io_data_fixture):
@@ -139,12 +164,16 @@ def test_audio_ops(fixture_lookup, io_data_fixture):
         pytest.param("decode_wav"),
         pytest.param("decode_flac"),
         pytest.param("encode_flac"),
+        pytest.param("decode_ogg"),
+        pytest.param("decode_ogg"),
     ],
     ids=[
         "resample",
         "decode_wav",
         "decode_flac",
         "encode_flac",
+        "decode_ogg",
+        "encode_ogg",
     ],
 )
 def test_audio_ops_in_graph(fixture_lookup, io_data_fixture):

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -84,7 +84,7 @@ def fixture_decode_flac():
   value = tf.cast(value, tf.int16)
 
   args = content
-  func = tfio.experimental.audio.decode_flac
+  func = lambda e: tfio.experimental.audio.decode_flac(e, dtype=tf.int16)
   expected = value
 
   return args, func, expected
@@ -102,7 +102,7 @@ def fixture_encode_flac():
   args = value
   def func(e):
     v = tfio.experimental.audio.encode_flac(e, rate=44100)
-    return tfio.experimental.audio.decode_flac(v)
+    return tfio.experimental.audio.decode_flac(v, dtype=tf.int16)
   expected = value
 
   return args, func, expected

--- a/third_party/vorbis.BUILD
+++ b/third_party/vorbis.BUILD
@@ -10,7 +10,6 @@ cc_library(
             "lib/**/*.c",
         ],
         exclude = [
-            "lib/analysis.c",
             "lib/barkmel.c",
             "lib/psytune.c",
             "lib/tone.c",


### PR DESCRIPTION
This PR adds Add `tfio.experimental.audio.[decode|encode]_ogg` support, as part of the effort to revisit audio APIs.

This PR is part of #839


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>