### PR TITLE
Support Repeated field in BigQuery api

### DIFF
--- a/tensorflow_io/bigquery/README.md
+++ b/tensorflow_io/bigquery/README.md
@@ -142,7 +142,7 @@ work that Tensor with dataset.batch, then you can use code like
 dataset = read_session.parallel_read_rows()
 def sparse_dataset_map(features, sparse_column_names):
   """
-  Map sparse repeated columns to tf.SparseTensor.
+  Map repeated columns to tf.SparseTensor.
   This matches how VarLenFeature is decoded from tf.Example datasets.
   """
   for col_name in sparse_column_names:

--- a/tensorflow_io/bigquery/README.md
+++ b/tensorflow_io/bigquery/README.md
@@ -89,15 +89,17 @@ It also supports reading repeated mode BigQuery column (each field contains arra
 form like
 
 ```
-        { "field_a_name": {"mode": "repeated", output_type: dtypes.int64},
-          "field_b_name": {"mode": "nullable", output_type: dtypes.string},
+        { "field_a_name": {"mode": BigQueryClient.FieldMode.REPEATED, output_type: dtypes.int64},
+          "field_b_name": {"mode": BigQueryClient.FieldMode.NULLABLE, output_type: dtypes.string},
           ...
-          "field_x_name": {"mode": "repeated", output_type: dtypes.string}
+          "field_x_name": {"mode": BigQueryClient.FieldMode.REQUIRED, output_type: dtypes.string}
         }
 
 ```
-"mode" is BigQuery column attribute concept, it can be 'repeated', 'nullable' or 'required'.The output field order is unrelated to the order of fields in
-selected_fields. If "mode" not specified, defaults to "nullable". If "output_type" not specified, DT_STRING is implied for all Tensors.
+"mode" is BigQuery column attribute concept, it can be 'repeated', 'nullable' or 'required' (enum BigQueryClient.FieldMode.REPEATED, NULLABLE, REQUIRED).The output field order is unrelated to the order of fields in
+selected_fields. If "mode" not specified, defaults to "nullable". If "output_type" not specified, DT_STRING is implied for all Tensors. 
+
+'repeated' is currently only supported when data_format = BigQueryClient.DataFormat.AVRO (which is default).
 
 ```
 from tensorflow.python.framework import ops
@@ -117,9 +119,10 @@ def main():
       "projects/" + GCP_PROJECT_ID,
       DATASET_GCP_PROJECT_ID, TABLE_ID, DATASET_ID,
       selected_fiels={
-          "field_a_name": {"mode": "repeated", output_type: dtypes.int64},
-          "field_b_name": {"mode": "nullable", output_type: dtypes.string},
-          "field_c_name": {"mode": "repeated", output_type: dtypes.string}
+          "field_a_name": {"mode": BigQueryClient.FieldMode.REPEATED, output_type: dtypes.int64},
+          "field_b_name": {"mode": BigQueryClient.FieldMode.NULLABLE, output_type: dtypes.string},
+          "field_c_name": {"mode": BigQueryClient.FieldMode.REQUIRED, output_type: dtypes.string}
+          "field_d_name": {"mode": BigQueryClient.FieldMode.REPEATED, output_type: dtypes.string}
         }
       requested_streams=2,
       row_restriction="num_characters > 1000",
@@ -151,7 +154,7 @@ def sparse_dataset_map(features, sparse_column_names):
     features[col_name] = tf.SparseTensor(indices=indices,
                                          values=features[col_name],
                                          dense_shape=[l])
-dataset_can_be_batched = dataset.map(lambda features: sparse_dataset_map(features, ["field_a_name", "field_b_name", "field_c_name"]))
+dataset_can_be_batched = dataset.map(lambda features: sparse_dataset_map(features, ["field_a_name", "field_d_name"]))
 
 ```
 to map that that as a SparseTensor first, then dataset.batch can work. The behavior of returning this kind of SparseTensor is exactly aligned with how to decode tf.example tf.io.VarLenFeature,

--- a/tensorflow_io/bigquery/README.md
+++ b/tensorflow_io/bigquery/README.md
@@ -85,7 +85,7 @@ if __name__ == '__main__':
 
 ```
 
-It also supports reading repeated mode BigQuery column (each field contains array of values). In this case, selected_fields needs be a dictionary in a
+It also supports reading BigQuery column with repeated mode (each field contains array of values with primitive type: Integer, Float, Boolean, String, but RECORD is not supported). In this case, selected_fields needs be a dictionary in a
 form like
 
 ```

--- a/tensorflow_io/bigquery/kernels/bigquery_lib.h
+++ b/tensorflow_io/bigquery/kernels/bigquery_lib.h
@@ -303,23 +303,29 @@ class BigQueryReaderAvroDatasetIterator
         case avro::AVRO_ENUM:
           dtype = DT_STRING;
           break;
-        case avro::AVRO_ARRAY:{
+        case avro::AVRO_ARRAY: {
           auto values_vector = field.value<avro::GenericArray>().value();
-          if(values_vector.empty()) dtype = output_types[i];
-          else{
+          if (values_vector.empty())
+            dtype = output_types[i];
+          else {
             auto value_type = values_vector[0].type();
-            if (value_type == avro::AVRO_BOOL) dtype = DT_BOOL;
-            else if (value_type == avro::AVRO_INT) dtype = DT_INT32;
-            else if (value_type == avro::AVRO_LONG) dtype = DT_INT64;
-            else if (value_type == avro::AVRO_FLOAT) dtype = DT_FLOAT;
-            else if (value_type == avro::AVRO_DOUBLE) dtype = DT_DOUBLE;
-            else if (value_type == avro::AVRO_STRING) dtype = DT_STRING;
+            if (value_type == avro::AVRO_BOOL)
+              dtype = DT_BOOL;
+            else if (value_type == avro::AVRO_INT)
+              dtype = DT_INT32;
+            else if (value_type == avro::AVRO_LONG)
+              dtype = DT_INT64;
+            else if (value_type == avro::AVRO_FLOAT)
+              dtype = DT_FLOAT;
+            else if (value_type == avro::AVRO_DOUBLE)
+              dtype = DT_DOUBLE;
+            else if (value_type == avro::AVRO_STRING)
+              dtype = DT_STRING;
             else
-              return errors::InvalidArgument("unsupported data type within AVRO_ARRAY ",
-                                 value_type);
-            }
+              return errors::InvalidArgument(
+                  "unsupported data type within AVRO_ARRAY ", value_type);
           }
-          break;
+        } break;
         case avro::AVRO_NULL:
           dtype = output_types[i];
           break;
@@ -369,69 +375,63 @@ class BigQueryReaderAvroDatasetIterator
           ((*out_tensors)[i]).scalar<tstring>()() =
               string((char *)&field_value[0], field_value.size());
         } break;
-        case avro::AVRO_ARRAY:{
-          if (output_types[i] == DT_BOOL){
+        case avro::AVRO_ARRAY: {
+          if (output_types[i] == DT_BOOL) {
             auto values_vector = field.value<avro::GenericArray>().value();
             unsigned int size = values_vector.size();
             Tensor output_tensor(ctx->allocator({}), DT_BOOL, {size});
             auto output_flat = output_tensor.flat<bool>();
-            for (unsigned int idx = 0; idx < size; idx++){
-               output_flat(idx) = values_vector[idx].value<bool>();
+            for (unsigned int idx = 0; idx < size; idx++) {
+              output_flat(idx) = values_vector[idx].value<bool>();
             }
             (*out_tensors)[i] = output_tensor;
-          }
-          else if (output_types[i] == DT_INT32){
+          } else if (output_types[i] == DT_INT32) {
             auto values_vector = field.value<avro::GenericArray>().value();
             unsigned int size = values_vector.size();
             Tensor output_tensor(ctx->allocator({}), DT_INT32, {size});
             auto output_flat = output_tensor.flat<int32>();
-            for (unsigned int idx = 0; idx < size; idx++){
-               output_flat(idx) = values_vector[idx].value<int32_t>();
+            for (unsigned int idx = 0; idx < size; idx++) {
+              output_flat(idx) = values_vector[idx].value<int32_t>();
             }
             (*out_tensors)[i] = output_tensor;
-          }
-          else if (output_types[i] == DT_INT64){
+          } else if (output_types[i] == DT_INT64) {
             auto values_vector = field.value<avro::GenericArray>().value();
             unsigned int size = values_vector.size();
             Tensor output_tensor(ctx->allocator({}), DT_INT64, {size});
             auto output_flat = output_tensor.flat<int64>();
-            for (unsigned int idx = 0; idx < size; idx++){
-               output_flat(idx) = values_vector[idx].value<int64_t>();
+            for (unsigned int idx = 0; idx < size; idx++) {
+              output_flat(idx) = values_vector[idx].value<int64_t>();
             }
             (*out_tensors)[i] = output_tensor;
-          }
-          else if (output_types[i] == DT_FLOAT) {
+          } else if (output_types[i] == DT_FLOAT) {
             auto values_vector = field.value<avro::GenericArray>().value();
             unsigned int size = values_vector.size();
             Tensor output_tensor(ctx->allocator({}), DT_FLOAT, {size});
             auto output_flat = output_tensor.flat<float>();
-            for (unsigned int idx = 0; idx < size; idx++){
-               output_flat(idx) = values_vector[idx].value<float>();
+            for (unsigned int idx = 0; idx < size; idx++) {
+              output_flat(idx) = values_vector[idx].value<float>();
             }
             (*out_tensors)[i] = output_tensor;
-          }
-          else if (output_types[i] == DT_DOUBLE){
+          } else if (output_types[i] == DT_DOUBLE) {
             auto values_vector = field.value<avro::GenericArray>().value();
             unsigned int size = values_vector.size();
             Tensor output_tensor(ctx->allocator({}), DT_DOUBLE, {size});
             auto output_flat = output_tensor.flat<double>();
-            for (unsigned int idx = 0; idx < size; idx++){
-               output_flat(idx) = values_vector[idx].value<double>();
+            for (unsigned int idx = 0; idx < size; idx++) {
+              output_flat(idx) = values_vector[idx].value<double>();
             }
             (*out_tensors)[i] = output_tensor;
-          }
-          else if (output_types[i] == DT_STRING) {
+          } else if (output_types[i] == DT_STRING) {
             auto values_vector = field.value<avro::GenericArray>().value();
             unsigned int size = values_vector.size();
             Tensor output_tensor(ctx->allocator({}), DT_STRING, {size});
             auto output_flat = output_tensor.flat<tstring>();
-            for (unsigned int idx = 0; idx < size; idx++){
-               output_flat(idx) = values_vector[idx].value<string>();
+            for (unsigned int idx = 0; idx < size; idx++) {
+              output_flat(idx) = values_vector[idx].value<string>();
             }
             (*out_tensors)[i] = output_tensor;
           }
-          }
-          break;
+        } break;
         case avro::AVRO_NULL:
           switch (output_types[i]) {
             case DT_BOOL:
@@ -467,7 +467,8 @@ class BigQueryReaderAvroDatasetIterator
   }
 
  private:
-  std::unique_ptr<avro::InputStream> memory_input_stream_ TF_GUARDED_BY(this->mu_);
+  std::unique_ptr<avro::InputStream> memory_input_stream_
+      TF_GUARDED_BY(this->mu_);
   avro::DecoderPtr decoder_ TF_GUARDED_BY(this->mu_);
 };
 

--- a/tensorflow_io/bigquery/python/ops/bigquery_api.py
+++ b/tensorflow_io/bigquery/python/ops/bigquery_api.py
@@ -49,6 +49,14 @@ class BigQueryClient:
         AVRO = "AVRO"
         ARROW = "ARROW"
 
+    class FieldMode(enum.Enum):
+        """BigQuery column mode.
+        """
+
+        NULLABLE = "NULLABLE"
+        REQUIRED = "REQUIRED"
+        REPEATED = "REPEATED"
+
     def __init__(self):
         """Creates a BigQueryClient to start BigQuery read sessions.
 
@@ -147,13 +155,15 @@ class BigQueryClient:
             output_types = []
             for field in selected_fields:
                 _selected_fields.append(field)
-                mode = selected_fields[field].get("mode", "nullable")
-                if mode == "repeated":
+                mode = selected_fields[field].get("mode", self.FieldMode.NULLABLE)
+                if mode == self.FieldMode.REPEATED:
                     selected_fields_repeated.append(True)
-                elif mode == "nullable" or mode == "required":
+                elif mode == self.FieldMode.NULLABLE or mode == self.FieldMode.REQUIRED:
                     selected_fields_repeated.append(False)
                 else:
-                    raise ValueError("mode needs be nullable, required or repeated")
+                    raise ValueError(
+                        "mode needs be BigQueryClient.FieldMode.NULLABLE, FieldMode.REQUIRED or FieldMode.REPEATED"
+                    )
                 output_types.append(
                     selected_fields[field].get("output_type", dtypes.string)
                 )

--- a/tensorflow_io/bigquery/python/ops/bigquery_api.py
+++ b/tensorflow_io/bigquery/python/ops/bigquery_api.py
@@ -62,11 +62,11 @@ class BigQueryClient:
         table_id,
         dataset_id,
         selected_fields,
-        selected_fields_repeated,
         output_types=None,
         row_restriction="",
         requested_streams=1,
         data_format: DataFormat = DataFormat.AVRO,
+        selected_fields_repeated=None,
     ):
         """Opens a session and returns a `BigQueryReadSession` object.
 

--- a/tensorflow_io/bigquery/python/ops/bigquery_api.py
+++ b/tensorflow_io/bigquery/python/ops/bigquery_api.py
@@ -307,19 +307,27 @@ class _BigQueryDataset(dataset_ops.DatasetSource):
         # selected_fields and corresponding output_types have to be sorted because
         # of b/141251314
         sorted_fields_with_types = sorted(
-            zip(selected_fields, selected_fields_repeated, output_types), key=itemgetter(0)
+            zip(selected_fields, selected_fields_repeated, output_types),
+            key=itemgetter(0),
         )
-        selected_fields, selected_fields_repeated, output_types = list(zip(*sorted_fields_with_types))
+        selected_fields, selected_fields_repeated, output_types = list(
+            zip(*sorted_fields_with_types)
+        )
         selected_fields = list(selected_fields)
         selected_fields_repeated = list(selected_fields_repeated)
         output_types = list(output_types)
 
-        tensor_shapes = list([None, ] if repeated else [] for repeated in selected_fields_repeated)
+        tensor_shapes = list(
+            [None,] if repeated else [] for repeated in selected_fields_repeated
+        )
 
         self._element_spec = collections.OrderedDict(
             zip(
                 selected_fields,
-                (tensor_spec.TensorSpec(shape, dtype) for (shape, dtype) in zip(tensor_shapes, output_types)),
+                (
+                    tensor_spec.TensorSpec(shape, dtype)
+                    for (shape, dtype) in zip(tensor_shapes, output_types)
+                ),
             )
         )
 

--- a/tensorflow_io/bigquery/python/ops/bigquery_api.py
+++ b/tensorflow_io/bigquery/python/ops/bigquery_api.py
@@ -66,7 +66,6 @@ class BigQueryClient:
         row_restriction="",
         requested_streams=1,
         data_format: DataFormat = DataFormat.AVRO,
-        selected_fields_repeated=None,
     ):
         """Opens a session and returns a `BigQueryReadSession` object.
 

--- a/tests/test_bigquery_eager.py
+++ b/tests/test_bigquery_eager.py
@@ -29,6 +29,7 @@ from tensorflow.python.framework import ops  # pylint: disable=wrong-import-orde
 from tensorflow import test  # pylint: disable=wrong-import-order
 from tensorflow_io.bigquery import (
     BigQueryTestClient,
+    BigQueryClient,
 )  # pylint: disable=wrong-import-order
 
 import google.cloud.bigquery_storage_v1beta1.proto.storage_pb2_grpc as storage_pb2_grpc  # pylint: disable=wrong-import-order
@@ -366,19 +367,28 @@ class BigqueryOpsTest(test.TestCase):
                     "long": {"output_type": dtypes.int64},
                     "float": {"output_type": dtypes.float32},
                     "double": {"output_type": dtypes.float64},
-                    "repeated_bool": {"mode": "repeated", "output_type": dtypes.bool},
-                    "repeated_int": {"mode": "repeated", "output_type": dtypes.int32},
-                    "repeated_long": {"mode": "repeated", "output_type": dtypes.int64},
+                    "repeated_bool": {
+                        "mode": BigQueryClient.FieldMode.REPEATED,
+                        "output_type": dtypes.bool,
+                    },
+                    "repeated_int": {
+                        "mode": BigQueryClient.FieldMode.REPEATED,
+                        "output_type": dtypes.int32,
+                    },
+                    "repeated_long": {
+                        "mode": BigQueryClient.FieldMode.REPEATED,
+                        "output_type": dtypes.int64,
+                    },
                     "repeated_float": {
-                        "mode": "repeated",
+                        "mode": BigQueryClient.FieldMode.REPEATED,
                         "output_type": dtypes.float32,
                     },
                     "repeated_double": {
-                        "mode": "repeated",
+                        "mode": BigQueryClient.FieldMode.REPEATED,
                         "output_type": dtypes.float64,
                     },
                     "repeated_string": {
-                        "mode": "repeated",
+                        "mode": BigQueryClient.FieldMode.REPEATED,
                         "output_type": dtypes.string,
                     },
                 },

--- a/tests/test_bigquery_eager.py
+++ b/tests/test_bigquery_eager.py
@@ -284,13 +284,8 @@ class BigqueryOpsTest(test.TestCase):
         "repeated_long": [200, 300, 900],
         "repeated_float": [1000.0, 700.0, 1200.0],
         "repeated_double": [101.0, 10.1, 0.3, 1.4],
-            "repeated_string": ["string1", "string2", "string3", "string4"],
-        "repeated_string": [
-            "string1",
-            "string2",
-            "string3",
-            "string4",
-        ], 
+        "repeated_string": ["string1", "string2", "string3", "string4"],
+        "repeated_string": ["string1", "string2", "string3", "string4",],
         "repeated_double": [101.0, 10.1, 0.3, 1.4],
     }
 

--- a/tests/test_bigquery_eager.py
+++ b/tests/test_bigquery_eager.py
@@ -183,16 +183,36 @@ class BigqueryOpsTest(test.TestCase):
               "doc": "nullable double"
           },
           {
-              "name": "repeated_string",
-              "type": {"type": "array", "items": "string"},
+              "name": "repeated_bool",
+              "type": {"type": "array", "items": "boolean"},
+              "doc": "repeated string"
+          },
+          {
+              "name": "repeated_int",
+              "type": {"type": "array", "items": "int"},
+              "doc": "repeated string"
+          },
+          {
+              "name": "repeated_long",
+              "type": {"type": "array", "items": "long"},
+              "doc": "repeated string"
+          },
+          {
+              "name": "repeated_float",
+              "type": {"type": "array", "items": "float"},
               "doc": "repeated string"
           },
           {
               "name": "repeated_double",
               "type": {"type": "array", "items": "double"},
+              "doc": "repeated double"
+          },
+          {
+              "name": "repeated_string",
+              "type": {"type": "array", "items": "string"},
               "doc": "repeated string"
           }
- 
+
       ]
   }"""
 
@@ -204,8 +224,12 @@ class BigqueryOpsTest(test.TestCase):
             "long": 100,
             "float": 1000.0,
             "double": 10000.0,
-            "repeated_string": ["string1"],
+            "repeated_bool": [True],
+            "repeated_int": [20],
+            "repeated_long": [200],
+            "repeated_float": [1000.0],
             "repeated_double": [10000.0],
+            "repeated_string": ["string1"],
         },
         {
             "string": "string2",
@@ -214,8 +238,12 @@ class BigqueryOpsTest(test.TestCase):
             "long": 102,
             "float": 1002.0,
             "double": 10002.0,
-            "repeated_string": ["string1", "string2"],
+            "repeated_bool": [True, False],
+            "repeated_int": [20, 40],
+            "repeated_long": [200, 400],
+            "repeated_float": [1000.0, 800.0],
             "repeated_double": [101.0, 10.1],
+            "repeated_string": ["string1", "string2"],
         },
     ]
     STREAM_2_ROWS = [
@@ -226,13 +254,21 @@ class BigqueryOpsTest(test.TestCase):
             "long": 200,
             "float": 2000.0,
             "double": 20000.0,
+            "repeated_bool": [True, False, True],
+            "repeated_int": [20, 40, 30],
+            "repeated_long": [200, 400, 700],
+            "repeated_float": [1000.0, 800.0, 1100.0],
+            "repeated_double": [101.0, 10.1, 0.3, 20.0],
             "repeated_string": ["string1", "string2", "string3"],
-            "repeated_double": [101.0, 10.1, 0.3],
         },
         {
             # Empty record, all values are null except for repeated fields
-            "repeated_string": ["string1", "string2", "string3", "string4"],
+            "repeated_bool": [False, True, True],
+            "repeated_int": [30, 40, 20],
+            "repeated_long": [200, 300, 900],
+            "repeated_float": [1000.0, 700.0, 1200.0],
             "repeated_double": [101.0, 10.1, 0.3, 1.4],
+            "repeated_string": ["string1", "string2", "string3", "string4"],
         },
     ]
 
@@ -243,12 +279,18 @@ class BigqueryOpsTest(test.TestCase):
         "int": 0,
         "long": 0,
         "string": "",
+        "repeated_bool": [False, True, True],
+        "repeated_int": [30, 40, 20],
+        "repeated_long": [200, 300, 900],
+        "repeated_float": [1000.0, 700.0, 1200.0],
+        "repeated_double": [101.0, 10.1, 0.3, 1.4],
+            "repeated_string": ["string1", "string2", "string3", "string4"],
         "repeated_string": [
             "string1",
             "string2",
             "string3",
             "string4",
-        ],  # repeated fields can't be null
+        ], 
         "repeated_double": [101.0, 10.1, 0.3, 1.4],
     }
 
@@ -289,36 +331,20 @@ class BigqueryOpsTest(test.TestCase):
             self.GCP_PROJECT_ID,
             self.TABLE_ID,
             self.DATASET_ID,
-            selected_fields=[
-                "string",
-                "boolean",
-                "int",
-                "long",
-                "float",
-                "double",
-                "repeated_string",
-                "repeated_double",
-            ],
-            selected_fields_repeated=[
-                False,
-                False,
-                False,
-                False,
-                False,
-                False,
-                True,
-                True,
-            ],
-            output_types=[
-                dtypes.string,
-                dtypes.bool,
-                dtypes.int32,
-                dtypes.int64,
-                dtypes.float32,
-                dtypes.float64,
-                dtypes.string,
-                dtypes.float64,
-            ],
+            selected_fields={
+                "string": {"output_type": dtypes.string},
+                "boolean": {"output_type": dtypes.bool},
+                "int": {"output_type": dtypes.int32},
+                "long": {"output_type": dtypes.int64},
+                "float": {"output_type": dtypes.float32},
+                "double": {"output_type": dtypes.float64},
+                "repeated_bool": {"mode": "repeated", "output_type": dtypes.bool},
+                "repeated_int": {"mode": "repeated", "output_type": dtypes.int32},
+                "repeated_long": {"mode": "repeated", "output_type": dtypes.int64},
+                "repeated_float": {"mode": "repeated", "output_type": dtypes.float32},
+                "repeated_double": {"mode": "repeated", "output_type": dtypes.float64},
+                "repeated_string": {"mode": "repeated", "output_type": dtypes.string},
+            },
             requested_streams=2,
         )
 

