### PR TITLE
Fix Docker file build failure

### DIFF
--- a/third_party/arrow.BUILD
+++ b/third_party/arrow.BUILD
@@ -86,6 +86,7 @@ cc_library(
         "cpp/src/arrow/util/config.h",
         "cpp/src/parquet/parquet_version.h",
     ],
+    copts = ["-std=c++11"],
     defines = [
         "ARROW_WITH_BROTLI",
         "ARROW_WITH_SNAPPY",

--- a/tools/dev/Dockerfile
+++ b/tools/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM tensorflow/tensorflow:custom-op-ubuntu16
 
-RUN rm /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list && apt-get update && \
+RUN rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list && apt-get update && \
     apt-get install -y \
     git \
     gcc \


### PR DESCRIPTION
This PR tries to fix issue raised in #987.

The issue seems to be related to Ubuntu 16.04 have a gcc 5.4 that is old
and does not plays well with std=c++14.
This PR adjust arrow's flag to std=c++11 to allow gcc 5.4 working again.

As python 3.5 will EOL in 09/13/2020, we might consider dropping Ubuntu 16.04
support (and issues related to gcc 5.4 + python 3.5) sometime this year.

This PR fixes #987.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>