### PR TITLE
Add 1-d audio support for tfio.audio.resample

### DIFF
--- a/tensorflow_io/core/python/ops/audio_ops.py
+++ b/tensorflow_io/core/python/ops/audio_ops.py
@@ -25,7 +25,8 @@ def resample(input, rate_in, rate_out, name=None):  # pylint: disable=redefined-
     """Resample audio.
 
     Args:
-      input: A 2-D `Tensor` of type `int16` or `float`. Audio input.
+      input: A 1-D (`[samples]`) or 2-D (`[samples, channels]`) `Tensor` of
+        type `int16` or `float`. Audio input.
       rate_in: The rate of the audio input.
       rate_out: The rate of the audio output.
       name: A name for the operation (optional).
@@ -33,8 +34,16 @@ def resample(input, rate_in, rate_out, name=None):  # pylint: disable=redefined-
     Returns:
       output: Resampled audio.
     """
-    return core_ops.io_audio_resample(
+    rank = tf.rank(input)
+
+    input = tf.cond(
+        tf.math.equal(rank, 1), lambda: tf.expand_dims(input, -1), lambda: input
+    )
+    value = core_ops.io_audio_resample(
         input, rate_in=rate_in, rate_out=rate_out, name=name
+    )
+    return tf.cond(
+        tf.math.equal(rank, 1), lambda: tf.squeeze(value, [-1]), lambda: value
     )
 
 

--- a/tests/test_audio_ops_eager.py
+++ b/tests/test_audio_ops_eager.py
@@ -31,9 +31,8 @@ def fixture_lookup_func(request):
     return _fixture_lookup
 
 
-@pytest.fixture(name="resample", scope="module")
-def fixture_resample():
-    """fixture_resample"""
+def fixture_resample_base():
+    """fixture_resample_base"""
     path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "test_audio",
@@ -57,6 +56,20 @@ def fixture_resample():
     expected = expected_value
 
     return args, func, expected
+
+
+@pytest.fixture(name="resample", scope="module")
+def fixture_resample():
+    """fixture_resample"""
+    args, func, expected = fixture_resample_base()
+    return args, func, expected
+
+
+@pytest.fixture(name="resample_1d", scope="module")
+def fixture_resample_1d():
+    """fixture_resample_1d"""
+    args, func, expected = fixture_resample_base()
+    return args[:, 0], func, expected[:, 0]
 
 
 @pytest.fixture(name="decode_wav", scope="module")
@@ -619,6 +632,7 @@ def fixture_encode_aac():
     ("io_data_fixture"),
     [
         pytest.param("resample"),
+        pytest.param("resample_1d"),
         pytest.param("decode_wav"),
         pytest.param("encode_wav"),
         pytest.param("decode_wav_u8"),
@@ -668,6 +682,7 @@ def fixture_encode_aac():
     ],
     ids=[
         "resample",
+        "resample[1d]",
         "decode_wav",
         "encode_wav",
         "decode_wav|u8",


### PR DESCRIPTION
This PR adds dd 1-d audio support for tfio.audio.resample
where audio is in the shape of `[samples]` instead of `[samples, channels]`.

This PR fixes #1006.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>