### PR TITLE
Removes namespace from parser keys

### DIFF
--- a/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
+++ b/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
@@ -401,7 +401,8 @@ class ParseAvroOp : public OpKernel {
                      errors::InvalidArgument("Avro schema error: ", error));
     }
 
-    OP_REQUIRES_OK(ctx, AvroParserTree::Build(&parser_tree_, CreateKeysAndTypes()));
+    OP_REQUIRES_OK(ctx,
+                   AvroParserTree::Build(&parser_tree_, CreateKeysAndTypes()));
   }
 
   void Compute(OpKernelContext* ctx) override {

--- a/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
+++ b/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
@@ -401,14 +401,7 @@ class ParseAvroOp : public OpKernel {
                      errors::InvalidArgument("Avro schema error: ", error));
     }
 
-    // Handle namespace
-    string avro_namespace(reader_schema_.root()->hasName()
-                              ? reader_schema_.root()->name().ns()
-                              : "");
-    VLOG(3) << "Retrieved namespace" << avro_namespace;
-
-    OP_REQUIRES_OK(ctx, AvroParserTree::Build(&parser_tree_, avro_namespace,
-                                              CreateKeysAndTypes()));
+    OP_REQUIRES_OK(ctx, AvroParserTree::Build(&parser_tree_, CreateKeysAndTypes()));
   }
 
   void Compute(OpKernelContext* ctx) override {

--- a/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
@@ -95,15 +95,8 @@ Status AvroFileStreamReader::OnWorkStartup() {
   reader_.reset(new avro::DataFileReader<avro::GenericDatum>(std::move(stream),
                                                              reader_schema_));
 
-  // Get the namespace
-  string avro_namespace(reader_schema_.root()->hasName()
-                            ? reader_schema_.root()->name().ns()
-                            : "");
-  VLOG(3) << "Retrieved namespace" << avro_namespace;
-
   // Create the parser tree
-  TF_RETURN_IF_ERROR(AvroParserTree::Build(&avro_parser_tree_, avro_namespace,
-                                           CreateKeysAndTypesFromConfig()));
+  TF_RETURN_IF_ERROR(AvroParserTree::Build(&avro_parser_tree_, CreateKeysAndTypesFromConfig()));
 
   return Status::OK();
 }

--- a/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
@@ -96,7 +96,8 @@ Status AvroFileStreamReader::OnWorkStartup() {
                                                              reader_schema_));
 
   // Create the parser tree
-  TF_RETURN_IF_ERROR(AvroParserTree::Build(&avro_parser_tree_, CreateKeysAndTypesFromConfig()));
+  TF_RETURN_IF_ERROR(AvroParserTree::Build(&avro_parser_tree_,
+                                           CreateKeysAndTypesFromConfig()));
 
   return Status::OK();
 }

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser.cc
@@ -524,7 +524,7 @@ string UnionParser::ToString(size_t level) const {
   return ss.str();
 }
 
-RootParser::RootParser() : AvroParser("") { }
+RootParser::RootParser() : AvroParser("") {}
 Status RootParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
                          const avro::GenericDatum& datum) const {
   const std::vector<AvroParserSharedPtr>& children(GetChildren());

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser.cc
@@ -524,21 +524,18 @@ string UnionParser::ToString(size_t level) const {
   return ss.str();
 }
 
-NamespaceParser::NamespaceParser(const string& name)
-    : AvroParser(""), name_(name) {}
-Status NamespaceParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                              const avro::GenericDatum& datum) const {
-  // TODO(fraudies): Check namespace match
+RootParser::RootParser() : AvroParser("") { }
+Status RootParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
+                         const avro::GenericDatum& datum) const {
   const std::vector<AvroParserSharedPtr>& children(GetChildren());
   for (const AvroParserSharedPtr& child : children) {
     TF_RETURN_IF_ERROR((*child).Parse(values, datum));
   }
   return Status::OK();
 }
