### PR TITLE
Change to float32 for AudioIOTensor and AudioIODataset in case of MP3 and Ogg

### DIFF
--- a/tensorflow_io/core/kernels/audio_mp3_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_mp3_kernels.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow_io/core/kernels/audio_kernels.h"
 
 #define MINIMP3_IMPLEMENTATION
+#define MINIMP3_FLOAT_OUTPUT
 #include "minimp3_ex.h"
 
 namespace tensorflow {
@@ -87,7 +88,7 @@ class MP3ReadableResource : public AudioReadableResourceBase {
     int64 rate = mp3dec_ex_.info.hz;
 
     shape_ = TensorShape({samples, channels});
-    dtype_ = DT_INT16;
+    dtype_ = DT_FLOAT;
     rate_ = rate;
 
     return Status::OK();
@@ -119,7 +120,7 @@ class MP3ReadableResource : public AudioReadableResourceBase {
       return errors::InvalidArgument("seek to ", sample_start,
                                      " failed: ", mp3dec_ex_.last_error);
     }
-    size_t returned = mp3dec_ex_read(&mp3dec_ex_, value->flat<int16>().data(),
+    size_t returned = mp3dec_ex_read(&mp3dec_ex_, value->flat<float>().data(),
                                      value->NumElements());
     if (returned != value->NumElements()) {
       return errors::InvalidArgument("read ", value->NumElements(), " from ",

--- a/tensorflow_io/core/ops/audio_ops.cc
+++ b/tensorflow_io/core/ops/audio_ops.cc
@@ -96,7 +96,6 @@ REGISTER_OP("IO>AudioEncodeWAV")
       return Status::OK();
     });
 
-
 REGISTER_OP("IO>AudioDecodeFlac")
     .Input("input: string")
     .Input("shape: int64")
@@ -130,8 +129,7 @@ REGISTER_OP("IO>AudioEncodeFlac")
 REGISTER_OP("IO>AudioDecodeOgg")
     .Input("input: string")
     .Input("shape: int64")
-    .Output("value: dtype")
-    .Attr("dtype: {int16, int32}")
+    .Output("value: float32")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       shape_inference::ShapeHandle shape;
       TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(1, &shape));
@@ -148,10 +146,9 @@ REGISTER_OP("IO>AudioDecodeOgg")
     });
 
 REGISTER_OP("IO>AudioEncodeOgg")
-    .Input("input: dtype")
+    .Input("input: float32")
     .Input("rate: int64")
     .Output("value: string")
-    .Attr("dtype: {int16}")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       c->set_output(0, c->Scalar());
       return Status::OK();

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -96,7 +96,7 @@ def encode_flac(input, rate, name=None): # pylint: disable=redefined-builtin
   """
   return core_ops.io_audio_encode_flac(input, rate, name=name)
 
-def decode_ogg(input, shape=None, dtype=None, name=None): # pylint: disable=redefined-builtin
+def decode_ogg(input, shape=None, name=None): # pylint: disable=redefined-builtin
   """Decode OGG audio from input string.
 
   Args:
@@ -106,13 +106,11 @@ def decode_ogg(input, shape=None, dtype=None, name=None): # pylint: disable=rede
     name: A name for the operation (optional).
 
   Returns:
-    output: Decoded audio.
+    output: Decoded audio as tf.float32.
   """
   if shape is None:
     shape = tf.constant([-1, -1], tf.int64)
-  assert (dtype is not None), "dtype (tf.int16) must be provided"
-  return core_ops.io_audio_decode_ogg(
-      input, shape=shape, dtype=dtype, name=name)
+  return core_ops.io_audio_decode_ogg(input, shape=shape, name=name)
 
 def encode_ogg(input, rate, name=None): # pylint: disable=redefined-builtin
   """Encode Ogg audio into string.

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -398,11 +398,19 @@ def fixture_audio_mp3():
       "test_audio", "l1-fl6.raw")
   raw = np.fromfile(raw_path, np.int16)
   raw = raw.reshape([-1, 2])
-  value = tf.cast(raw, tf.int16)
+  value = tf.cast(raw, tf.float32) / 32768.0
 
   args = path
