### PR TITLE
Fix mono mode encode_mp3 on Linux (through LAME)

### DIFF
--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -791,3 +791,13 @@ def test_audio_ops_in_graph(fixture_lookup, io_data_fixture):
     assert len(entries) == 1
     entries = entries[0]
     assert np.array_equal(entries, expected)
+
+
+def test_encode_mp3_mono():
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_audio", "mono_10khz.wav",
+    )
+    audio = tfio.audio.decode_wav(tf.io.read_file(path), dtype=tf.int16)
+    assert audio.shape == [5760, 1]
+    audio = tf.cast(audio, tf.float32) / 32768.0
+    _ = tfio.audio.encode_mp3(audio, rate=8000)

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -793,7 +793,11 @@ def test_audio_ops_in_graph(fixture_lookup, io_data_fixture):
     assert np.array_equal(entries, expected)
 
 
+@pytest.mark.skipif(
+    sys.platform in ("win32", "darwin"), reason="no lame for darwin or win32",
+)
 def test_encode_mp3_mono():
+    """test_encode_mp3_mono"""
     path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "test_audio", "mono_10khz.wav",
     )


### PR DESCRIPTION
This PR fixes mode mode encode_mp3 on Linux, as was raised in #973.
The issue was that encode_mp3 didn't take into consideration of
mono mode (need non-interleaved encode, and need set_mode).

This PR fixes #973.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>