### PR TITLE
Disable swapoff to avoid GitHub CI issue

### DIFF
--- a/.github/workflows/build.space.sh
+++ b/.github/workflows/build.space.sh
@@ -1,6 +1,7 @@
 # Free disk space on Linux
-        sudo swapoff /swapfile
-        sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        #sudo swapoff /swapfile
+        #sudo rm -rf /swapfile
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
         sudo apt-get remove php* ruby-* subversion mongodb-org -yq >/dev/null 2>&1
         sudo apt-get autoremove -y >/dev/null 2>&1
         sudo apt-get autoclean -y >/dev/null 2>&1


### PR DESCRIPTION
It looks like swapfile is not in GitHub CI anymore (or in somewhere else
than /swapfile). This PR disables swapoff to avoid build failures.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>