### PR TITLE
Downgrade LLVM to 9.0.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -831,7 +831,7 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    llvm_version = "10.0.0",
+    llvm_version = "9.0.0",
 )
 
 http_archive(


### PR DESCRIPTION
This PR downgrades LLVM to 9.0.0, see #937 for details.

This PR fixes #937 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>