### PR TITLE
 Skip Avro tests on macOS

### DIFF
--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -733,12 +733,10 @@ def test_audio_ops(fixture_lookup, io_data_fixture):
             "decode_aac",
             marks=[
                 pytest.mark.skipif(
-                    (sys.platform == "darwin" and sys.version_info < (3, 6))
-                    or (sys.platform == "linux" and sys.version_info < (3, 6))
+                    (sys.platform == "linux" and sys.version_info < (3, 6))
                     or (sys.platform == "win32"),
                     reason=(
                         "need ubuntu 18.04 which is python 3.6, "
-                        "and darwin with python3.5 is having trouble "
                         "and no windows support yet"
                     ),
                 )
@@ -748,12 +746,10 @@ def test_audio_ops(fixture_lookup, io_data_fixture):
             "encode_aac",
             marks=[
                 pytest.mark.skipif(
-                    (sys.platform == "darwin" and sys.version_info < (3, 6))
-                    or (sys.platform == "linux" and sys.version_info < (3, 6))
+                    (sys.platform == "linux" and sys.version_info < (3, 6))
                     or (sys.platform == "win32"),
                     reason=(
                         "need ubuntu 18.04 which is python 3.6, "
-                        "and darwin with python3.5 is having trouble "
                         "and no windows support yet"
                     ),
                 )

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -28,6 +28,9 @@ from avro.datafile import DataFileReader, DataFileWriter
 from avro.schema import Parse as parse
 import tensorflow_io as tfio
 
+if sys.platform == "darwin":
+    pytest.skip("TODO: skip macOS", allow_module_level=True)
+
 
 class AvroRecordsToFile:
     """AvroRecordsToFile"""


### PR DESCRIPTION
It looks like Avro tests is causing some issues on macOS. This PR skips all Avro tests for macOS.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>