--- a/tests/test_bigquery_eager.py
+++ b/tests/test_bigquery_eager.py
@@ -349,8 +349,8 @@ class BigqueryOpsTest(test.TestCase):
                     dtypes.int32,
                     dtypes.int64,
                     dtypes.float32,
-                    dtypes.float64
-                 ],
+                    dtypes.float64,
+                ],
                 requested_streams=2,
             )
         else:
@@ -369,9 +369,18 @@ class BigqueryOpsTest(test.TestCase):
                     "repeated_bool": {"mode": "repeated", "output_type": dtypes.bool},
                     "repeated_int": {"mode": "repeated", "output_type": dtypes.int32},
                     "repeated_long": {"mode": "repeated", "output_type": dtypes.int64},
-                    "repeated_float": {"mode": "repeated", "output_type": dtypes.float32},
-                    "repeated_double": {"mode": "repeated", "output_type": dtypes.float64},
-                    "repeated_string": {"mode": "repeated", "output_type": dtypes.string},
+                    "repeated_float": {
+                        "mode": "repeated",
+                        "output_type": dtypes.float32,
+                    },
+                    "repeated_double": {
+                        "mode": "repeated",
+                        "output_type": dtypes.float64,
+                    },
+                    "repeated_string": {
+                        "mode": "repeated",
+                        "output_type": dtypes.string,
+                    },
                 },
                 requested_streams=2,
             )
