### PR TITLE
Multiple Bazel enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -502,7 +502,7 @@ jobs:
   macos-nightly:
     name: Nightly ${{ matrix.python }} macOS
     if: github.event_name == 'push'
-    needs: [lint, build-number, macos-bazel]
+    needs: [build-number, release]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -545,7 +545,7 @@ jobs:
   linux-nightly:
     name: Nightly ${{ matrix.python }} Linux
     if: github.event_name == 'push'
-    needs: [lint, build-number, linux-bazel]
+    needs: [build-number, release]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -593,7 +593,7 @@ jobs:
   windows-nightly:
     name: Nightly ${{ matrix.python }} Windows
     if: github.event_name == 'push'
-    needs: [lint, build-number, windows-bazel]
+    needs: [build-number, release]
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Run Lint Script
         run: |
           set -x -e
@@ -31,7 +31,7 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: |
           set -x -e
           echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
@@ -49,7 +49,7 @@ jobs:
     name: Ubuntu 18.04
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: |
           set -x -e
           bash -x -e .github/workflows/build.space.sh
@@ -62,7 +62,7 @@ jobs:
     name: Ubuntu 20.04
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: |
           set -x -e
           bash -x -e .github/workflows/build.space.sh
@@ -75,7 +75,7 @@ jobs:
     name: CentOS 8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: |
           set -x -e
           bash -x -e .github/workflows/build.space.sh
@@ -88,7 +88,7 @@ jobs:
     name: CentOS 7
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: |
           set -x -e
           bash -x -e .github/workflows/build.space.sh
@@ -101,7 +101,7 @@ jobs:
     name: Bazel macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Bazel on macOS
         run: |
           set -x -e
@@ -132,7 +132,7 @@ jobs:
       matrix:
         python: ['3.5', '3.6', '3.7', '3.8']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-bazel-bin
@@ -169,7 +169,7 @@ jobs:
       matrix:
         python: ['3.5', '3.6', '3.7']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-wheel
@@ -203,7 +203,7 @@ jobs:
     name: Bazel Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Bazel on Linux
         run: |
           set -x -e
@@ -239,7 +239,7 @@ jobs:
           - os: ubuntu-18.04
             python: '3.5'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-bazel-bin
@@ -281,7 +281,7 @@ jobs:
           - os: ubuntu-18.04
             python: '3.5'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-wheel
@@ -308,7 +308,7 @@ jobs:
     name: Bazel Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
           python-version: 3.7.6
@@ -342,7 +342,7 @@ jobs:
       matrix:
         python: ['3.5', '3.6', '3.7', '3.8']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-bazel-bin
@@ -371,7 +371,7 @@ jobs:
       matrix:
         python: ['3.5', '3.6', '3.7']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-wheel
@@ -513,7 +513,7 @@ jobs:
           name: BUILD_NUMBER
       - uses: einaregilsson/build-number@v2
       - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-bazel-bin
@@ -566,7 +566,7 @@ jobs:
           name: BUILD_NUMBER
       - uses: einaregilsson/build-number@v2
       - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-bazel-bin
@@ -604,7 +604,7 @@ jobs:
           name: BUILD_NUMBER
       - uses: einaregilsson/build-number@v2
       - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-bazel-bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.5', '3.6', '3.7']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1
@@ -270,7 +270,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04]
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.5', '3.6', '3.7']
         exclude:
           - os: ubuntu-16.04
             python: '3.6'
@@ -369,7 +369,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.5', '3.6', '3.7']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ with https://github.com/tensorflow/tensorflow/issues/33183#issuecomment-55470121
 
 ```sh
 # Use following command to check if Xcode is correctly installed:
-/usr/bin/xcodebuild -version 
+xcodebuild -version
 
 # macOS's default python3 is 3.7.3
 python3 --version
@@ -176,10 +176,8 @@ bazel build -s --verbose_failures //tensorflow_io/...
 sudo python3 -m pip install pytest
 TFIO_DATAPATH=bazel-bin python3 -m pytest -s -v tests/test_serialization_eager.py
 ```
-If Xcode is installed, but /usr/bin/xcodebuild -version is not showing so, you might need to enable Xcode command line with following command:
-xcode-select -s /Applications/Xcode.app/Contents/Developer 
 
