### PR TITLE
Fix build target to osx 10.13 for swift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
           python3 tools/build/configure.py
           bazel build \
             ${BAZEL_OPTIMIZATION} \
+            --copt -Wunguarded-availability \
             --copt -mmacosx-version-min=10.13 \
             --linkopt -mmacosx-version-min=10.13 \
             --noshow_progress \

--- a/tools/build/swift/BUILD
+++ b/tools/build/swift/BUILD
@@ -8,9 +8,15 @@ swift_library(
         "//tensorflow_io/core:swift/audio.swift",
         "//tensorflow_io/core:swift/video.swift",
     ],
+    copts = [
+        "-target",
+        "x86_64-apple-macosx10.13",
+    ],
     linkopts = [
         "-L/usr/lib/swift",
         "-Wl,-rpath,/usr/lib/swift",
+        "-target",
+        "x86_64-apple-macosx10.13",
     ],
     module_name = "audio_video",
     alwayslink = True,


### PR DESCRIPTION
This PR fixes #936 where osx 10.14 encountered missing symbols:
```
Symbol not found: _$sSo16CMBlockBufferRefa9CoreMedia01_aB14InitTrampolineACWP
```

The reason was that while we pass `-mmacosx-version-min=10.13` in c++,
the swift was not covered.

This PR passes `-target x86_64-apple-macosx10.13` to swift as well.

This PR fixes #936.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>