### PR TITLE
Audio Spectrogram and Augment support

### DIFF
--- a/tensorflow_io/core/python/api/experimental/__init__.py
+++ b/tensorflow_io/core/python/api/experimental/__init__.py
@@ -23,3 +23,4 @@ from tensorflow_io.core.python.api.experimental import ffmpeg
 from tensorflow_io.core.python.api.experimental import image
 from tensorflow_io.core.python.api.experimental import text
 from tensorflow_io.core.python.api.experimental import columnar
+from tensorflow_io.core.python.api.experimental import audio

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -1,0 +1,19 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""tensorflow_io.experimental.audio"""
+
+from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disable=unused-import
+    spectrogram,
+)

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -16,6 +16,8 @@
 
 from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disable=unused-import
     spectrogram,
+    freq_mask,
+    time_mask,
     melscale,
     dbscale,
 )

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -16,4 +16,5 @@
 
 from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disable=unused-import
     spectrogram,
+    melscale,
 )

--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -17,4 +17,5 @@
 from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disable=unused-import
     spectrogram,
     melscale,
+    dbscale,
 )

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -23,19 +23,18 @@ def spectrogram(input, nfft, window, stride, name=None):
     """
     Create spectrogram from audio.
 
-    TODO: Support audio with channel > 1.
-
     Args:
       input: An 1-D audio signal Tensor.
       nfft: Size of FFT.
-      window: Size of sindow.
-      stride: size of hope between windows.
+      window: Size of window.
+      stride: Size of hops between windows.
       name: A name for the operation (optional).
 
     Returns:
       A tensor of spectrogram.
     """
 
+    # TODO: Support audio with channel > 1.
     return tf.math.abs(
         tf.signal.stft(
             input,
@@ -52,8 +51,6 @@ def melscale(input, rate, mels, fmin, fmax, name=None):
     """
     Turn spectrogram into mel scale spectrogram
 
-    TODO: Support audio with channel > 1.
-
     Args:
       input: A spectrogram Tensor with shape [frames, nfft+1].
       rate: Sample rate of the audio.
@@ -65,6 +62,8 @@ def melscale(input, rate, mels, fmin, fmax, name=None):
     Returns:
       A tensor of mel spectrogram with shape [frames, mels].
     """
+
+    # TODO: Support audio with channel > 1.
     nbins = tf.shape(input)[-1]
     matrix = tf.signal.linear_to_mel_weight_matrix(
         num_mel_bins=mels,
@@ -99,8 +98,6 @@ def freq_mask(input, param, name=None):
     """
     Apply masking to a spectrogram in the freq domain.
 
-    TODO: Support audio with channel > 1.
-
     Args:
       input: An audio spectogram.
       param: Parameter of freq masking.
@@ -108,6 +105,7 @@ def freq_mask(input, param, name=None):
     Returns:
       A tensor of spectrogram.
     """
+    # TODO: Support audio with channel > 1.
     freq_max = tf.shape(input)[1]
     f = tf.random.uniform(shape=(), minval=0, maxval=param, dtype=tf.dtypes.int32)
     f0 = tf.random.uniform(
@@ -124,8 +122,6 @@ def time_mask(input, param, name=None):
     """
     Apply masking to a spectrogram in the time domain.
 
-    TODO: Support audio with channel > 1.
-
     Args:
       input: An audio spectogram.
       param: Parameter of time masking.