-Restart terminal might be required to make the above change effective.
+If Xcode is installed, but `xcodebuild -version` is not showing so, you might need to enable Xcode command line with the command `xcode-select -s /Applications/Xcode.app/Contents/Developer`. Restart terminal might be required to make the above change effective.
 
 Note from the above the generated shared libraries (.so) are located in bazel-bin directory.
 When running pytest, `TFIO_DATAPATH=bazel-bin` has to be passed for shared libraries to

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -776,10 +776,11 @@ http_archive(
 
 http_archive(
     name = "com_googlesource_code_cctz",
-    strip_prefix = "cctz-master",
+    sha256 = "4ee3497b413229083998dd4295fa070b47a7253d88a15306733a06bae15ce945",
+    strip_prefix = "cctz-44541cf2b85ced2a6e5ad4276183a9812d1a54ab",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/cctz/archive/master.zip",
-        "https://github.com/google/cctz/archive/master.zip",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/cctz/archive/44541cf2b85ced2a6e5ad4276183a9812d1a54ab.zip",
+        "https://github.com/google/cctz/archive/44541cf2b85ced2a6e5ad4276183a9812d1a54ab.zip",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -818,15 +818,11 @@ http_archive(
 
 http_archive(
     name = "com_grail_bazel_toolchain",
-    # TODO: Remove after https://github.com/grailbio/bazel-toolchain/pull/43
-    patch_cmds = [
-        "sed -i.bak 's/>= 9/== 9/g' toolchain/tools/llvm_release_name.py",
-    ],
-    sha256 = "226936ab8c28e4946b17e4349d6478cfabafbd8a2614dcf525f97e56b7902899",
-    strip_prefix = "bazel-toolchain-533bee6d2b27ba772a237542722607313aefdf01",
+    sha256 = "9e6065ded4b7453143e1586d6819729a63cd233114b72bf85ff3435367b02c90",
+    strip_prefix = "bazel-toolchain-edd07e96a2ecaa131af9234d6582875d980c0ac7",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/grailbio/bazel-toolchain/archive/533bee6d2b27ba772a237542722607313aefdf01.tar.gz",
-        "https://github.com/grailbio/bazel-toolchain/archive/533bee6d2b27ba772a237542722607313aefdf01.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/grailbio/bazel-toolchain/archive/edd07e96a2ecaa131af9234d6582875d980c0ac7.tar.gz",
+        "https://github.com/grailbio/bazel-toolchain/archive/edd07e96a2ecaa131af9234d6582875d980c0ac7.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,7 @@ http_archive(
     sha256 = "424faab60a14cb92c2a062733b6977b4cc1e875a6398887c5911b3a1a6c56c51",
     strip_prefix = "libwebp-1.1.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/webmproject/libwebp/archive/v1.1.0.tar.gz",
         "https://github.com/webmproject/libwebp/archive/v1.1.0.tar.gz",
     ],
 )
@@ -26,6 +27,7 @@ http_archive(
     sha256 = "3a60d391fd579440561bf0e7f31af2222bc610ad6ce4d9d7bd2165bca8669110",
     strip_prefix = "freetype-2.10.1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.gz",
         "https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.gz",
     ],
 )
@@ -36,6 +38,7 @@ http_archive(
     sha256 = "7a49a2617da70b318d1464625e1c5fd6d369d04aa1b23a270d3d0926d8669432",
     strip_prefix = "easyexif-19d15151c3f663813dc70cf9ff568d25ab6ff93b",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/mayanklahiri/easyexif/archive/19d15151c3f663813dc70cf9ff568d25ab6ff93b.tar.gz",
         "https://github.com/mayanklahiri/easyexif/archive/19d15151c3f663813dc70cf9ff568d25ab6ff93b.tar.gz",
     ],
 )
@@ -46,6 +49,7 @@ http_archive(
     sha256 = "978de595fcc62448dbdc8ca8def7879fbe63245dd7f57c1898270e53a0abf95b",
     strip_prefix = "stb-052dce117ed989848a950308bd99eef55525dfb1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/nothings/stb/archive/052dce117ed989848a950308bd99eef55525dfb1.tar.gz",
         "https://github.com/nothings/stb/archive/052dce117ed989848a950308bd99eef55525dfb1.tar.gz",
     ],
 )
@@ -56,6 +60,8 @@ http_archive(
     sha256 = "c66e88d5786f2ca4dbebb14e06b566fb642a1a6947ad8cc9091f9f445134143f",
     strip_prefix = "boost_1_72_0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/downloads.sourceforge.net/project/boost/boost/1.72.0/boost_1_72_0.tar.gz",
         "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz",
         "https://downloads.sourceforge.net/project/boost/boost/1.72.0/boost_1_72_0.tar.gz",
     ],
