### PR TITLE
Allow user to specify rank of VarLenFeature

### DIFF
--- a/tensorflow_io/core/ops/avro_ops.cc
+++ b/tensorflow_io/core/ops/avro_ops.cc
@@ -40,9 +40,9 @@ Status AddDenseOutputShapes(const std::vector<TensorShapeType>& dense_shapes,
   return Status::OK();
 }
 
-shape_inference::DimensionOrConstant ComputeSparseRank(const ShapeHandle input_shape,
-                                                       int64 rank_delta,
-                                                       shape_inference::InferenceContext* c) {
+shape_inference::DimensionOrConstant ComputeSparseRank(
+    const ShapeHandle input_shape, int64 rank_delta,
+    shape_inference::InferenceContext* c) {
   shape_inference::DimensionOrConstant rank(c->UnknownDim());
   if (c->RankKnown(input_shape)) {
     rank = c->Rank(input_shape) + rank_delta;
@@ -55,17 +55,20 @@ shape_inference::DimensionOrConstant ComputeSparseRank(const ShapeHandle input_s
 // since this is not exposed publicly
 // Adds output shapes for sparse tensors in Parse*Example ops.
 void AddSparseOutputShapes(int num_sparse, const ShapeHandle input_shape,
-                           std::vector<int64> sparse_ranks, shape_inference::InferenceContext* c,
+                           std::vector<int64> sparse_ranks,
+                           shape_inference::InferenceContext* c,
                            int* output_idx) {
   for (int i = 0; i < num_sparse; ++i) {  // sparse_indices
-    shape_inference::DimensionOrConstant rank = ComputeSparseRank(input_shape, sparse_ranks[i], c);
+    shape_inference::DimensionOrConstant rank =
+        ComputeSparseRank(input_shape, sparse_ranks[i], c);
     c->set_output((*output_idx)++, c->Matrix(c->UnknownDim(), rank));
   }
   for (int i = 0; i < num_sparse; ++i) {  // sparse_values
     c->set_output((*output_idx)++, c->Vector(c->UnknownDim()));
   }
   for (int i = 0; i < num_sparse; ++i) {  // sparse_dense_shapes
-    shape_inference::DimensionOrConstant rank = ComputeSparseRank(input_shape, sparse_ranks[i], c);
+    shape_inference::DimensionOrConstant rank =
+        ComputeSparseRank(input_shape, sparse_ranks[i], c);
     c->set_output((*output_idx)++, c->Vector(rank));
   }
 }

--- a/tensorflow_io/core/ops/avro_ops.cc
+++ b/tensorflow_io/core/ops/avro_ops.cc
@@ -40,26 +40,32 @@ Status AddDenseOutputShapes(const std::vector<TensorShapeType>& dense_shapes,
   return Status::OK();
 }
 
+shape_inference::DimensionOrConstant ComputeSparseRank(const ShapeHandle input_shape,
+                                                       int64 rank_delta,
+                                                       shape_inference::InferenceContext* c) {
+  shape_inference::DimensionOrConstant rank(c->UnknownDim());
+  if (c->RankKnown(input_shape)) {
+    rank = c->Rank(input_shape) + rank_delta;
+  }
+  return rank;
+}
+
 // Copied verbatim from
 // https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/ops/parsing_ops.cc
 // since this is not exposed publicly
 // Adds output shapes for sparse tensors in Parse*Example ops.
 void AddSparseOutputShapes(int num_sparse, const ShapeHandle input_shape,
-                           int64 rank_delta,
-                           shape_inference::InferenceContext* c,
+                           std::vector<int64> sparse_ranks, shape_inference::InferenceContext* c,
                            int* output_idx) {
-  // Rank of SparseTensor is rank of input tensor plus rank_delta.
-  shape_inference::DimensionOrConstant rank(c->UnknownDim());
-  if (c->RankKnown(input_shape)) {
-    rank = c->Rank(input_shape) + rank_delta;
-  }
   for (int i = 0; i < num_sparse; ++i) {  // sparse_indices
+    shape_inference::DimensionOrConstant rank = ComputeSparseRank(input_shape, sparse_ranks[i], c);
     c->set_output((*output_idx)++, c->Matrix(c->UnknownDim(), rank));
   }
   for (int i = 0; i < num_sparse; ++i) {  // sparse_values
     c->set_output((*output_idx)++, c->Vector(c->UnknownDim()));
   }
   for (int i = 0; i < num_sparse; ++i) {  // sparse_dense_shapes
+    shape_inference::DimensionOrConstant rank = ComputeSparseRank(input_shape, sparse_ranks[i], c);
     c->set_output((*output_idx)++, c->Vector(rank));
   }
 }
@@ -77,6 +83,7 @@ REGISTER_OP("IO>ParseAvro")
     .Attr("num_sparse: int >= 0")
     .Attr("reader_schema: string")
     .Attr("sparse_keys: list(string) >= 0")
+    .Attr("sparse_ranks: list(int) >= 0")
     .Attr("dense_keys: list(string) >= 0")
     .Attr("sparse_types: list({float,double,int64,int32,string,bool}) >= 0")
     .Attr("dense_types: list({float,double,int64,int32,string,bool}) >= 0")
@@ -88,6 +95,7 @@ REGISTER_OP("IO>ParseAvro")
       std::vector<DataType> sparse_types;
       std::vector<DataType> dense_types;
       std::vector<string> sparse_keys;
+      std::vector<int64> sparse_ranks;
       std::vector<string> dense_keys;
 
       std::vector<PartialTensorShape> dense_shapes;
@@ -97,6 +105,7 @@ REGISTER_OP("IO>ParseAvro")
       TF_RETURN_IF_ERROR(c->GetAttr("dense_shapes", &dense_shapes));
 
       TF_RETURN_IF_ERROR(c->GetAttr("sparse_keys", &sparse_keys));
+      TF_RETURN_IF_ERROR(c->GetAttr("sparse_ranks", &sparse_ranks));
       TF_RETURN_IF_ERROR(c->GetAttr("dense_keys", &dense_keys));
 
       TF_RETURN_IF_ERROR(c->GetAttr("num_sparse", &num_sparse_from_user));
@@ -110,6 +119,9 @@ REGISTER_OP("IO>ParseAvro")
       }
       if (num_sparse != sparse_keys.size()) {
         return errors::InvalidArgument("len(sparse_types) != len(sparse_keys)");
+      }
+      if (num_sparse != sparse_ranks.size()) {
+        return errors::InvalidArgument("len(sparse_ranks) != num_sparse");
       }
       if (num_dense != dense_keys.size()) {
         return errors::InvalidArgument("len(dense_types) != len(dense_keys)");
@@ -142,7 +154,7 @@ REGISTER_OP("IO>ParseAvro")
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &names));
 
       int output_idx = 0;
-      AddSparseOutputShapes(num_sparse, input, 1, c, &output_idx);
+      AddSparseOutputShapes(num_sparse, input, sparse_ranks, c, &output_idx);
       TF_RETURN_IF_ERROR(
           AddDenseOutputShapes(dense_shapes, input, c, &output_idx));
       return Status::OK();

--- a/tensorflow_io/core/python/api/experimental/columnar.py
+++ b/tensorflow_io/core/python/api/experimental/columnar.py
@@ -30,7 +30,6 @@ from tensorflow_io.core.python.experimental.avro_dataset_ops import (  # pylint:
     make_avro_dataset,
 )
 
-from tensorflow_io.core.python.experimental.varlen_feature_with_rank import (  # pylint:
-    # disable=unused-import
+from tensorflow_io.core.python.experimental.varlen_feature_with_rank import (  # pylint: disable=unused-import
     VarLenFeatureWithRank,
 )

--- a/tensorflow_io/core/python/api/experimental/columnar.py
+++ b/tensorflow_io/core/python/api/experimental/columnar.py
@@ -29,3 +29,8 @@ from tensorflow_io.core.python.experimental.parse_avro_ops import (  # pylint: d
 from tensorflow_io.core.python.experimental.avro_dataset_ops import (  # pylint: disable=unused-import
     make_avro_dataset,
 )
+
+from tensorflow_io.core.python.experimental.varlen_feature_with_rank import (  # pylint:
+    # disable=unused-import
+    VarLenFeatureWithRank,
+)

--- a/tensorflow_io/core/python/experimental/parse_avro_ops.py
+++ b/tensorflow_io/core/python/experimental/parse_avro_ops.py
@@ -23,9 +23,11 @@ from tensorflow_io.core.python.ops import core_ops
 
 class VarLenFeatureWithRank:
     """
-    A class used to represent VarLenFeature with rank. This allows rank to be passed by users,
-    and when parsing, rank will be used to determine the shape of sparse feature. User should
-    use this class as opposed to VarLenFeature when defining features of data.
+    A class used to represent VarLenFeature with rank.
+    This allows rank to be passed by users, and when parsing,
+    rank will be used to determine the shape of sparse feature.
+    User should use this class as opposed to VarLenFeature
+    when defining features of data.
     """
     def __init__(self, dtype, rank=None):
         self.__dtype = dtype
@@ -343,19 +345,14 @@ def _features_to_raw_params(features, types):
         for key in sorted(features.keys()):
             feature = features[key]
             if isinstance(feature, VarLenFeatureWithRank):
-                _handle_varlen_feature(feature, key, sparse_keys, sparse_types, sparse_ranks, types)
+                _handle_varlen_feature(feature, key,
+                        sparse_keys, sparse_types, sparse_ranks, types)
             elif isinstance(feature, tf.io.SparseFeature):
-                _handle_sparse_feature(feature, key, sparse_keys, sparse_types, sparse_ranks, types)
+                _handle_sparse_feature(feature, key,
+                        sparse_keys, sparse_types, sparse_ranks, types)
             elif isinstance(feature, tf.io.FixedLenFeature):
-                _handle_fixedlen_feature(
-                    dense_defaults,
-                    dense_keys,
-                    dense_shapes,
-                    dense_types,
-                    feature,
-                    key,
-                    types,
-                )
+                _handle_fixedlen_feature(dense_defaults, dense_keys,
+                        dense_shapes, dense_types, feature, key, types)
             else:
                 raise ValueError("Invalid feature {}:{}.".format(key, feature))
     return (
@@ -386,7 +383,12 @@ def _handle_fixedlen_feature(
         dense_defaults[key] = feature.default_value
 
 
-def _handle_sparse_feature(feature, key, sparse_keys, sparse_types, types):
+def _handle_sparse_feature(feature,
+        key,
+        sparse_keys,
+        sparse_types,
+        sparse_ranks,
+        types):
     """handle_sparse_feature"""
     if tf.io.SparseFeature not in types:
         raise ValueError("Unsupported SparseFeature {}.".format(feature))
@@ -435,7 +437,12 @@ def _handle_sparse_feature(feature, key, sparse_keys, sparse_types, types):
         sparse_ranks.append(1)
 
 
-def _handle_varlen_feature(feature, key, sparse_keys, sparse_types, sparse_ranks, types):
+def _handle_varlen_feature(feature,
+        key,
+        sparse_keys,
+        sparse_types,
+        sparse_ranks,
+        types):
     """handle_varlen_feature"""
     if VarLenFeatureWithRank not in types:
         raise ValueError("Unsupported VarLenFeatureWithRank {}.".format(feature))

--- a/tensorflow_io/core/python/experimental/parse_avro_ops.py
+++ b/tensorflow_io/core/python/experimental/parse_avro_ops.py
@@ -92,8 +92,12 @@ def parse_avro(serialized, reader_schema, features, avro_names=None, name=None):
         dense_defaults,
         dense_shapes,
     ) = _features_to_raw_params(
-        features, [tensorflow_io.experimental.columnar.VarLenFeatureWithRank,
-                   tf.io.SparseFeature, tf.io.FixedLenFeature]
+        features,
+        [
+            tensorflow_io.experimental.columnar.VarLenFeatureWithRank,
+            tf.io.SparseFeature,
+            tf.io.FixedLenFeature,
+        ],
     )
 
     outputs = _parse_avro(
@@ -325,8 +329,9 @@ def _features_to_raw_params(features, types):
         # NOTE: We iterate over sorted keys to keep things deterministic.
         for key in sorted(features.keys()):
             feature = features[key]
-            if isinstance(feature,
-                          tensorflow_io.experimental.columnar.VarLenFeatureWithRank):
+            if isinstance(
+                feature, tensorflow_io.experimental.columnar.VarLenFeatureWithRank
+            ):
                 _handle_varlen_feature(
                     feature, key, sparse_keys, sparse_types, sparse_ranks, types
                 )

--- a/tensorflow_io/core/python/experimental/parse_avro_ops.py
+++ b/tensorflow_io/core/python/experimental/parse_avro_ops.py
@@ -29,6 +29,7 @@ class VarLenFeatureWithRank:
     User should use this class as opposed to VarLenFeature
     when defining features of data.
     """
+
     def __init__(self, dtype, rank=None):
         self.__dtype = dtype
         self.__rank = 1 if rank is None else rank
@@ -40,6 +41,7 @@ class VarLenFeatureWithRank:
     @property
     def dtype(self):
         return self.__dtype
+
 
 # Adjusted from
 # https://github.com/tensorflow/tensorflow/blob/v2.0.0/tensorflow/python/ops/parsing_ops.py
@@ -345,14 +347,23 @@ def _features_to_raw_params(features, types):
         for key in sorted(features.keys()):
             feature = features[key]
             if isinstance(feature, VarLenFeatureWithRank):
-                _handle_varlen_feature(feature, key,
-                        sparse_keys, sparse_types, sparse_ranks, types)
+                _handle_varlen_feature(
+                    feature, key, sparse_keys, sparse_types, sparse_ranks, types
+                )
             elif isinstance(feature, tf.io.SparseFeature):
-                _handle_sparse_feature(feature, key,
-                        sparse_keys, sparse_types, sparse_ranks, types)
+                _handle_sparse_feature(
+                    feature, key, sparse_keys, sparse_types, sparse_ranks, types
+                )
             elif isinstance(feature, tf.io.FixedLenFeature):
-                _handle_fixedlen_feature(dense_defaults, dense_keys,
-                        dense_shapes, dense_types, feature, key, types)
+                _handle_fixedlen_feature(
+                    dense_defaults,
+                    dense_keys,
+                    dense_shapes,
+                    dense_types,
+                    feature,
+                    key,
+                    types,
+                )
             else:
                 raise ValueError("Invalid feature {}:{}.".format(key, feature))
     return (
@@ -383,12 +394,9 @@ def _handle_fixedlen_feature(
         dense_defaults[key] = feature.default_value
 
 
-def _handle_sparse_feature(feature,
-        key,
-        sparse_keys,
-        sparse_types,
-        sparse_ranks,
-        types):
+def _handle_sparse_feature(
+    feature, key, sparse_keys, sparse_types, sparse_ranks, types
+):
     """handle_sparse_feature"""
     if tf.io.SparseFeature not in types:
         raise ValueError("Unsupported SparseFeature {}.".format(feature))
@@ -437,12 +445,9 @@ def _handle_sparse_feature(feature,
         sparse_ranks.append(1)
 
 
-def _handle_varlen_feature(feature,
-        key,
-        sparse_keys,
-        sparse_types,
-        sparse_ranks,
-        types):
+def _handle_varlen_feature(
+    feature, key, sparse_keys, sparse_types, sparse_ranks, types
+):
     """handle_varlen_feature"""
     if VarLenFeatureWithRank not in types:
         raise ValueError("Unsupported VarLenFeatureWithRank {}.".format(feature))

--- a/tensorflow_io/core/python/experimental/parse_avro_ops.py
+++ b/tensorflow_io/core/python/experimental/parse_avro_ops.py
@@ -21,6 +21,24 @@ import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops
 
 
+class VarLenFeatureWithRank:
+    """
+    A class used to represent VarLenFeature with rank. This allows rank to be passed by users,
+    and when parsing, rank will be used to determine the shape of sparse feature. User should
+    use this class as opposed to VarLenFeature when defining features of data.
+    """
+    def __init__(self, dtype, rank=None):
+        self.__dtype = dtype
+        self.__rank = 1 if rank is None else rank
+
+    @property
+    def rank(self):
+        return self.__rank
+
+    @property
+    def dtype(self):
+        return self.__dtype
+
 # Adjusted from
 # https://github.com/tensorflow/tensorflow/blob/v2.0.0/tensorflow/python/ops/parsing_ops.py
 # Note, there are several changes to 2.1.0
@@ -86,12 +104,13 @@ def parse_avro(serialized, reader_schema, features, avro_names=None, name=None):
     (
         sparse_keys,
         sparse_types,
+        sparse_ranks,
         dense_keys,
         dense_types,
         dense_defaults,
         dense_shapes,
     ) = _features_to_raw_params(
-        features, [tf.io.VarLenFeature, tf.io.SparseFeature, tf.io.FixedLenFeature]
+        features, [VarLenFeatureWithRank, tf.io.SparseFeature, tf.io.FixedLenFeature]
     )
 
     outputs = _parse_avro(
@@ -100,6 +119,7 @@ def parse_avro(serialized, reader_schema, features, avro_names=None, name=None):
         avro_names,
         sparse_keys,
         sparse_types,
+        sparse_ranks,
         dense_keys,
         dense_types,
         dense_defaults,
@@ -115,6 +135,7 @@ def _parse_avro(
     names=None,
     sparse_keys=None,
     sparse_types=None,
+    sparse_ranks=None,
     dense_keys=None,
     dense_types=None,
     dense_defaults=None,
@@ -133,6 +154,7 @@ def _parse_avro(
     sparse_types: A list of `DTypes` of the same length as `sparse_keys`.
       Only `tf.float32` (`FloatList`), `tf.int64` (`Int64List`),
       and `tf.string` (`BytesList`) are supported.
+    sparse_ranks: ranks of sparse feature. `tf.int64` (`Int64List`) is supported.
     dense_keys: A list of string keys in the examples' features.
       The results for these keys will be returned as `Tensor`s
     dense_types: A list of DTypes of the same length as `dense_keys`.
@@ -180,6 +202,7 @@ def _parse_avro(
             sparse_keys=sparse_keys,
             sparse_types=sparse_types,
             num_sparse=len(sparse_keys),
+            sparse_ranks=sparse_ranks,
             dense_keys=dense_keys,
             dense_shapes=dense_shapes,
             name=name,
@@ -306,6 +329,7 @@ def _features_to_raw_params(features, types):
     """
     sparse_keys = []
     sparse_types = []
+    sparse_ranks = []
     dense_keys = []
     dense_types = []
     # When the graph is built twice, multiple dense_defaults in a normal dict
@@ -318,10 +342,10 @@ def _features_to_raw_params(features, types):
         # NOTE: We iterate over sorted keys to keep things deterministic.
         for key in sorted(features.keys()):
             feature = features[key]
-            if isinstance(feature, tf.io.VarLenFeature):
-                _handle_varlen_feature(feature, key, sparse_keys, sparse_types, types)
+            if isinstance(feature, VarLenFeatureWithRank):
+                _handle_varlen_feature(feature, key, sparse_keys, sparse_types, sparse_ranks, types)
             elif isinstance(feature, tf.io.SparseFeature):
-                _handle_sparse_feature(feature, key, sparse_keys, sparse_types, types)
+                _handle_sparse_feature(feature, key, sparse_keys, sparse_types, sparse_ranks, types)
             elif isinstance(feature, tf.io.FixedLenFeature):
                 _handle_fixedlen_feature(
                     dense_defaults,
@@ -337,6 +361,7 @@ def _features_to_raw_params(features, types):
     return (
         sparse_keys,
         sparse_types,
+        sparse_ranks,
         dense_keys,
         dense_types,
         dense_defaults,
@@ -392,6 +417,9 @@ def _handle_sparse_feature(feature, key, sparse_keys, sparse_types, types):
         else:
             sparse_keys.append(index_key)
             sparse_types.append(tf.int64)
+            # sparse features always have rank 1 because they encode the indices separately (one for each component) and then merge these before the user get's them.
+            # setting 1 here is merely achieving the same behavior as before.
+            sparse_ranks.append(1)
     if feature.value_key in sparse_keys:
         dtype = sparse_types[sparse_keys.index(feature.value_key)]
         if dtype != feature.dtype:
@@ -402,16 +430,22 @@ def _handle_sparse_feature(feature, key, sparse_keys, sparse_types, types):
     else:
         sparse_keys.append(feature.value_key)
         sparse_types.append(feature.dtype)
+        # sparse features always have rank 1 because they encode the indices separately (one for each component) and then merge these before the user get's them.
+        # setting 1 here is merely achieving the same behavior as before.
+        sparse_ranks.append(1)
 
 
-def _handle_varlen_feature(feature, key, sparse_keys, sparse_types, types):
+def _handle_varlen_feature(feature, key, sparse_keys, sparse_types, sparse_ranks, types):
     """handle_varlen_feature"""
-    if tf.io.VarLenFeature not in types:
-        raise ValueError("Unsupported VarLenFeature {}.".format(feature))
+    if VarLenFeatureWithRank not in types:
+        raise ValueError("Unsupported VarLenFeatureWithRank {}.".format(feature))
     if not feature.dtype:
-        raise ValueError("Missing type for feature %s." % key)
+        raise ValueError("Missing type for VarLenFeatureWithRank %s." % key)
+    if not feature.rank:
+        raise ValueError("Missing rank for VarLenFeatureWithRank %s." % key)
     sparse_keys.append(key)
     sparse_types.append(feature.dtype)
+    sparse_ranks.append(feature.rank)
 
 
 # Pulled this method from tensorflow/python/ops/parsing_ops.py

--- a/tensorflow_io/core/python/experimental/varlen_feature_with_rank.py
+++ b/tensorflow_io/core/python/experimental/varlen_feature_with_rank.py
@@ -1,22 +1,38 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""VarLenFeatureWithRank"""
+
 import tensorflow as tf
 
 class VarLenFeatureWithRank:
-  """
-  A class used to represent VarLenFeature with rank.
-  This allows rank to be passed by users, and when parsing,
-  rank will be used to determine the shape of sparse feature.
-  User should use this class as opposed to VarLenFeature
-  when defining features of data.
-  """
+    """
+    A class used to represent VarLenFeature with rank.
+    This allows rank to be passed by users, and when parsing,
+    rank will be used to determine the shape of sparse feature.
+    User should use this class as opposed to VarLenFeature
+    when defining features of data.
+    """
 
-  def __init__(self, dtype: tf.dtypes.DType, rank: int=1):
-    self.__dtype = dtype
-    self.__rank = rank
+    def __init__(self, dtype: tf.dtypes.DType, rank: int = 1):
+        self.__dtype = dtype
+        self.__rank = rank
 
-  @property
-  def rank(self):
-    return self.__rank
+    @property
+    def rank(self):
+        return self.__rank
 
-  @property
-  def dtype(self):
-    return self.__dtype
+    @property
+    def dtype(self):
+        return self.__dtype

--- a/tensorflow_io/core/python/experimental/varlen_feature_with_rank.py
+++ b/tensorflow_io/core/python/experimental/varlen_feature_with_rank.py
@@ -16,6 +16,7 @@
 
 import tensorflow as tf
 
+
 class VarLenFeatureWithRank:
     """
     A class used to represent VarLenFeature with rank.

--- a/tensorflow_io/core/python/experimental/varlen_feature_with_rank.py
+++ b/tensorflow_io/core/python/experimental/varlen_feature_with_rank.py
@@ -1,0 +1,22 @@
+import tensorflow as tf
+
+class VarLenFeatureWithRank:
+  """
+  A class used to represent VarLenFeature with rank.
+  This allows rank to be passed by users, and when parsing,
+  rank will be used to determine the shape of sparse feature.
+  User should use this class as opposed to VarLenFeature
+  when defining features of data.
+  """
+
+  def __init__(self, dtype: tf.dtypes.DType, rank: int=1):
+    self.__dtype = dtype
+    self.__rank = rank
+
+  @property
+  def rank(self):
+    return self.__rank
+
+  @property
+  def dtype(self):
+    return self.__dtype

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -29,7 +29,7 @@ from avro.schema import Parse as parse
 from tensorflow_io.core.python.experimental.parse_avro_ops import VarLenFeatureWithRank
 import tensorflow_io as tfio
 
-#if sys.platform == "darwin":
+# if sys.platform == "darwin":
 #    pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
@@ -423,33 +423,41 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
                         }
                     ]}"""
         record_data = [
-          {"int_list_list": [[1, 2], [3, 4, 5]]},
-          {"int_list_list": [[6]]},
-          {"int_list_list": [[6]]},
+            {"int_list_list": [[1, 2], [3, 4, 5]]},
+            {"int_list_list": [[6]]},
+            {"int_list_list": [[6]]},
         ]
-        features = {
-          'int_list_list[*][*]': VarLenFeatureWithRank(tf.dtypes.int32)
-        }
+        features = {"int_list_list[*][*]": VarLenFeatureWithRank(tf.dtypes.int32)}
         expected_data = [
-          {"int_list_list[*][*]":
-            tf.compat.v1.SparseTensorValue(
-                indices=[[0, 0, 0], [0, 0, 1], [0, 1, 0],
-                         [0, 1, 1], [0, 1, 2], [1, 0, 0], [2, 0, 0]],
-                values=[1, 2, 3, 4, 5, 6, 6],
-                dense_shape=[3, 2, 3]
-            )
-          }
+            {
+                "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
+                    indices=[
+                        [0, 0, 0],
+                        [0, 0, 1],
+                        [0, 1, 0],
+                        [0, 1, 1],
+                        [0, 1, 2],
+                        [1, 0, 0],
+                        [2, 0, 0],
+                    ],
+                    values=[1, 2, 3, 4, 5, 6, 6],
+                    dense_shape=[3, 2, 3],
+                )
+            }
         ]
         with self.assertRaises(Exception) as context:
-            self._test_pass_dataset(reader_schema=reader_schema,
-                                    record_data=record_data,
-                                    expected_data=expected_data,
-                                    features=features,
-                                    writer_schema=reader_schema,
-                                    batch_size=3,
-                                    num_epochs=1)
-            self.assertTrue('is not compatible with supplied shape'
-                    in context.exception)
+            self._test_pass_dataset(
+                reader_schema=reader_schema,
+                record_data=record_data,
+                expected_data=expected_data,
+                features=features,
+                writer_schema=reader_schema,
+                batch_size=3,
+                num_epochs=1,
+            )
+            self.assertTrue(
+                "is not compatible with supplied shape" in context.exception
+            )
 
     def test_variable_length_passed_with_rank(self):
         """test_variable_length_passed_with_rank"""
@@ -469,30 +477,37 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
                         }
                     ]}"""
         record_data = [
-          {"int_list_list": [[1, 2], [3, 4, 5]]},
-          {"int_list_list": [[6]]},
-          {"int_list_list": [[6]]},
+            {"int_list_list": [[1, 2], [3, 4, 5]]},
+            {"int_list_list": [[6]]},
+            {"int_list_list": [[6]]},
         ]
-        features = {
-          'int_list_list[*][*]': VarLenFeatureWithRank(tf.dtypes.int32, 2)
-        }
+        features = {"int_list_list[*][*]": VarLenFeatureWithRank(tf.dtypes.int32, 2)}
         expected_data = [
-          {"int_list_list[*][*]":
-            tf.compat.v1.SparseTensorValue(
-                indices=[[0, 0, 0], [0, 0, 1], [0, 1, 0],
-                         [0, 1, 1], [0, 1, 2], [1, 0, 0], [2, 0, 0]],
-                values=[1, 2, 3, 4, 5, 6, 6],
-                dense_shape=[3, 2, 3]
-            )
-          }
+            {
+                "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
+                    indices=[
+                        [0, 0, 0],
+                        [0, 0, 1],
+                        [0, 1, 0],
+                        [0, 1, 1],
+                        [0, 1, 2],
+                        [1, 0, 0],
+                        [2, 0, 0],
+                    ],
+                    values=[1, 2, 3, 4, 5, 6, 6],
+                    dense_shape=[3, 2, 3],
+                )
+            }
         ]
-        self._test_pass_dataset(reader_schema=reader_schema,
-                                record_data=record_data,
-                                expected_data=expected_data,
-                                features=features,
-                                writer_schema=reader_schema,
-                                batch_size=3,
-                                num_epochs=1)
+        self._test_pass_dataset(
+            reader_schema=reader_schema,
+            record_data=record_data,
+            expected_data=expected_data,
+            features=features,
+            writer_schema=reader_schema,
+            batch_size=3,
+            num_epochs=1,
+        )
 
     def test_batching(self):
         """test_batching"""

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -426,9 +426,10 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]":
-                        tfio.experimental.columnar.VarLenFeatureWithRank(
-                            tf.dtypes.int32)
+        features = {
+            "int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.int32
+            )
         }
         expected_data = [
             {
@@ -483,9 +484,10 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]":
-                        tfio.experimental.columnar.VarLenFeatureWithRank(
-                            tf.dtypes.int32, 2)
+        features = {
+            "int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.int32, 2
+            )
         }
         expected_data = [
             {
@@ -1374,9 +1376,11 @@ class AvroDatasetTest(AvroDatasetTestBase):
                   }
               ]}"""
         record_data = [{"int_list": [1, 2]}, {"int_list": [3, 4, 5]}, {"int_list": [6]}]
-        features = {"int_list[*]":
-                        tfio.experimental.columnar.VarLenFeatureWithRank(
-                            tf.dtypes.int32, 1)}
+        features = {
+            "int_list[*]": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.int32, 1
+            )
+        }
         expected_data = [
             {
                 "int_list[*]": tf.compat.v1.SparseTensorValue(
@@ -1417,9 +1421,11 @@ class AvroDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]":
-                        tfio.experimental.columnar.VarLenFeatureWithRank(
-                            tf.dtypes.int32, 2)}
+        features = {
+            "int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.int32, 2
+            )
+        }
         expected_data = [
             {
                 "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
@@ -1790,10 +1796,12 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
         ]
         features = {
-            "guests[gender='male'].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
-            "guests[gender='female'].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='male'].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            ),
+            "guests[gender='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            ),
         }
         expected_data = [
             {
@@ -1861,8 +1869,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
             {"guests": [{"name": "Joel", "gender": "male"}]},
         ]
         features = {
-            "guests[gender='wrong_value'].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[gender='wrong_value'].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            )
         }
         expected_data = [
             {
@@ -1910,8 +1919,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[wrong_key='female'].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[wrong_key='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            )
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -1944,8 +1954,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[forgot_the_separator].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[forgot_the_separator].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            )
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -1978,9 +1989,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[used=too=many=separators].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(
-                    tf.dtypes.string)
+            "guests[used=too=many=separators].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            )
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -2057,9 +2068,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
             }
         ]
         features = {
-            "guests[gender='female'].address.street":
-                tfio.experimental.columnar.VarLenFeatureWithRank(
-                tf.dtypes.string)
+            "guests[gender='female'].address.street": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            )
         }
         expected_data = [
             {
@@ -2127,12 +2138,12 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
         ]
         features = {
-            "guests[gender='male'].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(
-                    tf.dtypes.string),
-            "guests[gender='female'].name":
-                tfio.experimental.columnar.VarLenFeatureWithRank(
-                    tf.dtypes.string),
+            "guests[gender='male'].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            ),
+            "guests[gender='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string
+            ),
         }
         expected_data = [
             {

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -26,11 +26,10 @@ import tensorflow as tf
 from avro.io import DatumReader, DatumWriter, BinaryDecoder, BinaryEncoder
 from avro.datafile import DataFileReader, DataFileWriter
 from avro.schema import Parse as parse
-from tensorflow_io.core.python.experimental.parse_avro_ops import VarLenFeatureWithRank
 import tensorflow_io as tfio
 
-# if sys.platform == "darwin":
-#    pytest.skip("TODO: skip macOS", allow_module_level=True)
+if sys.platform == "darwin":
+   pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
 class AvroRecordsToFile:
@@ -427,7 +426,7 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]": VarLenFeatureWithRank(tf.dtypes.int32)}
+        features = {"int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32)}
         expected_data = [
             {
                 "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
@@ -481,7 +480,7 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]": VarLenFeatureWithRank(tf.dtypes.int32, 2)}
+        features = {"int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32, 2)}
         expected_data = [
             {
                 "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
@@ -1369,7 +1368,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
                   }
               ]}"""
         record_data = [{"int_list": [1, 2]}, {"int_list": [3, 4, 5]}, {"int_list": [6]}]
-        features = {"int_list[*]": VarLenFeatureWithRank(tf.dtypes.int32, 1)}
+        features = {"int_list[*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32, 1)}
         expected_data = [
             {
                 "int_list[*]": tf.compat.v1.SparseTensorValue(
@@ -1410,7 +1409,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]": VarLenFeatureWithRank(tf.dtypes.int32, 2)}
+        features = {"int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32, 2)}
         expected_data = [
             {
                 "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
@@ -1781,8 +1780,8 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
         ]
         features = {
-            "guests[gender='male'].name": VarLenFeatureWithRank(tf.dtypes.string),
-            "guests[gender='female'].name": VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='male'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
         }
         expected_data = [
             {
@@ -1850,7 +1849,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
             {"guests": [{"name": "Joel", "gender": "male"}]},
         ]
         features = {
-            "guests[gender='wrong_value'].name": VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[gender='wrong_value'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
         }
         expected_data = [
             {
@@ -1898,7 +1897,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[wrong_key='female'].name": VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[wrong_key='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -1931,7 +1930,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[forgot_the_separator].name": VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[forgot_the_separator].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -1964,7 +1963,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[used=too=many=separators].name": VarLenFeatureWithRank(
+            "guests[used=too=many=separators].name": tfio.experimental.columnar.VarLenFeatureWithRank(
                 tf.dtypes.string
             )
         }
@@ -2043,7 +2042,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
             }
         ]
         features = {
-            "guests[gender='female'].address.street": VarLenFeatureWithRank(
+            "guests[gender='female'].address.street": tfio.experimental.columnar.VarLenFeatureWithRank(
                 tf.dtypes.string
             )
         }
@@ -2113,8 +2112,8 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
         ]
         features = {
-            "guests[gender='male'].name": VarLenFeatureWithRank(tf.dtypes.string),
-            "guests[gender='female'].name": VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='male'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
         }
         expected_data = [
             {

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 """AvroDatasetTest"""
+# pylint: disable=line-too-long
+# see https://github.com/tensorflow/io/pull/962#issuecomment-632346602
 
 import sys
 from functools import reduce

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -29,8 +29,8 @@ from avro.schema import Parse as parse
 from tensorflow_io.core.python.experimental.parse_avro_ops import VarLenFeatureWithRank
 import tensorflow_io as tfio
 
-if sys.platform == "darwin":
-    pytest.skip("TODO: skip macOS", allow_module_level=True)
+#if sys.platform == "darwin":
+#    pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
 class AvroRecordsToFile:
@@ -406,6 +406,7 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
         self._verify_output(expected_data=expected_data, actual_dataset=actual_dataset)
 
     def test_variable_length_failed_with_wrong_rank(self):
+        """test_variable_length_failed_with_wrong_rank"""
         reader_schema = """{
                     "type": "record",
                     "name": "row",
@@ -432,7 +433,8 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
         expected_data = [
           {"int_list_list[*][*]":
             tf.compat.v1.SparseTensorValue(
-                indices=[[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [0, 1, 2], [1, 0, 0], [2, 0, 0]],
+                indices=[[0, 0, 0], [0, 0, 1], [0, 1, 0],
+                         [0, 1, 1], [0, 1, 2], [1, 0, 0], [2, 0, 0]],
                 values=[1, 2, 3, 4, 5, 6, 6],
                 dense_shape=[3, 2, 3]
             )
@@ -446,9 +448,11 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
                                     writer_schema=reader_schema,
                                     batch_size=3,
                                     num_epochs=1)
-            self.assertEqual('is not compatible with supplied shape' in context.exception)
+            self.assertTrue('is not compatible with supplied shape'
+                    in context.exception)
 
     def test_variable_length_passed_with_rank(self):
+        """test_variable_length_passed_with_rank"""
         reader_schema = """{
                     "type": "record",
                     "name": "row",
@@ -475,7 +479,8 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
         expected_data = [
           {"int_list_list[*][*]":
             tf.compat.v1.SparseTensorValue(
-                indices=[[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [0, 1, 2], [1, 0, 0], [2, 0, 0]],
+                indices=[[0, 0, 0], [0, 0, 1], [0, 1, 0],
+                         [0, 1, 1], [0, 1, 2], [1, 0, 0], [2, 0, 0]],
                 values=[1, 2, 3, 4, 5, 6, 6],
                 dense_shape=[3, 2, 3]
             )

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -29,7 +29,7 @@ from avro.schema import Parse as parse
 import tensorflow_io as tfio
 
 if sys.platform == "darwin":
-   pytest.skip("TODO: skip macOS", allow_module_level=True)
+    pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
 class AvroRecordsToFile:
@@ -426,7 +426,10 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32)}
+        features = {"int_list_list[*][*]":
+                        tfio.experimental.columnar.VarLenFeatureWithRank(
+                            tf.dtypes.int32)
+        }
         expected_data = [
             {
                 "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
@@ -480,7 +483,10 @@ class MakeAvroRecordDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32, 2)}
+        features = {"int_list_list[*][*]":
+                        tfio.experimental.columnar.VarLenFeatureWithRank(
+                            tf.dtypes.int32, 2)
+        }
         expected_data = [
             {
                 "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
@@ -1368,7 +1374,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
                   }
               ]}"""
         record_data = [{"int_list": [1, 2]}, {"int_list": [3, 4, 5]}, {"int_list": [6]}]
-        features = {"int_list[*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32, 1)}
+        features = {"int_list[*]":
+                        tfio.experimental.columnar.VarLenFeatureWithRank(
+                            tf.dtypes.int32, 1)}
         expected_data = [
             {
                 "int_list[*]": tf.compat.v1.SparseTensorValue(
@@ -1409,7 +1417,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
             {"int_list_list": [[6]]},
             {"int_list_list": [[6]]},
         ]
-        features = {"int_list_list[*][*]": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.int32, 2)}
+        features = {"int_list_list[*][*]":
+                        tfio.experimental.columnar.VarLenFeatureWithRank(
+                            tf.dtypes.int32, 2)}
         expected_data = [
             {
                 "int_list_list[*][*]": tf.compat.v1.SparseTensorValue(
@@ -1780,8 +1790,10 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
         ]
         features = {
-            "guests[gender='male'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
-            "guests[gender='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='male'].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='female'].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
         }
         expected_data = [
             {
@@ -1849,7 +1861,8 @@ class AvroDatasetTest(AvroDatasetTestBase):
             {"guests": [{"name": "Joel", "gender": "male"}]},
         ]
         features = {
-            "guests[gender='wrong_value'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[gender='wrong_value'].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
         }
         expected_data = [
             {
@@ -1897,7 +1910,8 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[wrong_key='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[wrong_key='female'].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -1930,7 +1944,8 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[forgot_the_separator].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
+            "guests[forgot_the_separator].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string)
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -1963,9 +1978,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
           """
         record_data = [{"guests": [{"name": "Hans"}]}]
         features = {
-            "guests[used=too=many=separators].name": tfio.experimental.columnar.VarLenFeatureWithRank(
-                tf.dtypes.string
-            )
+            "guests[used=too=many=separators].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(
+                    tf.dtypes.string)
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
 
@@ -2042,9 +2057,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
             }
         ]
         features = {
-            "guests[gender='female'].address.street": tfio.experimental.columnar.VarLenFeatureWithRank(
-                tf.dtypes.string
-            )
+            "guests[gender='female'].address.street":
+                tfio.experimental.columnar.VarLenFeatureWithRank(
+                tf.dtypes.string)
         }
         expected_data = [
             {
@@ -2112,8 +2127,12 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
         ]
         features = {
-            "guests[gender='male'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
-            "guests[gender='female'].name": tfio.experimental.columnar.VarLenFeatureWithRank(tf.dtypes.string),
+            "guests[gender='male'].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(
+                    tf.dtypes.string),
+            "guests[gender='female'].name":
+                tfio.experimental.columnar.VarLenFeatureWithRank(
+                    tf.dtypes.string),
         }
         expected_data = [
             {


### PR DESCRIPTION
Why?
- VarLenFeature under eager mode is broken. All sparse tensors are assumed to have rank 2. And the built-in VarLenFeature does not allow to define the rank otherwise. We need to define our "own" variable length feature and rank needs to be known at op construction time.

What?
- Define VarLenFeatureWithRank which allows user to pass rank in.