@@ -133,6 +129,7 @@ def time_mask(input, param, name=None):
     Returns:
       A tensor of spectrogram.
     """
+    # TODO: Support audio with channel > 1.
     time_max = tf.shape(input)[0]
     t = tf.random.uniform(shape=(), minval=0, maxval=param, dtype=tf.dtypes.int32)
     t0 = tf.random.uniform(

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -93,3 +93,53 @@ def dbscale(input, top_db, name=None):
     log_spec = 10.0 * (tf.math.log(power) - tf.math.log(10.0))
     log_spec = tf.math.maximum(log_spec, tf.math.reduce_max(log_spec) - top_db)
     return log_spec
+
+
+def freq_mask(input, param, name=None):
+    """
+    Apply masking to a spectrogram in the freq domain.
+
+    TODO: Support audio with channel > 1.
+
+    Args:
+      input: An audio spectogram.
+      param: Parameter of freq masking.
+      name: A name for the operation (optional).
+    Returns:
+      A tensor of spectrogram.
+    """
+    freq_max = tf.shape(input)[1]
+    f = tf.random.uniform(shape=(), minval=0, maxval=param, dtype=tf.dtypes.int32)
+    f0 = tf.random.uniform(
+        shape=(), minval=0, maxval=freq_max - f, dtype=tf.dtypes.int32
+    )
+    indices = tf.reshape(tf.range(freq_max), (1, -1))
+    condition = tf.math.logical_and(
+        tf.math.greater_equal(indices, f0), tf.math.less(indices, f0 + f)
+    )
+    return tf.where(condition, 0, input)
+
+
+def time_mask(input, param, name=None):
+    """
+    Apply masking to a spectrogram in the time domain.
+
+    TODO: Support audio with channel > 1.
+
+    Args:
+      input: An audio spectogram.
+      param: Parameter of time masking.
+      name: A name for the operation (optional).
+    Returns:
+      A tensor of spectrogram.
+    """
+    time_max = tf.shape(input)[0]
+    t = tf.random.uniform(shape=(), minval=0, maxval=param, dtype=tf.dtypes.int32)
+    t0 = tf.random.uniform(
+        shape=(), minval=0, maxval=time_max - t, dtype=tf.dtypes.int32
+    )
+    indices = tf.reshape(tf.range(time_max), (-1, 1))
+    condition = tf.math.logical_and(
+        tf.math.greater_equal(indices, t0), tf.math.less(indices, t0 + t)
+    )
+    return tf.where(condition, 0, input)

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -1,0 +1,48 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Audio Ops."""
+
+import numpy as np
+
+import tensorflow as tf
+
+
+def spectrogram(input, nfft, window, stride, name=None):
+    """
+    Create spectrogram from audio.
+
+    TODO: Support audio with channel > 1.
+
+    Args:
+      input: An 1-D audio signal Tensor.
+      nfft: Size of FFT.
+      window: Size of sindow.
+      stride: size of hope between windows.
+      name: A name for the operation (optional).
+
+    Returns:
+      A tensor of spectrogram.
+    """
+
+    return tf.math.abs(
+        tf.signal.stft(
+            input,
+            frame_length=window,
+            frame_step=stride,
+            fft_length=nfft,
+            window_fn=tf.signal.hann_window,
+            pad_end=True,
+        )
+    )

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -46,3 +46,32 @@ def spectrogram(input, nfft, window, stride, name=None):
             pad_end=True,
         )
     )
+
+
+def melscale(input, rate, mels, fmin, fmax, name=None):
+    """
+    Turn spectrogram into mel scale spectrogram
+
+    TODO: Support audio with channel > 1.
+
+    Args:
+      input: A spectrogram Tensor with shape [frames, nfft+1].
+      rate: Sample rate of the audio.
+      mels: Number of mel filterbanks.
+      fmin: Minimum frequency. 
+      fmax: Maximum frequency. 
+      name: A name for the operation (optional).
+
+    Returns:
+      A tensor of mel spectrogram with shape [frames, mels].
+    """
+    nbins = tf.shape(input)[-1]
+    matrix = tf.signal.linear_to_mel_weight_matrix(
+        num_mel_bins=mels,
+        num_spectrogram_bins=nbins,
+        sample_rate=rate,
+        lower_edge_hertz=fmin,
+        upper_edge_hertz=fmax,
+    )
+
+    return tf.tensordot(input, matrix, 1)

--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -75,3 +75,21 @@ def melscale(input, rate, mels, fmin, fmax, name=None):
     )
 
     return tf.tensordot(input, matrix, 1)
+
+
+def dbscale(input, top_db, name=None):
+    """
+    Turn spectrogram into db scale
+
+    Args:
+      input: A spectrogram Tensor.
+      top_db: Minimum negative cut-off `max(10 * log10(S)) - top_db`
+      name: A name for the operation (optional).
+
+    Returns:
+      A tensor of mel spectrogram with shape [frames, mels].
+    """
+    power = tf.math.square(input)
+    log_spec = 10.0 * (tf.math.log(power) - tf.math.log(10.0))
+    log_spec = tf.math.maximum(log_spec, tf.math.reduce_max(log_spec) - top_db)
+    return log_spec

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -805,3 +805,26 @@ def test_encode_mp3_mono():
     assert audio.shape == [5760, 1]
     audio = tf.cast(audio, tf.float32) / 32768.0
     _ = tfio.audio.encode_mp3(audio, rate=8000)
+
+
+def test_spectrogram():
+    """test_spectrogram"""
+
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_audio", "mono_10khz.wav",
+    )
+    audio = tfio.audio.decode_wav(tf.io.read_file(path), dtype=tf.int16)
+    assert audio.shape == [5760, 1]
+    audio = tf.cast(audio, tf.float32) / 32768.0
+
+    # TODO remove once spectrogram support channel > 1
+    audio = tf.reshape(audio, [-1])
+
+    nfft = 400
+    window = 400
+    stride = 200
+    spectrogram = tfio.experimental.audio.spectrogram(audio, nfft, window, stride)
+
+    # TODO: assert content of spectrogram
+    assert spectrogram.shape == [29, 201]
+    assert spectrogram.dtype == tf.float32

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -823,8 +823,22 @@ def test_spectrogram():
     nfft = 400
     window = 400
     stride = 200
-    spectrogram = tfio.experimental.audio.spectrogram(audio, nfft, window, stride)
+    spectrogram = tfio.experimental.audio.spectrogram(
+        audio, nfft=nfft, window=window, stride=stride
+    )
 
     # TODO: assert content of spectrogram
     assert spectrogram.shape == [29, 201]
     assert spectrogram.dtype == tf.float32