@@ -67,6 +73,7 @@ http_archive(
     sha256 = "e382ac6685544ae9539084793ac0a4ffd377ba476ea756439625552e14d212b0",
     strip_prefix = "avro-release-1.9.1/lang/c++",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/apache/avro/archive/release-1.9.1.tar.gz",
         "https://github.com/apache/avro/archive/release-1.9.1.tar.gz",
     ],
 )
@@ -77,6 +84,7 @@ http_archive(
     sha256 = "30bd2c428216e50400d493b38ca33a25efb1dd65f79dfc614ab0c957a3ac2c28",
     strip_prefix = "rapidjson-418331e99f859f00bdc8306f69eba67e8693c55e",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/miloyip/rapidjson/archive/418331e99f859f00bdc8306f69eba67e8693c55e.tar.gz",
         "https://github.com/miloyip/rapidjson/archive/418331e99f859f00bdc8306f69eba67e8693c55e.tar.gz",
     ],
 )
@@ -87,6 +95,7 @@ http_archive(
     sha256 = "44602436c52c29d4f301f55f6fd8115f945469b868348e3cddaf91ab2473ea26",
     strip_prefix = "lmdb-LMDB_0.9.24/libraries/liblmdb",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/LMDB/lmdb/archive/LMDB_0.9.24.tar.gz",
         "https://github.com/LMDB/lmdb/archive/LMDB_0.9.24.tar.gz",
     ],
 )
@@ -97,6 +106,7 @@ http_archive(
     sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
     strip_prefix = "zlib-1.2.11",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.11.tar.gz",
         "https://zlib.net/zlib-1.2.11.tar.gz",
     ],
 )
@@ -107,6 +117,7 @@ http_archive(
     sha256 = "4904c5ea7914a58f60a5e2fbc397be67e7a25c380d7d07c1c31a3eefff1c92f1",
     strip_prefix = "openexr-2.4.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/openexr/openexr/archive/v2.4.0.tar.gz",
         "https://github.com/openexr/openexr/archive/v2.4.0.tar.gz",
     ],
 )
@@ -124,6 +135,7 @@ http_archive(
     sha256 = "12c26422e89da7032efcd60d48f3d82c7c0b4c9f3f61aa30c5e3df512946c6cf",
     strip_prefix = "libgeotiff-1.5.1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.5.1.zip",
         "https://download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.5.1.zip",
     ],
 )
@@ -134,6 +146,7 @@ http_archive(
     sha256 = "0b157e1aa81df4d0dbd89368a0005916bb717f0c09143b4dbc1b20d59204e9f2",
     strip_prefix = "proj-6.2.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/download.osgeo.org/proj/proj-6.2.0.zip",
         "https://download.osgeo.org/proj/proj-6.2.0.zip",
     ],
 )
@@ -144,6 +157,7 @@ http_archive(
     sha256 = "adf051d4c10781ea5cfabbbc4a2577b6ceca68590d23b58b8260a8e24cc5f081",
     strip_prefix = "sqlite-amalgamation-3300100",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/www.sqlite.org/2019/sqlite-amalgamation-3300100.zip",
         "https://www.sqlite.org/2019/sqlite-amalgamation-3300100.zip",
     ],
 )
@@ -157,6 +171,7 @@ http_archive(
     sha256 = "597d9894061f4871a909f1c2c3f56725a69c188ea17784cc71e1e170687faf00",
     strip_prefix = "azure-storage-cpplite-0.2.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/Azure/azure-storage-cpplite/archive/v0.2.0.tar.gz",
         "https://github.com/Azure/azure-storage-cpplite/archive/v0.2.0.tar.gz",
     ],
 )
@@ -167,6 +182,7 @@ http_archive(
     sha256 = "5f9a3ee85db4ea1d3b1fa9159352aebc2af72732fc2f58c96a3f0768dba0e9aa",
     strip_prefix = "hdf5-1.10.6",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.gz",
         "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.gz",
     ],
 )
@@ -177,6 +193,7 @@ http_archive(
     sha256 = "a364f5162c7d1a455cc915e8e3cf5f4bd8b75d09bc0f53965b0c9ca1383c52c8",
     strip_prefix = "zstd-1.4.4",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/facebook/zstd/archive/v1.4.4.tar.gz",
         "https://github.com/facebook/zstd/archive/v1.4.4.tar.gz",
     ],
 )
@@ -187,6 +204,7 @@ http_archive(
     sha256 = "658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc",
     strip_prefix = "lz4-1.9.2",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/lz4/lz4/archive/v1.9.2.tar.gz",
         "https://github.com/lz4/lz4/archive/v1.9.2.tar.gz",
     ],
 )
