### PR TITLE
Bump windows python version to 3.8.3 for GitHub CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,10 +312,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8.2
+          python-version: 3.8.3
       - name: Bazel on Windows
         env:
-          PYTHON_VERSION: 3.8.2
+          PYTHON_VERSION: 3.8.3
           BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
         shell: cmd
         run: |


### PR DESCRIPTION
GitHub CI upgrades python to 3.8.3 for Windows. For that we have
to bump it as otherwise the build breaks.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>