### PR TITLE
Enable python 3.8 build on windows and linux

### DIFF
--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -22,6 +22,7 @@ fi
 
 if [[ "$PYTHON_VERSION" == "python3.8" ]]; then
   echo "TODO: Python 3.8 test is not supported yet as dependency might not be available"
+  exit 0
 fi
 
 if [[ $(uname) == "Linux" ]]; then

--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -19,6 +19,11 @@ if [[ "$#" -gt 0 ]]; then
   PYTHON_VERSION="${1}"
   shift
 fi
+
+if [[ "$PYTHON_VERSION" == "python3.8" ]]; then
+  echo "TODO: Python 3.8 test is not supported yet as dependency might not be available"
+fi
+
 if [[ $(uname) == "Linux" ]]; then
   apt-get -y -qq update
   if [[ "${PYTHON_VERSION}" == "python3.7" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,12 +189,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04]
-        python: ['3.5', '3.6', '3.7']
+        python: ['3.5', '3.6', '3.7', '3.8']
         exclude:
           - os: ubuntu-16.04
             python: '3.6'
           - os: ubuntu-16.04
             python: '3.7'
+          - os: ubuntu-16.04
+            python: '3.8'
           - os: ubuntu-18.04
             python: '3.5'
     steps:
@@ -274,7 +276,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7']
+        python: ['3.5', '3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1
@@ -358,6 +360,10 @@ jobs:
           path: Linux-3.7-wheel
       - uses: actions/download-artifact@v1
         with:
+          name: Linux-3.8-wheel
+          path: Linux-3.8-wheel
+      - uses: actions/download-artifact@v1
+        with:
           name: Windows-3.5-wheel
           path: Windows-3.5-wheel
       - uses: actions/download-artifact@v1
@@ -368,6 +374,10 @@ jobs:
         with:
           name: Windows-3.7-wheel
           path: Windows-3.7-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.8-wheel
+          path: Windows-3.8-wheel
       - run: |
           set -e -x
           mkdir -p wheelhouse
@@ -377,9 +387,11 @@ jobs:
           cp Linux-3.5-wheel/*.whl wheelhouse/
           cp Linux-3.6-wheel/*.whl wheelhouse/
           cp Linux-3.7-wheel/*.whl wheelhouse/
+          cp Linux-3.8-wheel/*.whl wheelhouse/
           cp Windows-3.5-wheel/*.whl wheelhouse/
           cp Windows-3.6-wheel/*.whl wheelhouse/
           cp Windows-3.7-wheel/*.whl wheelhouse/
+          cp Windows-3.8-wheel/*.whl wheelhouse/
           ls -la wheelhouse/
           sha256sum wheelhouse/*.whl
       - uses: actions/upload-artifact@v1
@@ -452,12 +464,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04]
-        python: ['3.5', '3.6', '3.7']
+        python: ['3.5', '3.6', '3.7', '3.8']
         exclude:
           - os: ubuntu-16.04
             python: '3.6'
           - os: ubuntu-16.04
             python: '3.7'
+          - os: ubuntu-16.04
+            python: '3.8'
           - os: ubuntu-18.04
             python: '3.5'
     steps:
@@ -557,6 +571,10 @@ jobs:
           path: Linux-3.7-nightly
       - uses: actions/download-artifact@v1
         with:
+          name: Linux-3.8-nightly
+          path: Linux-3.8-nightly
+      - uses: actions/download-artifact@v1
+        with:
           name: Windows-3.5-nightly
           path: Windows-3.5-nightly
       - uses: actions/download-artifact@v1
@@ -567,6 +585,10 @@ jobs:
         with:
           name: Windows-3.7-nightly
           path: Windows-3.7-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.8-nightly
+          path: Windows-3.8-nightly
       - run: |
           set -e -x
           mkdir -p dist
@@ -576,9 +598,11 @@ jobs:
           cp Linux-3.5-nightly/*.whl dist/
           cp Linux-3.6-nightly/*.whl dist/
           cp Linux-3.7-nightly/*.whl dist/
+          cp Linux-3.8-nightly/*.whl dist/
           cp Windows-3.5-nightly/*.whl dist/
           cp Windows-3.6-nightly/*.whl dist/
           cp Windows-3.7-nightly/*.whl dist/
+          cp Windows-3.8-nightly/*.whl dist/
           ls -la dist/
           sha256sum dist/*.whl
       - uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
tensorflow 2.2.0rc1 adds python3.8 support for Windows and linux. This PR 
- enables python 3.8 build on windows and linux for tensorflow-io
- test for python 3.8 is not possible as tests dependency may not have python3.8 yet
- macOS does not have python3.8 as tensorflow has not released macOS 3.8 yet.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>