### PR TITLE
support partially-known and unknown shape specification in decode_json

### DIFF
--- a/tensorflow_io/core/ops/serialization_ops.cc
+++ b/tensorflow_io/core/ops/serialization_ops.cc
@@ -25,24 +25,13 @@ REGISTER_OP("IO>DecodeJSON")
     .Input("input: string")
     .Input("names: string")
     .Output("value: dtypes")
-    .Attr("shapes: list(shape)")
     .Attr("dtypes: list(type)")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       // TODO: support batch (1-D) input
       shape_inference::ShapeHandle unused;
       TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(0), 0, &unused));
-      std::vector<TensorShape> shapes;
-      TF_RETURN_IF_ERROR(c->GetAttr("shapes", &shapes));
-      if (shapes.size() != c->num_outputs()) {
-        return errors::InvalidArgument(
-            "shapes and types should be the same: ", shapes.size(), " vs. ",
-            c->num_outputs());
-      }
-      for (size_t i = 0; i < shapes.size(); ++i) {
-        shape_inference::ShapeHandle shape;
-        TF_RETURN_IF_ERROR(
-            c->MakeShapeFromPartialTensorShape(shapes[i], &shape));
-        c->set_output(static_cast<int64>(i), shape);
+      for (size_t i = 0; i < c->num_outputs(); ++i) {
+        c->set_output(static_cast<int64>(i), c->MakeShape({c->UnknownDim()}));
       }
       return Status::OK();
     });

--- a/tensorflow_io/core/python/experimental/serialization_ops.py
+++ b/tensorflow_io/core/python/experimental/serialization_ops.py
@@ -67,10 +67,14 @@ def decode_json(data, specs, name=None):
     named_spec(named)
     named = tf.nest.flatten(named)
     names = [e.named() for e in named]
-    shapes = [e.shape for e in named]
+    shapes = [
+        tf.constant([-1 if d is None else d for d in e.shape.as_list()], tf.int32)
+        for e in named
+    ]
     dtypes = [e.dtype for e in named]
 
-    values = core_ops.io_decode_json(data, names, shapes, dtypes, name=name)
+    values = core_ops.io_decode_json(data, names, dtypes, name=name)
+    values = [tf.reshape(value, shape) for value, shape in zip(values, shapes)]
     return tf.nest.pack_sequence_as(specs, values)
 
 

--- a/tests/test_serialization_eager.py
+++ b/tests/test_serialization_eager.py
@@ -15,6 +15,7 @@
 """Test Serialization"""
 
 import os
+import json
 import numpy as np
 
 import pytest
@@ -185,3 +186,17 @@ def test_serialization_decode_in_dataset(
                 for v, r in zip(tf.nest.flatten(value), tf.nest.flatten(returned))
             ]
         )
+
+
+def test_json_partial_shape():
+    """Test case for partial shape GitHub 918."""
+    r = json.dumps({"foo": [1, 2, 3, 4, 5]})
+
+    @tf.function(autograph=False)
+    def parse_json(json_text):
+        specs = {"foo": tf.TensorSpec(tf.TensorShape([None]), tf.int32)}
+        parsed = tfio.experimental.serialization.decode_json(json_text, specs)
+        return parsed["foo"]
+
+    v = parse_json(r)
+    assert np.array_equal(v, [1, 2, 3, 4, 5])


### PR DESCRIPTION
This PR tries to address the isseu in #918 by adding
support for partially-known and unknown shape specification in decode_json.

In this PR, the shapes are not passed in C++ kernels anymore. Instead,
the C++ kernels will always render 1-D output tensor first with a
follow-up tf.reshape to fixup the shape later.

This PR fixes #918.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>