@@ -197,6 +215,7 @@ http_archive(
     sha256 = "4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c",
     strip_prefix = "brotli-1.0.7",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/brotli/archive/v1.0.7.tar.gz",
         "https://github.com/google/brotli/archive/v1.0.7.tar.gz",
     ],
 )
@@ -207,6 +226,7 @@ http_archive(
     sha256 = "16b677f07832a612b0836178db7f374e414f94657c138e6993cbfc5dcc58651f",
     strip_prefix = "snappy-1.1.8",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/snappy/archive/1.1.8.tar.gz",
         "https://github.com/google/snappy/archive/1.1.8.tar.gz",
     ],
 )
@@ -216,6 +236,7 @@ http_archive(
     sha256 = "a63ecb93182134ba4293fd5f22d6e08ca417caafa244afaa751cbfddf6415b13",
     strip_prefix = "double-conversion-3.1.5",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/double-conversion/archive/v3.1.5.tar.gz",
         "https://github.com/google/double-conversion/archive/v3.1.5.tar.gz",
     ],
 )
@@ -226,6 +247,7 @@ http_archive(
     sha256 = "b7452d1873c6c43a580d2b4ae38cfaf8fa098ee6dc2925bae98dce0c010b1366",
     strip_prefix = "thrift-0.12.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/apache/thrift/archive/0.12.0.tar.gz",
         "https://github.com/apache/thrift/archive/0.12.0.tar.gz",
     ],
 )
@@ -236,6 +258,7 @@ http_archive(
     sha256 = "d7b3838758a365c8c47d55ab0df1006a70db951c6964440ba354f81f518b8d8d",
     strip_prefix = "arrow-apache-arrow-0.16.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/apache/arrow/archive/apache-arrow-0.16.0.tar.gz",
         "https://github.com/apache/arrow/archive/apache-arrow-0.16.0.tar.gz",
     ],
 )
@@ -251,6 +274,7 @@ http_archive(
     sha256 = "2d14551fd87262ec4917db3ae688ca2574d716faecccb1ac5136a478579cee19",
     strip_prefix = "librdkafka-1.4.0-RC2",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/edenhill/librdkafka/archive/v1.4.0-RC2.tar.gz",
         "https://github.com/edenhill/librdkafka/archive/v1.4.0-RC2.tar.gz",
     ],
 )
@@ -261,6 +285,7 @@ http_archive(
     sha256 = "a05178665f21896dbb0974106dba1ad144975414abd760b4cf8f5cc979f9beb9",
     strip_prefix = "dcmtk-3.6.5",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/dicom.offis.de/download/dcmtk/dcmtk365/dcmtk-3.6.5.tar.gz",
         "https://dicom.offis.de/download/dcmtk/dcmtk365/dcmtk-3.6.5.tar.gz",
     ],
 )
@@ -271,6 +296,7 @@ http_archive(
     sha256 = "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9",
     strip_prefix = "openjpeg-2.3.1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
         "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
     ],
 )
@@ -281,6 +307,7 @@ http_archive(
     sha256 = "5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634",
     strip_prefix = "tiff-4.1.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/download.osgeo.org/libtiff/tiff-4.1.0.tar.gz",
         "https://download.osgeo.org/libtiff/tiff-4.1.0.tar.gz",
     ],
 )
@@ -291,6 +318,7 @@ http_archive(
     sha256 = "daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4",
     strip_prefix = "libpng-1.6.37",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/download.sourceforge.net/libpng/libpng-1.6.37.tar.gz",
         "https://download.sourceforge.net/libpng/libpng-1.6.37.tar.gz",
     ],
 )
@@ -301,6 +329,7 @@ http_archive(
     sha256 = "a8563307cb09161633479aff0880368ed57396f6d532facba973cf303d699717",
     strip_prefix = "fmjpeg2koj-6de80e15a43a4d1c411109aea388007afee24263",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/DraconPern/fmjpeg2koj/archive/6de80e15a43a4d1c411109aea388007afee24263.tar.gz",
         "https://github.com/DraconPern/fmjpeg2koj/archive/6de80e15a43a4d1c411109aea388007afee24263.tar.gz",
     ],
 )
@@ -311,6 +340,7 @@ http_archive(
     sha256 = "6e6bed6f75cf54006b6bafb01b3b96df19605572131a2260fddaf0e87949ced0",
     strip_prefix = "aws-checksums-0.1.5",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/awslabs/aws-checksums/archive/v0.1.5.tar.gz",
         "https://github.com/awslabs/aws-checksums/archive/v0.1.5.tar.gz",
     ],
 )