-  func = lambda args: tfio.IODataset.graph(tf.int16).from_audio(args)
-  expected = [v for _, v in enumerate(value)]
+  def func(args):
+    delta = tf.constant(0.00005, tf.float32)
+    v = tfio.IODataset.graph(tf.float32).from_audio(args)
+    e = tf.data.Dataset.from_tensor_slices([value])
+    e = e.unbatch()
+    dataset = tf.data.Dataset.zip((v, e))
+    dataset = dataset.map(lambda v, e: (v - e))
+    dataset = dataset.map(lambda v: tf.math.logical_and(tf.math.less(v, delta), tf.math.greater(v, -delta)))
+    return dataset
+  expected = [tf.ones_like(v, tf.bool) for _, v in enumerate(value)]
 
   return args, func, expected
 

--- a/tests/test_io_tensor_eager.py
+++ b/tests/test_io_tensor_eager.py
@@ -180,13 +180,14 @@ def fixture_audio_mp3():
       "test_audio", "l1-fl6.raw")
   raw = np.fromfile(raw_path, np.int16)
   raw = raw.reshape([-1, 2])
-  value = tf.cast(raw, tf.int16)
+  value = tf.cast(raw, tf.float32) / 32768.0
 
   args = path
-  func = lambda args: tfio.IOTensor.graph(tf.int16).from_audio(args)
+  func = lambda args: tfio.IOTensor.graph(tf.float32).from_audio(args)
   expected = value
+  equal = lambda a, b: np.allclose(a, b, atol=0.00005)
 
-  return args, func, expected, np.array_equal
+  return args, func, expected, equal
 
 @pytest.fixture(name="audio_rate_mp3", scope="module")
 def fixture_audio_rate_mp3():

--- a/tests/test_io_tensor_eager.py
+++ b/tests/test_io_tensor_eager.py
@@ -55,7 +55,7 @@ def fixture_audio_wav():
   func = lambda e: tfio.IOTensor.graph(tf.int16).from_audio(e)
   expected = value
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_rate_wav", scope="module")
 def fixture_audio_rate_wav():
@@ -68,7 +68,7 @@ def fixture_audio_rate_wav():
   func = lambda e: tfio.IOTensor.graph(tf.int16).from_audio(e).rate
   expected = tf.constant(44100)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_wav_24", scope="module")
 def fixture_audio_wav_24():
@@ -87,7 +87,7 @@ def fixture_audio_wav_24():
   func = lambda args: tfio.IOTensor.graph(tf.int32).from_audio(args)
   expected = value
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_rate_wav_24", scope="module")
 def fixture_audio_rate_wav_24():
@@ -100,7 +100,7 @@ def fixture_audio_rate_wav_24():
   func = lambda args: tfio.IOTensor.graph(tf.int32).from_audio(args).rate
   expected = tf.constant(44100)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_ogg", scope="module")
 def fixture_audio_ogg():
@@ -113,13 +113,14 @@ def fixture_audio_ogg():
       "test_audio", "ZASFX_ADSR_no_sustain.wav")
   audio = tf.audio.decode_wav(tf.io.read_file(path))
   value = audio.audio * (1 << 15)
-  value = tf.cast(value, tf.int16)
+  value = tf.cast(value, tf.float32) / 32768.0
 
   args = ogg_path
-  func = lambda args: tfio.IOTensor.graph(tf.int16).from_audio(args)
+  func = lambda args: tfio.IOTensor.graph(tf.float32).from_audio(args)
   expected = value
+  equal = lambda a, b: np.allclose(a, b, atol=0.00002)
 
-  return args, func, expected
+  return args, func, expected, equal
 
 @pytest.fixture(name="audio_rate_ogg", scope="module")
 def fixture_audio_rate_ogg():
@@ -132,7 +133,7 @@ def fixture_audio_rate_ogg():
   func = lambda args: tfio.IOTensor.graph(tf.int16).from_audio(args).rate
   expected = tf.constant(44100)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_flac", scope="module")
 def fixture_audio_flac():
@@ -151,7 +152,7 @@ def fixture_audio_flac():
   func = lambda args: tfio.IOTensor.graph(tf.int16).from_audio(args)
   expected = value
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_rate_flac", scope="module")
 def fixture_audio_rate_flac():
@@ -164,7 +165,7 @@ def fixture_audio_rate_flac():
   func = lambda args: tfio.IOTensor.graph(tf.int16).from_audio(args).rate
   expected = tf.constant(44100)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_mp3", scope="module")
 def fixture_audio_mp3():