@@ -447,17 +456,19 @@ class BigqueryOpsTest(test.TestCase):
     def test_read_rows_nonrepeated_only(self):
         """Test for reading rows with non-repeated fields only, then selected_fields and output_types are list (backward compatible)."""
         client = BigQueryTestClient(BigqueryOpsTest.server.endpoint())
-        read_session = self._get_read_session(client,nonrepeated_only=True)
+        read_session = self._get_read_session(client, nonrepeated_only=True)
 
         streams_list = read_session.get_streams()
         self.assertEqual(len(streams_list), 2)
         dataset1 = read_session.read_rows(streams_list[0])
         itr1 = iter(dataset1)
         self.assertEqual(
-            self._get_nonrepeated_only_fields(self.STREAM_1_ROWS[0]), self._normalize_dictionary(itr1.get_next())
+            self._get_nonrepeated_only_fields(self.STREAM_1_ROWS[0]),
+            self._normalize_dictionary(itr1.get_next()),
         )
         self.assertEqual(
-            self._get_nonrepeated_only_fields(self.STREAM_1_ROWS[1]), self._normalize_dictionary(itr1.get_next())
+            self._get_nonrepeated_only_fields(self.STREAM_1_ROWS[1]),
+            self._normalize_dictionary(itr1.get_next()),
         )
         with self.assertRaises(errors.OutOfRangeError):
             itr1.get_next()
