### PR TITLE
Enable libgav1 support for avif image format

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -937,3 +937,10 @@ http_archive(
         "https://github.com/videolan/dav1d/archive/0.6.0.tar.gz",
     ],
 )
+
+new_git_repository(
+    name = "libgav1",
+    build_file = "//third_party:libgav1.BUILD",
+    commit = "6ab7d65a68350ed4ec6aaabfa18715b2d76a231c",
+    remote = "https://chromium.googlesource.com/codecs/libgav1",
+)

--- a/third_party/libavif.BUILD
+++ b/third_party/libavif.BUILD
@@ -14,7 +14,6 @@ cc_library(
         ],
         exclude = [
             "src/codec_aom.c",
-            "src/codec_libgav1.c",
             "src/codec_rav1e.c",
         ],
     ),
@@ -22,7 +21,7 @@ cc_library(
     defines = [
         #"AVIF_CODEC_AOM=1",
         "AVIF_CODEC_DAV1D=1",
-        #"AVIF_CODEC_LIBGAV1=1",
+        "AVIF_CODEC_LIBGAV1=1",
         #"AVIF_CODEC_RAV1E=1",
     ],
     includes = [
@@ -31,5 +30,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@dav1d",
+        "@libgav1",
     ],
 )

--- a/third_party/libgav1.BUILD
+++ b/third_party/libgav1.BUILD
@@ -1,0 +1,33 @@
+# Description:
+#   libgav1 decoder for AVIF library
+
+licenses(["notice"])  # Apache license
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "libgav1",
+    srcs = glob(
+        [
+            "src/**/*.cc",
+            "src/**/*.h",
+        ],
+    ),
+    hdrs = glob([
+        "src/**/*.inc",
+    ]),
+    defines = [
+        "LIBGAV1_MAX_BITDEPTH=8",
+    ],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/algorithm",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
+    ],
+)


### PR DESCRIPTION
This PR enables libgav1 support for avif image format, part of #882

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>