@@ -185,7 +186,7 @@ def fixture_audio_mp3():
   func = lambda args: tfio.IOTensor.graph(tf.int16).from_audio(args)
   expected = value
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="audio_rate_mp3", scope="module")
 def fixture_audio_rate_mp3():
@@ -198,7 +199,7 @@ def fixture_audio_rate_mp3():
   func = lambda args: tfio.IOTensor.graph(tf.int16).from_audio(args).rate
   expected = tf.constant(44100)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="kafka")
 def fixture_kafka():
@@ -210,7 +211,7 @@ def fixture_kafka():
     return v
   expected = [("D" + str(i)).encode() for i in range(10)]
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="hdf5", scope="module")
 def fixture_hdf5(request):
@@ -233,7 +234,7 @@ def fixture_hdf5(request):
     shutil.rmtree(tmp_path)
   request.addfinalizer(fin)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="hdf5_graph", scope="module")
 def fixture_hdf5_graph(request):
@@ -257,7 +258,7 @@ def fixture_hdf5_graph(request):
     shutil.rmtree(tmp_path)
   request.addfinalizer(fin)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="hdf5_scalar", scope="module")
 def fixture_hdf5_scalar(request):
@@ -307,7 +308,7 @@ def fixture_hdf5_scalar(request):
     shutil.rmtree(tmp_path)
   request.addfinalizer(fin)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="hdf5_multiple_dimension", scope="module")
 def fixture_hdf5_multiple_dimension(request):
@@ -330,7 +331,7 @@ def fixture_hdf5_multiple_dimension(request):
     shutil.rmtree(tmp_path)
   request.addfinalizer(fin)
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="arrow", scope="module")
 def fixture_arrow():
@@ -347,7 +348,7 @@ def fixture_arrow():
   func = lambda t: tfio.IOTensor.from_arrow(t)(column)
   expected = table[column].to_pylist()
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 @pytest.fixture(name="arrow_graph", scope="module")
 def fixture_arrow_graph():
@@ -366,7 +367,7 @@ def fixture_arrow_graph():
   func = lambda _: tfio.IOTensor.from_arrow(table, spec=spec)(column)
   expected = table.column(column).to_pylist()
 
-  return args, func, expected
+  return args, func, expected, np.array_equal
 
 # scalar is a special IOTensor that is alias to Tensor
 @pytest.mark.parametrize(
@@ -380,14 +381,14 @@ def fixture_arrow_graph():
 )
 def test_io_tensor_scalar(fixture_lookup, io_tensor_fixture):
   """test_io_tensor_scalar"""
-  args, func, expected = fixture_lookup(io_tensor_fixture)
+  args, func, expected, equal = fixture_lookup(io_tensor_fixture)
 
   values = func(args)
 
   # Test to_tensor
   entries = [value.to_tensor() for value in values]
   assert len(entries) == len(expected)
-  assert np.all([v == e for v, e in zip(entries, expected)])
+  assert np.all([equal(v, e) for v, e in zip(entries, expected)])
 
 # slice (__getitem__) is the most basic operation for IOTensor
 @pytest.mark.parametrize(
@@ -415,19 +416,19 @@ def test_io_tensor_scalar(fixture_lookup, io_tensor_fixture):
 )
 def test_io_tensor_slice(fixture_lookup, io_tensor_fixture):
   """test_io_tensor_slice"""
-  args, func, expected = fixture_lookup(io_tensor_fixture)
+  args, func, expected, equal = fixture_lookup(io_tensor_fixture)
 
   io_tensor = func(args)
 
   # Test to_tensor
   entries = io_tensor.to_tensor()
   assert len(entries) == len(expected)
-  assert np.array_equal(entries, expected)
+  assert equal(entries, expected)
 
   # Test __getitem__, use 7 to partition
   indices = list(range(0, len(expected), 7))
   for start, stop in list(zip(indices, indices[1:] + [len(expected)])):
-    assert np.array_equal(io_tensor[start:stop], expected[start:stop])
+    assert equal(io_tensor[start:stop], expected[start:stop])
 
 # full slicing/index across multiple dimensions
 @pytest.mark.parametrize(
@@ -441,7 +442,7 @@ def test_io_tensor_slice(fixture_lookup, io_tensor_fixture):
 )
 def test_io_tensor_slice_multiple_dimension(fixture_lookup, io_tensor_fixture):
   """test_io_tensor_slice_multiple_dimension"""