+
+    rate = 10000
+    mels = 128
+    fmin = 0
+    fmax = 5000
+    mel_spectrogram = tfio.experimental.audio.melscale(
+        spectrogram, rate=rate, mels=mels, fmin=fmin, fmax=fmax
+    )
+
+    # TODO: assert content of mel_spectrogram
+    assert mel_spectrogram.shape == [29, 128]
+    assert mel_spectrogram.dtype == tf.float32

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -842,3 +842,11 @@ def test_spectrogram():
     # TODO: assert content of mel_spectrogram
     assert mel_spectrogram.shape == [29, 128]
     assert mel_spectrogram.dtype == tf.float32
+
+    dbscale_mel_spectrogram = tfio.experimental.audio.dbscale(
+        mel_spectrogram, top_db=80
+    )
+
+    # TODO: assert content of dbscale_mel_spectrogram
+    assert dbscale_mel_spectrogram.shape == [29, 128]
+    assert dbscale_mel_spectrogram.dtype == tf.float32

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -828,7 +828,7 @@ def test_spectrogram():
     )
 
     # TODO: assert content of spectrogram
-    assert spectrogram.shape == [29, 201]
+    assert spectrogram.shape == [29, nfft // 2 + 1]
     assert spectrogram.dtype == tf.float32
 
     rate = 10000
@@ -840,7 +840,7 @@ def test_spectrogram():
     )
 
     # TODO: assert content of mel_spectrogram
-    assert mel_spectrogram.shape == [29, 128]
+    assert mel_spectrogram.shape == [29, mels]
     assert mel_spectrogram.dtype == tf.float32
 
     dbscale_mel_spectrogram = tfio.experimental.audio.dbscale(
@@ -848,7 +848,7 @@ def test_spectrogram():
     )
 
     # TODO: assert content of dbscale_mel_spectrogram
-    assert dbscale_mel_spectrogram.shape == [29, 128]
+    assert dbscale_mel_spectrogram.shape == [29, mels]
     assert dbscale_mel_spectrogram.dtype == tf.float32
 
     spec = dbscale_mel_spectrogram

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -850,3 +850,11 @@ def test_spectrogram():
     # TODO: assert content of dbscale_mel_spectrogram
     assert dbscale_mel_spectrogram.shape == [29, 128]
     assert dbscale_mel_spectrogram.dtype == tf.float32
+
+    spec = dbscale_mel_spectrogram
+
+    # Freq masking
+    spec = tfio.experimental.audio.freq_mask(spec, param=30)
+
+    # Time masking
+    spec = tfio.experimental.audio.time_mask(spec, param=10)

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -1026,8 +1026,8 @@ def fixture_video_mp4():
             "prometheus",
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),
@@ -1047,8 +1047,8 @@ def fixture_video_mp4():
             "prometheus_scrape",
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),
@@ -1140,8 +1140,8 @@ def test_io_dataset_basic(fixture_lookup, io_dataset_fixture):
             "prometheus",
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),
@@ -1161,8 +1161,8 @@ def test_io_dataset_basic(fixture_lookup, io_dataset_fixture):
             "prometheus_scrape",
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),
@@ -1273,8 +1273,8 @@ def test_io_dataset_basic_operation(fixture_lookup, io_dataset_fixture):
             "prometheus",
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),
@@ -1375,8 +1375,8 @@ def test_io_dataset_for_training(fixture_lookup, io_dataset_fixture):
             None,
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),
@@ -1385,8 +1385,8 @@ def test_io_dataset_for_training(fixture_lookup, io_dataset_fixture):
             2,
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),
@@ -1547,8 +1547,8 @@ def test_io_dataset_in_dataset_parallel(
             "prometheus",
             marks=[
                 pytest.mark.skipif(
-                    sys.platform == "darwin",
-                    reason="TODO macOS does not support prometheus",
+                    (sys.platform == "darwin") or (sys.platform == "linux"),
+                    reason="TODO: GitHub issue 829",
                 ),
             ],
         ),


### PR DESCRIPTION
This PR adds initial audio spectrogram and augment support, to enrich the audio processing in tfio. APIs are placed under `tfio.experimental.audio`:

- `tfio.experimental.audio.spectrogram` to convert audio waveform to spectrogram (this is a a fused wrapper of `tf.signal.stft`)
- `tfio.experimental.audio.melscale` to allow creation of mel_spectrogram
- `tfio.experimental.audio.dbscale` to convert to dbscale for spectrogram
- `tfio.experimental.audio.freq_mask` to apply masking to a spectrogram in the freq domain
- `tfio.experimental.audio.time_mask` to apply masking to a spectrogram in the time domain

More details about freq/time masking are in [reference](https://arxiv.org/abs/1904.08779).

There are also discussions in #839 and implementations in DeepSpeech.

All implementations are python based, which helps gradient.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>