### PR TITLE
Fix hang when use when use tf.gfile.Copy to copy a small file (#833)

### DIFF
--- a/tensorflow_io/core/oss/kernels/ossfs/oss_file_system.cc
+++ b/tensorflow_io/core/oss/kernels/ossfs/oss_file_system.cc
@@ -130,7 +130,9 @@ class OSSRandomAccessFile : public RandomAccessFile {
 
   Status Read(uint64 offset, size_t n, StringPiece* result,
               char* scratch) const override {
-    if (offset > total_file_length_) {
+    // offset is 0 based, so last offset should be
+    // just before total_file_length_
+    if (offset >= total_file_length_) {
       return errors::OutOfRange("EOF reached, ", offset,
                                 " is read out of file length ",
                                 total_file_length_);

--- a/tests/test_ossfs.py
+++ b/tests/test_ossfs.py
@@ -82,6 +82,10 @@ class OSSFSTest(test.TestCase):
         self.assertFalse(gfile.Exists(f))
         self.assertTrue(gfile.Exists(f2))
 
+        f3 = get_oss_path("test_file_3")
+        gfile.Copy(f2, f3, overwrite=True)
+        self.assertTrue(gfile.Exists(f3))
+
     def test_dir_operations(self):
         """ Test directory operations"""
 


### PR DESCRIPTION
The root cause of this issue is the incorrect EOF condition check.
Since offset is 0 based, so last offset should be just before total_file_length_.