### PR TITLE
Switch to use fixed version of LLVM 10 for macOS build

### DIFF
--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # =============================================================================
 """Config Utility to write .bazelrc based on tensorflow."""
-from __future__ import print_function
 import re
 import sys
 import tensorflow as tf
@@ -101,9 +100,13 @@ def write_config():
             bazel_rc.write(
                 'build --action_env TF_SHARED_LIBRARY_NAME="{}"\n'.format(library_name)
             )
+            bazel_rc.write('build --cxxopt="-std=c++14""\n')
             # Needed for GRPC build
             if sys.platform == "darwin":
                 bazel_rc.write('build --copt="-DGRPC_BAZEL_BUILD"\n')
+            # Use llvm toolchain
+            if sys.platform == "darwin":
+                bazel_rc.write('build --crosstool_top=@llvm_toolchain//:toolchain"\n')
             for argv in sys.argv[1:]:
                 if argv == "--cuda":
                     bazel_rc.write('build --action_env TF_NEED_CUDA="1"\n')

--- a/tools/build/swift/BUILD
+++ b/tools/build/swift/BUILD
@@ -10,6 +10,7 @@ swift_library(
     ],
     linkopts = [
         "-L/usr/lib/swift",
+        "-Wl,-rpath,/usr/lib/swift",
     ],
     module_name = "audio_video",
     alwayslink = True,

--- a/tools/build/tensorflow_io.bzl
+++ b/tools/build/tensorflow_io.bzl
@@ -18,11 +18,9 @@ def tf_io_copts():
                 "/DNDEBUG",
             ],
             "@bazel_tools//src/conditions:darwin": [
-                "-std=c++11",
                 "-DNDEBUG",
             ],
             "//conditions:default": [
-                "-std=c++11",
                 "-DNDEBUG",
                 "-pthread",
             ],


### PR DESCRIPTION
This PR:
- Switch to use fixed version of LLVM 10 for macOS build (vs. previously unpredictable llvm version based on GitHub Actions).
- Remove -std=c++11 and stay with c++14 across the board
- Add "-Wl,-rpath,/usr/lib/swift" in the rpath to make sure it could find /usr/lib/swift when running.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>