### PR TITLE
Add Fade support for audio ops

### DIFF
--- a/tensorflow_io/core/python/api/experimental/audio.py
+++ b/tensorflow_io/core/python/api/experimental/audio.py
@@ -16,8 +16,9 @@
 
 from tensorflow_io.core.python.experimental.audio_ops import (  # pylint: disable=unused-import
     spectrogram,
-    freq_mask,
-    time_mask,
     melscale,
     dbscale,
+    freq_mask,
+    time_mask,
+    fade,
 )

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -858,3 +858,32 @@ def test_spectrogram():
 
     # Time masking
     spec = tfio.experimental.audio.time_mask(spec, param=10)
+
+
+def test_fade():
+    """test_fade"""
+
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_audio", "mono_10khz.wav",
+    )
+    audio = tfio.audio.decode_wav(tf.io.read_file(path), dtype=tf.int16)
+    assert audio.shape == [5760, 1]
+    audio = tf.cast(audio, tf.float32) / 32768.0
+
+    audio = audio[2000:4000]
+
+    fade_in = 1000
+    fade_out = 1500
+    for mode in ["linear", "logarithmic", "exponential"]:
+        fade = tfio.experimental.audio.fade(
+            audio, fade_in=fade_in, fade_out=fade_out, mode=mode
+        )
+
+        # TODO: validate fade effect
+        # import matplotlib.pyplot as plt
+        # plt.figure()
+        # plt.plot(audio.numpy())
+        # plt.savefig("{}_data.png".format(mode))
+        # plt.figure()
+        # plt.plot(fade.numpy())
+        # plt.savefig("{}_fade.png".format(mode))


### PR DESCRIPTION
This PR adds `tfio.experimental.audio.fade` so that it is posible
to apply fade effect to audio signal.

Only `linear`, `logarithmic`, `exponential` shapes are supported.
Both logarithmic and exponential uses simple natural form. This could
be a starting point for future expansions.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>