-  args, func, expected = fixture_lookup(io_tensor_fixture)
+  args, func, expected, equal = fixture_lookup(io_tensor_fixture)
 
   io_tensor = func(args)
 
@@ -451,7 +452,7 @@ def test_io_tensor_slice_multiple_dimension(fixture_lookup, io_tensor_fixture):
     indices_1 = list(range(0, len(expected[0]), 11))
     for start_1, stop_1 in list(
         zip(indices_1, indices_1[1:] + [len(expected[0])])):
-      assert np.array_equal(
+      assert equal(
           io_tensor[start_0:stop_0, start_1:stop_1],
           expected[start_0:stop_0, start_1:stop_1])
 
@@ -498,7 +499,7 @@ def test_io_tensor_slice_multiple_dimension(fixture_lookup, io_tensor_fixture):
 def test_io_tensor_slice_in_dataset(
     fixture_lookup, io_tensor_fixture, num_parallel_calls):
   """test_io_tensor_slice_in_dataset"""
-  args, func, expected = fixture_lookup(io_tensor_fixture)
+  args, func, expected, equal = fixture_lookup(io_tensor_fixture)
 
   # Test to_tensor within dataset
 
@@ -515,7 +516,7 @@ def test_io_tensor_slice_in_dataset(
   item = 0
   for entries in dataset:
     assert len(entries) == len(expected)
-    assert np.array_equal(entries, expected)
+    assert equal(entries, expected)
     item += 1
   assert item == 2
 
@@ -532,7 +533,7 @@ def test_io_tensor_slice_in_dataset(
   item = 0
   for entries in dataset:
     assert len(entries) == len(expected[:100])
-    assert np.array_equal(entries, expected[:100])
+    assert equal(entries, expected[:100])
     item += 1
   assert item == 2
 
@@ -556,11 +557,11 @@ def test_io_tensor_slice_in_dataset(
 )
 def test_io_tensor_meta(fixture_lookup, io_tensor_fixture):
   """test_io_tensor_slice"""
-  args, func, expected = fixture_lookup(io_tensor_fixture)
+  args, func, expected, equal = fixture_lookup(io_tensor_fixture)
 
   # Test meta data attached to IOTensor
   meta = func(args)
-  assert meta == expected
+  assert equal(meta, expected)
 
 # meta inside dataset is also supported for GraphIOTensor
 @pytest.mark.parametrize(
@@ -582,7 +583,7 @@ def test_io_tensor_meta(fixture_lookup, io_tensor_fixture):
 )
 def test_io_tensor_meta_in_dataset(fixture_lookup, io_tensor_fixture):
   """test_io_tensor_slice"""
-  args, func, expected = fixture_lookup(io_tensor_fixture)
+  args, func, expected, equal = fixture_lookup(io_tensor_fixture)
 
   # Note: @tf.function is actually not needed, as tf.data.Dataset
   # will automatically wrap the `func` into a graph anyway.
@@ -596,7 +597,7 @@ def test_io_tensor_meta_in_dataset(fixture_lookup, io_tensor_fixture):
 
   item = 0
   for meta in dataset:
-    assert meta == expected
+    assert equal(meta, expected)
     item += 1
   assert item == 2
 
@@ -627,7 +628,7 @@ def test_io_tensor_meta_in_dataset(fixture_lookup, io_tensor_fixture):
 )
 def test_io_tensor_benchmark(benchmark, fixture_lookup, io_tensor_fixture):
   """test_io_tensor_benchmark"""
-  args, func, expected = fixture_lookup(io_tensor_fixture)
+  args, func, expected, equal = fixture_lookup(io_tensor_fixture)
 
   def f(v):
     io_tensor = func(v)
@@ -635,4 +636,4 @@ def test_io_tensor_benchmark(benchmark, fixture_lookup, io_tensor_fixture):
 
   entries = benchmark(f, args)
 
-  assert np.array_equal(entries, expected)
+  assert equal(entries, expected)


### PR DESCRIPTION
Change to float32 for AudioIOTensor and AudioIODataset in case of MP3 and Ogg, and make related changes to `decode_ogg`.

This is related to discussion to https://github.com/tensorflow/io/issues/839#issuecomment-600051081

Note `decode_mp3` is not in place yet. I will defer to #815 for now. May pick up if needed.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>