@@ -321,6 +351,7 @@ http_archive(
     sha256 = "01c2a58553a37b3aa5914d9e0bf7bf14507ff4937bc5872a678892ca20fcae1f",
     strip_prefix = "aws-c-common-0.4.29",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/awslabs/aws-c-common/archive/v0.4.29.tar.gz",
         "https://github.com/awslabs/aws-c-common/archive/v0.4.29.tar.gz",
     ],
 )
@@ -331,6 +362,7 @@ http_archive(
     sha256 = "31d880d1c868d3f3df1e1f4b45e56ac73724a4dc3449d04d47fc0746f6f077b6",
     strip_prefix = "aws-c-event-stream-0.1.4",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/awslabs/aws-c-event-stream/archive/v0.1.4.tar.gz",
         "https://github.com/awslabs/aws-c-event-stream/archive/v0.1.4.tar.gz",
     ],
 )
@@ -341,6 +373,7 @@ http_archive(
     sha256 = "8724a2c3f00478e5f9af00d1d9bc67b7a0a557cc587a10f7097b1257008c2e68",
     strip_prefix = "aws-sdk-cpp-1.7.270",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.7.270.tar.gz",
         "https://github.com/aws/aws-sdk-cpp/archive/1.7.270.tar.gz",
     ],
 )
@@ -350,7 +383,7 @@ http_archive(
     sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
     strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
     urls = [
-        "http://mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/43ef2148c0936ebf7cb4be6b19927a9d9d145b8f.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/43ef2148c0936ebf7cb4be6b19927a9d9d145b8f.tar.gz",
         "https://github.com/abseil/abseil-cpp/archive/43ef2148c0936ebf7cb4be6b19927a9d9d145b8f.tar.gz",
     ],
 )
@@ -360,7 +393,7 @@ http_archive(
     sha256 = "1188e29000013ed6517168600fc35a010d58c5d321846d6a6dfee74e4c788b45",
     strip_prefix = "boringssl-7f634429a04abc48e2eb041c81c5235816c96514",
     urls = [
-        "https://mirror.bazel.build/github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz",
         "https://github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz",
     ],
 )
@@ -371,7 +404,7 @@ http_archive(
     sha256 = "e9c37986337743f37fd14fe8737f246e97aec94b39d1b71e8a5973f72a9fc4f5",
     strip_prefix = "curl-7.60.0",
     urls = [
-        "https://mirror.bazel.build/curl.haxx.se/download/curl-7.60.0.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.60.0.tar.gz",
         "https://curl.haxx.se/download/curl-7.60.0.tar.gz",
     ],
 )
@@ -381,7 +414,7 @@ http_archive(
     sha256 = "12a13686cab7ffaf8ea01711b8f55e1dbd3bf059b7c46a25fefa1250bdd9dd23",
     strip_prefix = "flatbuffers-b99332efd732e6faf60bb7ce1ce5902ed65d5ba3",
     urls = [
-        "https://mirror.bazel.build/github.com/google/flatbuffers/archive/b99332efd732e6faf60bb7ce1ce5902ed65d5ba3.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/b99332efd732e6faf60bb7ce1ce5902ed65d5ba3.tar.gz",
         "https://github.com/google/flatbuffers/archive/b99332efd732e6faf60bb7ce1ce5902ed65d5ba3.tar.gz",
     ],
 )
@@ -392,6 +425,7 @@ http_archive(
     sha256 = "b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145",
     strip_prefix = "xz-5.2.4",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/tukaani.org/xz/xz-5.2.4.tar.gz",
         "https://tukaani.org/xz/xz-5.2.4.tar.gz",
     ],
 )
@@ -402,8 +436,8 @@ http_archive(
     sha256 = "2483d5a42bc39575fc215c6994554f5169db777262d606ebe9cd8d5f37557f72",
     strip_prefix = "util-linux-2.32.1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/karelzak/util-linux/archive/v2.32.1.tar.gz",
         "https://github.com/karelzak/util-linux/archive/v2.32.1.tar.gz",
-        "https://mirror.bazel.build/github.com/karelzak/util-linux/archive/v2.32.1.tar.gz",
     ],
 )
 
@@ -413,7 +447,7 @@ http_archive(
     sha256 = "8ba1b91a14431fe37091936c3a34469d7473965ab9edde0343c88f2d920bd918",
     strip_prefix = "FFmpeg-n2.8.15",
     urls = [
-        "https://mirror.bazel.build/github.com/FFmpeg/FFmpeg/archive/n2.8.15.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/FFmpeg/FFmpeg/archive/n2.8.15.tar.gz",
         "https://github.com/FFmpeg/FFmpeg/archive/n2.8.15.tar.gz",
     ],
 )
