### PR TITLE
Fix issue: fail to use tf.gfile.Rename to rename oss directory (#834)

### DIFF
--- a/tensorflow_io/core/oss/kernels/ossfs/oss_file_system.cc
+++ b/tensorflow_io/core/oss/kernels/ossfs/oss_file_system.cc
@@ -1035,12 +1035,18 @@ Status OSSFileSystem::RenameFile(const std::string& src,
 
   Status status = IsDirectory(src);
   if (status.ok()) {
+    if (!str_util::EndsWith(sobject, "/")){
+      sobject += "/";
+    }
+    if (!str_util::EndsWith(dobject, "/")){
+      dobject += "/";
+    }
     std::vector<std::string> childPaths;
     _ListObjects(pool, oss_options, sbucket, sobject, &childPaths, true, false,
                  false, 1000);
     for (const auto& child : childPaths) {
-      std::string tmp_sobject = sobject + "/" + child;
-      std::string tmp_dobject = dobject + "/" + child;
+      std::string tmp_sobject = sobject + child;
+      std::string tmp_dobject = dobject + child;
 
       aos_str_set(&source_object, tmp_sobject.c_str());
       aos_str_set(&dest_object, tmp_dobject.c_str());
@@ -1058,14 +1064,6 @@ Status OSSFileSystem::RenameFile(const std::string& src,
                                 " failed, errMsg: ", msg);
       }
       _DeleteObjectInternal(oss_options, sbucket, tmp_sobject);
-    }
-
-    if (!str_util::EndsWith(sobject, "/")) {
-      sobject += "/";
-    }
-
-    if (!str_util::EndsWith(dobject, "/")) {
-      dobject += "/";
     }
   }
 

--- a/tests/test_ossfs.py
+++ b/tests/test_ossfs.py
@@ -140,6 +140,23 @@ class OSSFSTest(test.TestCase):
         self.assertEqual(content, content_s)
         self.assertIn("d2", content)
 
+        # Test Rename non-empty directories
+        not_empty_dir = get_oss_path("not_empty_dir/")
+        rename_not_empty_dir = get_oss_path("rename_not_empty_dir/")
+        gfile.MakeDirs(not_empty_dir)
+        not_empty_file = get_oss_path("not_empty_dir/not_empty_file")
+        rename_not_empty_file = get_oss_path("rename_not_empty_dir/not_empty_file")
+        with gfile.Open(not_empty_file, mode="w") as fh:
+            content = "file content"
+            fh.write(content)
+        self.assertTrue(gfile.Exists(not_empty_dir))
+        self.assertTrue(gfile.Exists(not_empty_file))
+        gfile.Rename(not_empty_dir, rename_not_empty_dir, overwrite=True)
+        self.assertFalse(gfile.Exists(not_empty_dir))
+        self.assertFalse(gfile.Exists(not_empty_file))
+        self.assertTrue(gfile.Exists(rename_not_empty_dir))
+        self.assertTrue(gfile.Exists(rename_not_empty_file))
+
 
 if __name__ == "__main__":
     test.main()


### PR DESCRIPTION
The problem:
   When there's trailling '/' in directory path, the Rename function incorrectly put two '/'s in the path, which in oss is considered as a differecnt file (thus a 404 NotFound error is reported)

The fix is to correctly handle the url join