### PR TITLE
Update dav1d BUILD file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -930,6 +930,14 @@ http_archive(
 http_archive(
     name = "dav1d",
     build_file = "//third_party:dav1d.BUILD",
+    patch_cmds = [
+        "mkdir -p include8/common",
+        "sed 's/define DAV1D_COMMON_BITDEPTH_H/define DAV1D_COMMON_BITDEPTH_H\\'$'\\n''#define BITDEPTH 8/g' include/common/bitdepth.h > include8/common/bitdepth.h",
+        "cat include/common/dump.h > include8/common/dump.h",
+        "mkdir -p include16/common",
+        "sed 's/define DAV1D_COMMON_BITDEPTH_H/define DAV1D_COMMON_BITDEPTH_H\\'$'\\n''#define BITDEPTH 16/g' include/common/bitdepth.h > include16/common/bitdepth.h",
+        "cat include/common/dump.h > include16/common/dump.h",
+    ],
     sha256 = "66c3e831a93f074290a72aad5da907e3763ecb092325f0250a841927b3d30ce3",
     strip_prefix = "dav1d-0.6.0",
     urls = [

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -1052,15 +1052,7 @@ def fixture_video_mp4():
                 ),
             ],
         ),
-        pytest.param(
-            "kinesis",
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support kinesis",
-                ),
-            ],
-        ),
+        pytest.param("kinesis", marks=[pytest.mark.skip(reason="TODO")],),
         pytest.param("pubsub"),
         pytest.param("hdf5"),
         pytest.param("grpc"),

--- a/third_party/dav1d.BUILD
+++ b/third_party/dav1d.BUILD
@@ -6,94 +6,137 @@ licenses(["notice"])  # BSD license
 exports_files(["COPYING"])
 
 cc_library(
-    name = "dav1d",
+    name = "dav1d8",
+    srcs = [
+        "include8/common/bitdepth.h",
+        "include8/common/dump.h",
+        "src/cdef_apply_tmpl.c",
+        "src/cdef_tmpl.c",
+        "src/fg_apply_tmpl.c",
+        "src/film_grain_tmpl.c",
+        "src/ipred_prepare_tmpl.c",
+        "src/ipred_tmpl.c",
+        "src/itx_tmpl.c",
+        "src/lf_apply_tmpl.c",
+        "src/loopfilter_tmpl.c",
+        "src/looprestoration_tmpl.c",
+        "src/lr_apply_tmpl.c",
+        "src/mc_tmpl.c",
+        "src/recon_tmpl.c",
+    ],
+    hdrs = [],
+    copts = [],
+    defines = [],
+    includes = [
+        "include8",
+    ],
     visibility = ["//visibility:public"],
     deps = [
-        ":dav1d16",
-        ":dav1d8",
+        ":source",
     ],
-)
-
-cc_library(
-    name = "dav1d8",
-    srcs = glob(
-        [
-            "include/dav1d/*.h",
-            "include/common/*.h",
-            "src/*.c",
-            "src/x86/*.c",
-            "src/x86/*.h",
-            "src/*.h",
-        ],
-        exclude = [
-            "src/x86/msac_init.c",
-        ],
-    ) + select({
-        "@bazel_tools//src/conditions:windows": [
-            "include/compat/msvc/stdatomic.h",
-            "src/win32/thread.c",
-        ],
-        "//conditions:default": [],
-    }),
-    hdrs = [
-        "build/config.h",
-        "build/vcs_version.h",
-        "build/version.h",
-    ],
-    copts = [
-        "-std=c99",
-    ],
-    defines = [
-        "_FILE_OFFSET_BITS=64",
-        "_GNU_SOURCE",
-        "BITDEPTH=8",
-    ],
-    includes = [
-        "build",
-        "include",
-        "include/dav1d",
-    ] + select({
-        "@bazel_tools//src/conditions:windows": [
-            "include/compat/msvc",
-        ],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:public"],
+    alwayslink = 1,
 )
 
 cc_library(
     name = "dav1d16",
-    srcs = glob(
-        [
-            "include/dav1d/*.h",
-            "include/common/*.h",
-            "src/*.c",
-            "src/x86/*.h",
-            "src/x86/*.c",
-            "src/*.h",
-        ],
-        exclude = [
-            "src/x86/msac_init.c",
-        ],
-    ) + select({
+    srcs = [
+        "include16/common/bitdepth.h",
+        "include16/common/dump.h",
+        "src/cdef_apply_tmpl.c",
+        "src/cdef_tmpl.c",
+        "src/fg_apply_tmpl.c",
+        "src/film_grain_tmpl.c",
+        "src/ipred_prepare_tmpl.c",
+        "src/ipred_tmpl.c",
+        "src/itx_tmpl.c",
+        "src/lf_apply_tmpl.c",
+        "src/loopfilter_tmpl.c",
+        "src/looprestoration_tmpl.c",
+        "src/lr_apply_tmpl.c",
+        "src/mc_tmpl.c",
+        "src/recon_tmpl.c",
+    ],
+    hdrs = [],
+    copts = [],
+    defines = [],
+    includes = [
+        "include16",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":source",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "source",
+    srcs = [
+        "include/common/bitdepth.h",
+        "src/cdf.c",
+        "src/cpu.c",
+        "src/data.c",
+        "src/decode.c",
+        "src/dequant_tables.c",
+        "src/getbits.c",
+        "src/intra_edge.c",
+        "src/itx_1d.c",
+        "src/lf_mask.c",
+        "src/lib.c",
+        "src/log.c",
+        "src/msac.c",
+        "src/obu.c",
+        "src/picture.c",
+        "src/qm.c",
+        "src/ref.c",
+        "src/ref_mvs.c",
+        "src/scan.c",
+        "src/tables.c",
+        "src/thread_task.c",
+        "src/warpmv.c",
+        "src/wedge.c",
+    ] + select({
         "@bazel_tools//src/conditions:windows": [
-            "include/compat/msvc/stdatomic.h",
             "src/win32/thread.c",
         ],
         "//conditions:default": [],
     }),
+    hdrs = [],
+    copts = [],
+    defines = [],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":header",
+    ],
+)
+
+cc_library(
+    name = "header",
+    srcs = [],
     hdrs = [
         "build/config.h",
         "build/vcs_version.h",
         "build/version.h",
-    ],
+        "include/common/attributes.h",
+        "include/common/intops.h",
+        "include/common/mem.h",
+        "include/common/validate.h",
+    ] + glob([
+        "include/dav1d/*.h",
+        "src/*.h",
+        "src/x86/*.h",
+    ]) + select({
+        "@bazel_tools//src/conditions:windows": [
+            "include/compat/msvc/stdatomic.h",
+        ],
+        "//conditions:default": [],
+    }),
     copts = [
         "-std=c99",
     ],
     defines = [
         "_FILE_OFFSET_BITS=64",
         "_GNU_SOURCE",
-        "BITDEPTH=16",
     ],
     includes = [
         "build",
@@ -106,6 +149,7 @@ cc_library(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
+    deps = [],
 )
 
 genrule(

--- a/third_party/libavif.BUILD
+++ b/third_party/libavif.BUILD
@@ -29,7 +29,8 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "@dav1d",
+        "@dav1d//:dav1d16",
+        "@dav1d//:dav1d8",
         "@libgav1",
     ],
 )


### PR DESCRIPTION
This PR updates third-party dav1d BUILD files so that `BITDEPTH` are definied separatedly
for 8 and 16 bits inside the header file. In the past `BITDEPTH` was defined in compiler options which generates lots of warnings.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>