@@ -424,7 +458,7 @@ http_archive(
     sha256 = "bbccc87cd031498728bcc2dba5596a47e6fd92b2cec060a71feef65617a261fe",
     strip_prefix = "FFmpeg-n3.4.4",
     urls = [
-        "https://mirror.bazel.build/github.com/FFmpeg/FFmpeg/archive/n3.4.4.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/FFmpeg/FFmpeg/archive/n3.4.4.tar.gz",
         "https://github.com/FFmpeg/FFmpeg/archive/n3.4.4.tar.gz",
     ],
 )
@@ -434,6 +468,7 @@ http_archive(
     sha256 = "c911dc70f62f507f3a361cbc21d6e0d502b91254382255309bc60b7a0f48de28",
     strip_prefix = "rules_python-38f86fb55b698c51e8510c807489c9f4e047480e",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/rules_python/archive/38f86fb55b698c51e8510c807489c9f4e047480e.tar.gz",
         "https://github.com/bazelbuild/rules_python/archive/38f86fb55b698c51e8510c807489c9f4e047480e.tar.gz",
     ],
 )
@@ -458,6 +493,7 @@ http_archive(
     sha256 = "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81",
     strip_prefix = "grpc-1.26.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/grpc/grpc/archive/v1.26.0.tar.gz",
         "https://github.com/grpc/grpc/archive/v1.26.0.tar.gz",
     ],
 )
@@ -493,6 +529,7 @@ http_archive(
     sha256 = "da799f591aed933f63575ef0fbf7b7a20a84363633f031fcd48c936cee771502",
     strip_prefix = "rules_swift-1b0fd91696928ce940bcc220f36c898694f10115",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/rules_swift/archive/1b0fd91696928ce940bcc220f36c898694f10115.tar.gz",
         "https://github.com/bazelbuild/rules_swift/archive/1b0fd91696928ce940bcc220f36c898694f10115.tar.gz",
     ],
 )
@@ -514,7 +551,7 @@ http_archive(
     sha256 = "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392",
     strip_prefix = "google-cloud-cpp-0.13.0",
     urls = [
-        "https://mirror.bazel.build/github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz",
         "https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz",
     ],
 )
@@ -525,6 +562,7 @@ http_archive(
     sha256 = "cb531e445115e28054a33ad968c2d7d8ade4693721866ce1b9adf9a78762c032",
     strip_prefix = "googleapis-960b76b1f0c46d12610088977d1129cc7405f3dc",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/googleapis/googleapis/archive/960b76b1f0c46d12610088977d1129cc7405f3dc.tar.gz",
         "https://github.com/googleapis/googleapis/archive/960b76b1f0c46d12610088977d1129cc7405f3dc.tar.gz",
     ],
 )
@@ -547,7 +585,7 @@ http_archive(
     sha256 = "a31397714a353587413d307337d0b58f8a2e20e2b9d02f2e24e3463fa4eeda81",
     strip_prefix = "re2-2018-10-01",
     urls = [
-        "https://mirror.bazel.build/github.com/google/re2/archive/2018-10-01.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/re2/archive/2018-10-01.tar.gz",
         "https://github.com/google/re2/archive/2018-10-01.tar.gz",
     ],
 )
@@ -557,7 +595,7 @@ http_archive(
     sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
     strip_prefix = "googletest-release-1.8.1",
     urls = [
-        "https://mirror.bazel.build/github.com/google/googletest/archive/release-1.8.1.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/googletest/archive/release-1.8.1.tar.gz",
         "https://github.com/google/googletest/archive/release-1.8.1.tar.gz",
     ],
 )
@@ -568,7 +606,7 @@ http_archive(
     sha256 = "720da414e7aebb255fcdaee106894e4d30e2472ac1390c2c15b70c84c7479658",
     strip_prefix = "libarchive-3.3.3",
     urls = [
-        "https://mirror.bazel.build/github.com/libarchive/libarchive/archive/v3.3.3.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/libarchive/libarchive/archive/v3.3.3.tar.gz",
         "https://github.com/libarchive/libarchive/archive/v3.3.3.tar.gz",
     ],
 )
@@ -579,7 +617,7 @@ http_archive(
     sha256 = "574499cba22a599393e28d99ecfa1e7fc85be7d6651d543045244d5b561cb7ff",
     strip_prefix = "libexpat-R_2_2_6/expat",
     urls = [
-        "https://mirror.bazel.build/github.com/libexpat/libexpat/archive/R_2_2_6.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/libexpat/libexpat/archive/R_2_2_6.tar.gz",
         "http://github.com/libexpat/libexpat/archive/R_2_2_6.tar.gz",
     ],
 )