-string NamespaceParser::ToString(size_t level) const {
+string RootParser::ToString(size_t level) const {
   std::stringstream ss;
-  ss << LevelToString(level) << "|---NamespaceParser(" << name_ << ")"
-     << std::endl;
+  ss << LevelToString(level) << "|---RootParser()" << std::endl;
   ss << ChildrenToString(level);
   return ss.str();
 }

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser.h
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser.h
@@ -282,12 +282,9 @@ class UnionParser : public AvroParser {
 };
 
 // Parses the namespace
-class NamespaceParser : public AvroParser {
+class RootParser : public AvroParser {
  public:
-  NamespaceParser(const string& name);
-  // checks namespace of value against given namespace
-  // - if matches passes avro value to all it's child parsers
-  // - if does not match returns error with actual and expected namespace
+  RootParser();
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
                const avro::GenericDatum& datum) const override;
   virtual string ToString(size_t level = 0) const;
@@ -295,9 +292,6 @@ class NamespaceParser : public AvroParser {
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_UNKNOWN};
   }
-
- private:
-  string name_;
 };
 
 }  // namespace data

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
@@ -24,9 +24,7 @@ namespace tensorflow {
 namespace data {
 
 /* static */ constexpr const char* const AvroParserTree::kArrayAllElements;
-/* static */ constexpr const char* const AvroParserTree::kDefaultNamespace;
 
-// TODO(fraudies): Change log level from INFO to DEBUG for most items
 Status AvroParserTree::ParseValues(
     std::map<string, ValueStoreUniquePtr>* key_to_value,
     const std::function<bool(avro::GenericDatum&)> read_value,
@@ -103,7 +101,6 @@ Status AvroParserTree::ParseValues(
 }
 
 Status AvroParserTree::Build(AvroParserTree* parser_tree,
-                             const string& avro_namespace,
                              const std::vector<KeyWithType>& keys_and_types) {
   // Check unique keys
   VLOG(7) << "Validate keys";
@@ -112,10 +109,7 @@ Status AvroParserTree::Build(AvroParserTree* parser_tree,
   // TODO: Validate filters etc, no nesting, no name conflict in shorthand
   // TODO: Check for nested filters and throw error, e.g. disallow
   // [name[first=last]age=friends.age]
-  // TODO(fraudies): Add to validation that lhs/rhs being a constant won't be
-  // possible lhs != rhs
-  const string& resolved_avro_namespace =
-      (*parser_tree).ResolveAndSetNamespace(avro_namespace);
+  // TODO(fraudies): Add to validation that lhs/rhs being a constant won't be possible lhs != rhs
 
   // Convert to internal names and order names to handle filters properly
   // through parse order
@@ -129,8 +123,7 @@ Status AvroParserTree::Build(AvroParserTree* parser_tree,
     VLOG(7) << "Add key prefix: " << key_and_type.first;
 
     // Built prefixes
-    std::vector<string> key_prefixes = GetPartsWithoutAvroNamespace(
-        key_and_type.first, resolved_avro_namespace);
+    std::vector<string> key_prefixes = GetParts(key_and_type.first);
     prefixes.push_back(key_prefixes);
 
     // Built map from key to type
@@ -138,7 +131,7 @@ Status AvroParserTree::Build(AvroParserTree* parser_tree,
   }
 
   VLOG(7) << "Build prefix tree";
-  OrderedPrefixTree prefix_tree(resolved_avro_namespace);
+  OrderedPrefixTree prefix_tree;
   OrderedPrefixTree::Build(&prefix_tree, prefixes);
 
   VLOG(7) << "Prefix tree\n" << prefix_tree.ToString();
@@ -147,7 +140,7 @@ Status AvroParserTree::Build(AvroParserTree* parser_tree,
 
   // Use the expected type to decide which value parser node to add
   (*parser_tree).root_ =
-      std::make_shared<NamespaceParser>(prefix_tree.GetRootPrefix());
+      std::make_shared<RootParser>();
 
   // Use the prefix tree to build the parser tree
   TF_RETURN_IF_ERROR((*parser_tree)
@@ -164,15 +157,6 @@ Status AvroParserTree::Build(AvroParserTree* parser_tree,
   return Status::OK();
 }
 
-string AvroParserTree::ResolveAndSetNamespace(const string& avro_namespace) {
-  if (avro_namespace.size() > 0) {
-    avro_namespace_ = avro_namespace;
-  } else {
-    avro_namespace_ = kDefaultNamespace;
-  }
-  return avro_namespace_;
-}
-
 Status AvroParserTree::Build(
     AvroParser* parent, const std::vector<PrefixTreeNodeSharedPtr>& children) {
   for (PrefixTreeNodeSharedPtr child : children) {
@@ -181,8 +165,7 @@ Status AvroParserTree::Build(
     AvroParserUniquePtr avro_parser(nullptr);
 
     // Create a parser and add it to the parent
-    const string& user_name(RemoveAddedDots(
-        RemoveDefaultAvroNamespace((*child).GetName(kSeparator))));
+    const string& user_name(RemoveAddedDots((*child).GetName(kSeparator)));
 
     TF_RETURN_IF_ERROR(
         CreateValueParser(avro_parser, (*child).GetPrefix(), user_name));
@@ -557,29 +540,13 @@ string AvroParserTree::ResolveFilterName(const string& user_name,
   }
 }
 
-std::vector<string> AvroParserTree::GetPartsWithoutAvroNamespace(
-    const string& user_name, const string& avro_namespace) {
+std::vector<string> AvroParserTree::GetParts(const string& user_name) {
   string name = user_name;
-  if (str_util::StartsWith(name, avro_namespace)) {
-    name = name.substr(avro_namespace.size() + 1,
-                       string::npos);  // +1 to remove separator
-  }
   RE2::GlobalReplace(&name, RE2("\\["), ".[");  // [ -> .[
   RE2::GlobalReplace(&name, RE2(":"), ".:");    // : -> .:
   std::vector<string> parts =
       SplitOnDelimiterButNotInsideSquareBrackets(name, kSeparator);
   return parts;
-}
-
-// Will remove the default avro namespace if it exists; otherwise the value
-// won't change
-string AvroParserTree::RemoveDefaultAvroNamespace(const string& name) {
-  if (str_util::StartsWith(name, kDefaultNamespace)) {
-    return name.substr(strlen(kDefaultNamespace) + 1,
-                       string::npos);  // +1 to remove separator
-  } else {
-    return name;
-  }
 }
 
 string AvroParserTree::RemoveAddedDots(const string& name) {

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
@@ -109,7 +109,8 @@ Status AvroParserTree::Build(AvroParserTree* parser_tree,
   // TODO: Validate filters etc, no nesting, no name conflict in shorthand
   // TODO: Check for nested filters and throw error, e.g. disallow
   // [name[first=last]age=friends.age]
-  // TODO(fraudies): Add to validation that lhs/rhs being a constant won't be possible lhs != rhs
+  // TODO(fraudies): Add to validation that lhs/rhs being a constant won't be
+  // possible lhs != rhs
 
   // Convert to internal names and order names to handle filters properly
   // through parse order
@@ -139,8 +140,7 @@ Status AvroParserTree::Build(AvroParserTree* parser_tree,
   (*parser_tree).keys_and_types_ = ordered_keys_and_types;
 
   // Use the expected type to decide which value parser node to add
-  (*parser_tree).root_ =
-      std::make_shared<RootParser>();
+  (*parser_tree).root_ = std::make_shared<RootParser>();
 
   // Use the prefix tree to build the parser tree
   TF_RETURN_IF_ERROR((*parser_tree)

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.h
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.h
@@ -60,7 +60,7 @@ class AvroParserTree {
  public:
   // Creates all parser nodes with the given namespace and for the given keys
   // with their types
-  static Status Build(AvroParserTree* parser_tree, const string& avro_namespace,
+  static Status Build(AvroParserTree* parser_tree,
                       const std::vector<KeyWithType>& keys_and_types);
 
   // Parses all values in a batch into the map keyed by the user-defined keys
@@ -73,9 +73,6 @@ class AvroParserTree {
   Status ParseValues(std::map<string, ValueStoreUniquePtr>* key_to_value,
                      const std::function<bool(avro::GenericDatum&)> read_value,
                      const avro::ValidSchema& reader_schema) const;
-
-  // Returns the namespace for this parser
-  inline string GetAvroNamespace() const { return avro_namespace_; }
 
   // Returns the root of the parser tree -- exposed for testing
   inline AvroParserSharedPtr getRoot() const { return root_; }
@@ -92,10 +89,6 @@ class AvroParserTree {
   // The constant for all element keys
   static constexpr const char* const kArrayAllElements = "[*]";
 
-  // The constant for the default namespace -- used when the user did not define
-  // a namespace
-  static constexpr const char* const kDefaultNamespace = "default";
-
   // Build the avro parser tree for the parent for the given children from a
   // prefix tree
   Status Build(AvroParser* parent,
@@ -104,11 +97,6 @@ class AvroParserTree {
   // Initialize will compute the final descendents for each node, called after
   // build
   void Initialize();
-
-  // Resolve and set namespace
-  // If no namespace has been provided aka avro_namespace = '', then this method
-  // resolves to the default namespace
-  string ResolveAndSetNamespace(const string& avro_namespace);
 
   // Creates the value parser for the given infix and user name
   // Note, that this method only creates value parsers for non-primitive avro
@@ -156,13 +144,8 @@ class AvroParserTree {
   static string ResolveFilterName(const string& user_name,
                                   const string& side_name,
                                   const string& filter_name);
-
-  // Get all parts of a user name without accounting for the avro namespace
-  static std::vector<string> GetPartsWithoutAvroNamespace(
-      const string& user_name, const string& avro_namespace);
-
-  // Removes the default avro namespace from the name -- if it is present
-  static string RemoveDefaultAvroNamespace(const string& name);
+  // Get all parts of a user name
+  static std::vector<string> GetParts(const string& user_name);
 
   // Removes additional dots that would not be part of the user name
   // These are the dots in front of the symbols `[` and `:`
@@ -200,14 +183,6 @@ class AvroParserTree {
   // Is this infix a branch? -- must be
   // [:boolean|:int|:long|:float|:double|:bytes|:string]
   static bool IsBranch(const string& infix);
-
-  // Is the given namespace the default namespace
-  static bool IsDefaultNamespace(const string& avro_namespace) {
-    return avro_namespace == kDefaultNamespace;
-  };
-
-  // The avro namespace
-  string avro_namespace_;
 
   // The parser root
   AvroParserSharedPtr root_;

--- a/tensorflow_io/core/kernels/avro/utils/prefix_tree.cc
+++ b/tensorflow_io/core/kernels/avro/utils/prefix_tree.cc
@@ -23,10 +23,15 @@ PrefixTreeNode::PrefixTreeNode(const std::string& prefix,
 std::string PrefixTreeNode::GetName(char separator) const {
   std::string name;
   name += prefix_;
-  PrefixTreeNode* father = father_;
-  while (father != nullptr) {
-    name = father->prefix_ + separator + name;
-    father = father->father_;
+  PrefixTreeNode* current = father_;
+  // Root has empty name
+  if (current == nullptr) {
+    return name;
+  }
+  // Exclude the root from the name
+  while (current->father_ != nullptr) {
+    name = current->prefix_ + separator + name;
+    current = current->father_;
   }
   return name;
 }
@@ -73,8 +78,9 @@ std::string PrefixTreeNode::ToString(int level) const {
 // -------------------------------------------------------------------------------------------------
 // Ordered prefix tree
 // -------------------------------------------------------------------------------------------------
-OrderedPrefixTree::OrderedPrefixTree(const std::string& root_name)
-    : root_(new PrefixTreeNode(root_name)) {}
+// Note, the root always has an empty name, it's a placeholder to simplify the code
+OrderedPrefixTree::OrderedPrefixTree()
+  : root_(new PrefixTreeNode("")) { }
 
 void OrderedPrefixTree::Insert(const std::vector<std::string>& prefixes) {
   PrefixTreeNodeSharedPtr node = root_;
@@ -99,21 +105,6 @@ PrefixTreeNodeSharedPtr OrderedPrefixTree::FindNearest(
   *remaining = prefixes;
   // If the root has a prefix
   auto prefix = (*remaining).begin();
-  if ((*root_).HasPrefix()) {
-    // If we dont have any prefixes then we can't match the root
-    if (prefix == (*remaining).end()) {
-      return nullptr;
-    } else {
-      std::string root_prefix(GetRootPrefix());
-      // If the root prefix does not match we can't find the node
-      if (root_prefix.compare(*prefix) != 0) {
-        return nullptr;
-      }
-      // We matched
-      prefix = (*remaining).erase(prefix);
-    }
-  }
-
   PrefixTreeNodeSharedPtr node(root_);
   PrefixTreeNodeSharedPtr next_node;
   // We don't have a root with prefix, then start with the children

--- a/tensorflow_io/core/kernels/avro/utils/prefix_tree.cc
+++ b/tensorflow_io/core/kernels/avro/utils/prefix_tree.cc
@@ -78,9 +78,9 @@ std::string PrefixTreeNode::ToString(int level) const {
 // -------------------------------------------------------------------------------------------------
 // Ordered prefix tree
 // -------------------------------------------------------------------------------------------------
-// Note, the root always has an empty name, it's a placeholder to simplify the code
-OrderedPrefixTree::OrderedPrefixTree()
-  : root_(new PrefixTreeNode("")) { }
+// Note, the root always has an empty name, it's a placeholder to simplify the
+// code
+OrderedPrefixTree::OrderedPrefixTree() : root_(new PrefixTreeNode("")) {}
 
 void OrderedPrefixTree::Insert(const std::vector<std::string>& prefixes) {
   PrefixTreeNodeSharedPtr node = root_;

--- a/tensorflow_io/core/kernels/avro/utils/prefix_tree.h
+++ b/tensorflow_io/core/kernels/avro/utils/prefix_tree.h
@@ -39,13 +39,11 @@ class PrefixTreeNode {
   inline std::string GetPrefix() const { return prefix_; };
 
   // Get's the full name using the separator between prefix names of tree nodes
+  // Note, that this excludes the root node which is an auxiliary node
   std::string GetName(char separator) const;
 
   // Is terminal if this node has no children
   inline bool IsTerminal() const { return children_.size() == 0; }
-
-  // A prefix exists if it is not the empty string
-  bool HasPrefix() const { return prefix_.size() > 0; }
 
   // Find the prefix tree for the given child prefix
   PrefixTreeNodeSharedPtr Find(const std::string& child_prefix) const;
@@ -60,7 +58,7 @@ class PrefixTreeNode {
   // The prefix for this tree node
   std::string prefix_;
 
-  // The father of this tree node -- always exists
+  // The father of this tree node -- always exists in memory
   PrefixTreeNode* father_;
 
   // The children of this prefix tree node
@@ -72,10 +70,7 @@ class PrefixTreeNode {
 class OrderedPrefixTree {
  public:
   // Construct a prefix tree with the optional root_name
-  OrderedPrefixTree(const std::string& root_name = "");
-
-  // Get the root prefix
-  inline std::string GetRootPrefix() const { return (*root_).GetPrefix(); }
+  OrderedPrefixTree();
 
   // Get the root of the prefix tree
   inline PrefixTreeNodeSharedPtr GetRoot() const { return root_; }

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -2177,7 +2177,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
             batch_size=2,
         )
 
-    #@pytest.mark.skipif(sys.platform == "darwin", reason="macOS fails now")
+    # @pytest.mark.skipif(sys.platform == "darwin", reason="macOS fails now")
     def test_ignore_namespace(self):
         """test_namespace"""
         reader_schema = """
@@ -2192,9 +2192,7 @@ class AvroDatasetTest(AvroDatasetTestBase):
                 }
             ]
           }"""
-        features = {
-            "string_value": tf.io.FixedLenFeature([], tf.dtypes.string)
-        }
+        features = {"string_value": tf.io.FixedLenFeature([], tf.dtypes.string)}
         record_data = [{"string_value": "a"}, {"string_value": "bb"}]
         expected_data = [
             {

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -2177,8 +2177,8 @@ class AvroDatasetTest(AvroDatasetTestBase):
             batch_size=2,
         )
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="macOS fails now")
-    def test_namespace(self):
+    #@pytest.mark.skipif(sys.platform == "darwin", reason="macOS fails now")
+    def test_ignore_namespace(self):
         """test_namespace"""
         reader_schema = """
           {
@@ -2193,12 +2193,12 @@ class AvroDatasetTest(AvroDatasetTestBase):
             ]
           }"""
         features = {
-            "com.test.string_value": tf.io.FixedLenFeature([], tf.dtypes.string)
+            "string_value": tf.io.FixedLenFeature([], tf.dtypes.string)
         }
         record_data = [{"string_value": "a"}, {"string_value": "bb"}]
         expected_data = [
             {
-                "com.test.string_value": tf.convert_to_tensor(
+                "string_value": tf.convert_to_tensor(
                     [tf.compat.as_bytes("a"), tf.compat.as_bytes("bb")]
                 )
             }


### PR DESCRIPTION
Why?
Namespace is only a concept that is used during link resolution and inside the schema registry to load record types through their fully qualified name. At the time of parsing this resolution has happened and we only deal with a single schema and their fields. In this case the namespace should be irrelevant.

What?
- Remove the namespace from the parser keys
- Replace namespace parser node through a root parser node
- Simplify the prefix tree and ordered prefix tree by always setting the root prefix to ""
- Simplify the avro parser tree by removing the concept of namespace
- Adjusting a test case that shows that the namespace is ignored

This change is made by @fraudies in our internal fork and backported here. 