@@ -465,10 +476,12 @@ class BigqueryOpsTest(test.TestCase):
         dataset2 = read_session.read_rows(streams_list[1])
         itr2 = iter(dataset2)
         self.assertEqual(
-            self._get_nonrepeated_only_fields(self.STREAM_2_ROWS[0]), self._normalize_dictionary(itr2.get_next())
+            self._get_nonrepeated_only_fields(self.STREAM_2_ROWS[0]),
+            self._normalize_dictionary(itr2.get_next()),
         )
         self.assertEqual(
-            self._get_nonrepeated_only_fields(self.DEFAULT_VALUES), self._normalize_dictionary(itr2.get_next())
+            self._get_nonrepeated_only_fields(self.DEFAULT_VALUES),
+            self._normalize_dictionary(itr2.get_next()),
         )
         with self.assertRaises(errors.OutOfRangeError):
             itr2.get_next()


### PR DESCRIPTION
Fixes #627 

**Goal**
Support decoding BigQuery repeated field with primitive type as Tensor.

**Non-goal**
Support repeated field with non-primitive type such as Record.

**Impact**
This change fills an important gap in the BigQueryDataset API. The repeated field in BigQuery can be used to represent what equivalent to tf.io.VarLenFeature (normally used to represent Sparse features) in TFExample.  Combining with the existing capability of generating scalar Tensor for nullable/required BigQuery field,  this enables featurewise on-pair with TFExampleDataset (TFRecordDataset+ TFexample parse function https://www.tensorflow.org/tutorials/load_data/tfrecord) . 


See README.md to see how to use this API.  In high level, for a repeated field, it returns a rank-1 variable-length dense tensor  

Let's say,  `_tensor` is the Tensor mentioned above, user can do 
```
l = tf.size(_tensor, tf.int64)
indices = tf.reshape(tf.range(l, dtype=tf.int64), [l, 1])
_SparseTensor= tf.SparseTensor(indices=indices,
values=_tensor,
dense_shape=[l])
```
to get a SparseTensor. Then they can use `dataset.batch` with this SparseTensor without a problem. 

The behaviour of returning this kind of SparseTensor is exactly aligned with how to decode tf.example tf.io.VarLenFeature (which contains a list of values, just like the REPEATED field in BigQuery, returns a SparseTensor).


