### PR TITLE
Move --copt="-mmacosx-version-min=10.13" and --linkopt="-mmacosx-verson-min=10.13" to bazelrc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,6 @@ jobs:
           python3 tools/build/configure.py
           bazel build \
             ${BAZEL_OPTIMIZATION} \
-            --copt -mmacosx-version-min=10.13 \
-            --linkopt -mmacosx-version-min=10.13 \
             --noshow_progress \
             --noshow_loading_progress \
             --verbose_failures \

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -101,9 +101,12 @@ def write_config():
             bazel_rc.write(
                 'build --action_env TF_SHARED_LIBRARY_NAME="{}"\n'.format(library_name)
             )
-            # Needed for GRPC build
             if sys.platform == "darwin":
+                # Needed for GRPC build
+                # Pin to 10.13 to avoid discrepancy with release
                 bazel_rc.write('build --copt="-DGRPC_BAZEL_BUILD"\n')
+                bazel_rc.write('build --copt="-mmacosx-version-min=10.13"\n')
+                bazel_rc.write('build --linkopt="-mmacosx-version-min=10.13"\n')
             for argv in sys.argv[1:]:
                 if argv == "--cuda":
                     bazel_rc.write('build --action_env TF_NEED_CUDA="1"\n')


### PR DESCRIPTION
This PR is related to #855.

When we release python wheels for macOS, we stay with OSX 10.13. However,
the options:
```
--copt="-mmacosx-version-min=10.13"
--linkopt="-mmacosx-version-min=10.13"
```

This causes some discrepencies between local debug and release version.

This PR adds those two options in bazelrc so that it will be run even for local build.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>