### PR TITLE
Fix hdf5 issue when resource tensor might be reused in graph incorrectly

### DIFF
--- a/tensorflow_io/core/python/ops/hdf5_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/hdf5_dataset_ops.py
@@ -25,13 +25,13 @@ class HDF5IODataset(tf.data.Dataset):
 
     def __init__(self, filename, dataset, spec=None, internal=True):
         """HDF5IODataset."""
-        with tf.name_scope("HDF5IODataset") as scope:
+        with tf.name_scope("HDF5IODataset"):
             assert internal
 
             # TODO: unique shared_name might be removed if HDF5 is thead-safe?
             resource, _ = core_ops.io_hdf5_readable_init(
                 filename,
-                container=scope,
+                container="HDF5IODataset",
                 shared_name="{}/{}".format(filename, uuid.uuid4().hex),
             )
             if tf.executing_eagerly():

--- a/tensorflow_io/core/python/ops/hdf5_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/hdf5_dataset_ops.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """HDF5Dataset"""
 
+import uuid
+
 import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops
 
@@ -23,11 +25,15 @@ class HDF5IODataset(tf.data.Dataset):
 
     def __init__(self, filename, dataset, spec=None, internal=True):
         """HDF5IODataset."""
-        with tf.name_scope("HDF5IODataset"):
+        with tf.name_scope("HDF5IODataset") as scope:
             assert internal
 
             # TODO: unique shared_name might be removed if HDF5 is thead-safe?
-            resource, _ = core_ops.io_hdf5_readable_init(filename)
+            resource, _ = core_ops.io_hdf5_readable_init(
+                filename,
+                container=scope,
+                shared_name="{}/{}".format(filename, uuid.uuid4().hex),
+            )
             if tf.executing_eagerly():
                 shape, dtype = core_ops.io_hdf5_readable_spec(resource, dataset)
                 dtype = tf.as_dtype(dtype.numpy())

--- a/tests/test_hdf5_eager.py
+++ b/tests/test_hdf5_eager.py
@@ -1,0 +1,65 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for HDF5 file"""
+
+import os
+import glob
+import shutil
+import tempfile
+import numpy as np
+import h5py
+
+import tensorflow as tf
+import tensorflow_io as tfio
+
+
+def test_hdf5():
+    """test_hdf5: GitHub issue 841"""
+
+    def create_datasets(runpath, cnt=10):
+        os.makedirs(runpath, exist_ok=True)
+        for i in range(cnt):
+            f = h5py.File(f"{runpath}/file_{i}.h5", "w")
+            total_samples = np.random.randint(50000, 100000)
+            f.create_dataset("features", data=np.random.random((total_samples, 60)))
+            f.create_dataset("targets", data=np.random.random((total_samples, 3)))
+            f.close()
+
+    runpath = tempfile.mkdtemp()
+    create_datasets(runpath)
+
+    for i in range(2):
+        cnt = 0
+        for p in glob.glob(f"{runpath}/*.h5"):
+            try:
+                features = tfio.IODataset.from_hdf5(p, "/features")
+                targets = tfio.IODataset.from_hdf5(p, "/targets")
+                dataset = tf.data.Dataset.zip((features, targets))
+
+                for t in dataset:
+                    cnt += t[0].shape[0]
+
+            except Exception as e:
+                print(f"Failed going through {p}")
+                raise e
+            print(f"Success going through {p}")
+
+    print(f"Iterated {cnt} items")
+
+    shutil.rmtree(runpath)
+
+
+if __name__ == "__main__":
+    test.main()

--- a/tests/test_hdf5_eager.py
+++ b/tests/test_hdf5_eager.py
@@ -31,7 +31,7 @@ def test_hdf5():
     def create_datasets(runpath, cnt=10):
         os.makedirs(runpath, exist_ok=True)
         for i in range(cnt):
-            f = h5py.File(f"{runpath}/file_{i}.h5", "w")
+            f = h5py.File("{}/file_{}.h5".format(runpath, i), "w")
             total_samples = np.random.randint(50000, 100000)
             f.create_dataset("features", data=np.random.random((total_samples, 60)))
             f.create_dataset("targets", data=np.random.random((total_samples, 3)))

--- a/tests/test_hdf5_eager.py
+++ b/tests/test_hdf5_eager.py
@@ -52,11 +52,11 @@ def test_hdf5():
                     cnt += t[0].shape[0]
 
             except Exception as e:
-                print(f"Failed going through {p}")
+                print("Failed going through {}".format(p))
                 raise e
-            print(f"Success going through {p}")
+            print("Success going through {}".format(p))
 
-    print(f"Iterated {cnt} items")
+    print("Iterated {} items".format(cnt))
 
     shutil.rmtree(runpath)
 

--- a/tests/test_hdf5_eager.py
+++ b/tests/test_hdf5_eager.py
@@ -42,7 +42,7 @@ def test_hdf5():
 
     for i in range(2):
         cnt = 0
-        for p in glob.glob(f"{runpath}/*.h5"):
+        for p in glob.glob("{}/*.h5".format(runpath)):
             try:
                 features = tfio.IODataset.from_hdf5(p, "/features")
                 targets = tfio.IODataset.from_hdf5(p, "/targets")


### PR DESCRIPTION
This PR fixes #841

The reason for the issue was that the resource tensor might be reused in graph incorrectly
in tensorflow code base (likely some change in behavior on how the resource should be intepeareted).

This PR assign a unique container and name to make sure resource created for hdf5 is never re-used.

(The same issue may happen in other ops as well?)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>