@@ -594,6 +632,7 @@ http_archive(
     sha256 = "1a0909a1146a214a6ab9de28902045461901baab4e0ee43797539ec05b6dbae0",
     strip_prefix = "apr-1.6.5",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/apache/apr/archive/1.6.5.tar.gz",
         "https://github.com/apache/apr/archive/1.6.5.tar.gz",
     ],
 )
@@ -608,6 +647,7 @@ http_archive(
     sha256 = "4c9ae319cedc16890fc2776920e7d529672dda9c3a9a9abd53bd80c2071b39af",
     strip_prefix = "apr-util-1.6.1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/apache/apr-util/archive/1.6.1.tar.gz",
         "https://github.com/apache/apr-util/archive/1.6.1.tar.gz",
     ],
 )
@@ -622,6 +662,7 @@ http_archive(
     sha256 = "4d850d15cdd4fdb9e82817eb069050d7575059a9a2729c82b23440e4445da199",
     strip_prefix = "mxml-2.12",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/michaelrsweet/mxml/archive/v2.12.tar.gz",
         "https://github.com/michaelrsweet/mxml/archive/v2.12.tar.gz",
     ],
 )
@@ -632,6 +673,7 @@ http_archive(
     sha256 = "6450d3970578c794b23e9e1645440c6f42f63be3f82383097660db5cf2fba685",
     strip_prefix = "aliyun-oss-c-sdk-3.7.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aliyun/aliyun-oss-c-sdk/archive/3.7.0.tar.gz",
         "https://github.com/aliyun/aliyun-oss-c-sdk/archive/3.7.0.tar.gz",
     ],
 )
@@ -642,7 +684,7 @@ http_archive(
     sha256 = "c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6",
     strip_prefix = "jsoncpp-1.8.4",
     urls = [
-        "http://mirror.tensorflow.org/github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz",
         "https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz",
     ],
 )
@@ -651,7 +693,7 @@ http_archive(
     name = "io_bazel_rules_go",
     sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz",
     ],
 )
@@ -659,7 +701,10 @@ http_archive(
 http_archive(
     name = "bazel_gazelle",
     sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz"],
+    urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz",
+    ],
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
@@ -713,6 +758,7 @@ http_archive(
     sha256 = "aa865d3509ba8f3527392303bd95a11f48f19e68197b3d1d0bae9fab004bee87",
     strip_prefix = "nucleus-0.4.1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/nucleus/archive/0.4.1.tar.gz",
         "https://github.com/google/nucleus/archive/0.4.1.tar.gz",
     ],
 )
@@ -723,6 +769,7 @@ http_archive(
     sha256 = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269",
     strip_prefix = "bzip2-1.0.8",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
         "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
     ],
 )
@@ -730,7 +777,10 @@ http_archive(
 http_archive(
     name = "com_googlesource_code_cctz",
     strip_prefix = "cctz-master",
-    urls = ["https://github.com/google/cctz/archive/master.zip"],
+    urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/cctz/archive/master.zip",
+        "https://github.com/google/cctz/archive/master.zip",
+    ],
 )
 
 # This is the 1.9 release of htslib.
@@ -740,6 +790,7 @@ http_archive(
     sha256 = "c4d3ae84014f8a80f5011521f391e917bc3b4f6ebd78e97f238472e95849ec14",
     strip_prefix = "htslib-1.9",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/samtools/htslib/archive/1.9.zip",
         "https://github.com/samtools/htslib/archive/1.9.zip",
     ],
 )
@@ -749,7 +800,7 @@ http_archive(
     sha256 = "43c9b882fa921923bcba764453f4058d102bece35a37c9f6383c713004aacff1",
     strip_prefix = "rules_closure-9889e2348259a5aad7e805547c1a0cf311cfcd91",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/9889e2348259a5aad7e805547c1a0cf311cfcd91.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/9889e2348259a5aad7e805547c1a0cf311cfcd91.tar.gz",  # 2018-12-21
         "https://github.com/bazelbuild/rules_closure/archive/9889e2348259a5aad7e805547c1a0cf311cfcd91.tar.gz",  # 2018-12-21
     ],
 )
