### PR TITLE
Change Windows Build Python from 3.7.6 to 3.8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,10 +312,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7.6
+          python-version: 3.8.2
       - name: Bazel on Windows
         env:
-          PYTHON_VERSION: 3.7.6
+          PYTHON_VERSION: 3.8.2
           BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
         shell: cmd
         run: |


### PR DESCRIPTION
GitHub deprecated the python 3.7.6 from their python env.
This breaks our CI. So we have to either bump to 3.7.7 or 3.8.2.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>