### PR TITLE
Use python environment markers to limit pip3_import

### DIFF
--- a/tools/lint/requirements.txt
+++ b/tools/lint/requirements.txt
@@ -1,3 +1,3 @@
 pylint==2.4.4
-black==19.10b0
-pyupgrade==2.1.0
+black==19.10b0;python_version>="3.6"
+pyupgrade==2.1.0;python_version>="3.6"


### PR DESCRIPTION
This PR tries to fix issue in #909 where on debian 9 with python 3.5,
no black or pyupgrade package available. This causes pip3_import to fail.

This PR use python environment markers to skip in case python is less than 3.6.
It is not possible to run `bazel run //tools/lint:lint` but at least the
`bazel build -s --verbose_failures //tensorflow_io/...` will succeed.

This PR fixes #909.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>