@@ -759,7 +810,10 @@ http_archive(
     name = "bazel_skylib",
     sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
     strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+    urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz",
+    ],
 )
 
 http_archive(
@@ -770,7 +824,10 @@ http_archive(
     ],
     sha256 = "226936ab8c28e4946b17e4349d6478cfabafbd8a2614dcf525f97e56b7902899",
     strip_prefix = "bazel-toolchain-533bee6d2b27ba772a237542722607313aefdf01",
-    urls = ["https://github.com/grailbio/bazel-toolchain/archive/533bee6d2b27ba772a237542722607313aefdf01.tar.gz"],
+    urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/grailbio/bazel-toolchain/archive/533bee6d2b27ba772a237542722607313aefdf01.tar.gz",
+        "https://github.com/grailbio/bazel-toolchain/archive/533bee6d2b27ba772a237542722607313aefdf01.tar.gz",
+    ],
 )
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
@@ -786,6 +843,7 @@ http_archive(
     sha256 = "43fc4bc34f13da15b8acfa72fd594678e214d1cab35fc51d3a54969a725464eb",
     strip_prefix = "vorbis-1.3.6",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/xiph/vorbis/archive/v1.3.6.tar.gz",
         "https://github.com/xiph/vorbis/archive/v1.3.6.tar.gz",
     ],
 )
@@ -799,6 +857,7 @@ http_archive(
     sha256 = "3da31a4eb31534b6f878914b7379b873c280e610649fe5c07935b3d137a828bc",
     strip_prefix = "ogg-1.3.4",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/xiph/ogg/archive/v1.3.4.tar.gz",
         "https://github.com/xiph/ogg/archive/v1.3.4.tar.gz",
     ],
 )
@@ -809,6 +868,7 @@ http_archive(
     sha256 = "668cdeab898a7dd43cf84739f7e1f3ed6b35ece2ef9968a5c7079fe9adfe1689",
     strip_prefix = "flac-1.3.3",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/xiph/flac/archive/1.3.3.tar.gz",
         "https://github.com/xiph/flac/archive/1.3.3.tar.gz",
     ],
 )
@@ -819,6 +879,7 @@ http_archive(
     sha256 = "09395758f4c964fb158875f3cc9b9a65f36e9f5b2a27fb10f99519a0a6aef664",
     strip_prefix = "minimp3-55da78cbeea5fb6757f8df672567714e1e8ca3e9",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/lieff/minimp3/archive/55da78cbeea5fb6757f8df672567714e1e8ca3e9.tar.gz",
         "https://github.com/lieff/minimp3/archive/55da78cbeea5fb6757f8df672567714e1e8ca3e9.tar.gz",
     ],
 )
@@ -829,6 +890,7 @@ http_archive(
     sha256 = "682042fc6f9bee6294ec453f470dadc26c6ff29b9c9e9ad2ffc1f4312fd64771",
     strip_prefix = "speexdsp-1.2.0",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/downloads.xiph.org/releases/speex/speexdsp-1.2.0.tar.gz",
         "https://downloads.xiph.org/releases/speex/speexdsp-1.2.0.tar.gz",
     ],
 )
@@ -839,6 +901,7 @@ http_archive(
     sha256 = "2c9e176b2df3f72d9cb3bcd0959ebfc9da3efcedbea70fb945270c7bfa9e7758",
     strip_prefix = "minimp4-14d452e4fac71da38f5c02e211486144075f4ecb",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/lieff/minimp4/archive/14d452e4fac71da38f5c02e211486144075f4ecb.tar.gz",
         "https://github.com/lieff/minimp4/archive/14d452e4fac71da38f5c02e211486144075f4ecb.tar.gz",
     ],
 )
@@ -849,6 +912,7 @@ http_archive(
     sha256 = "9868c1149a04bae1131533c5cbd1c46f9c077f834f6147abaef8791a7c91b1a1",
     strip_prefix = "postgresql-12.1",
     urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/ftp.postgresql.org/pub/source/v12.1/postgresql-12.1.tar.gz",
         "https://ftp.postgresql.org/pub/source/v12.1/postgresql-12.1.tar.gz",
     ],
 )


### PR DESCRIPTION
- Prefix https://storage.googleapis.com/mirror.tensorflow.org/ for all Bazel download, conform to tensorflow's bazel rules.
- Remove unneeded patch as grailbio/bazel-toolchain#43 has been merged
- Replace cctz from master to a commit hash with sha256
- Small update on README.md
- Adjust order of the GitHub Actions
- Skip 3.8 test for now due to dependency missing
- Use checkout@v2

Note not all of our packages are mirrored in https://storage.googleapis.com/mirror.tensorflow.org. However, at least this may reduce some workload.

For a list of mirrored packages:
- https://storage.googleapis.com/mirror.tensorflow.org

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>