### PR TITLE
Apply clang check in github CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
           sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          bazel run -s --verbose_failures //tools/lint:check -- bazel pyupgrade black
+          bazel run -s --verbose_failures //tools/lint:check -- bazel pyupgrade black clang
 
   macos:
     name: macOS


### PR DESCRIPTION
After the clang reformatting across the codebase(https://github.com/tensorflow/io/pull/1011), we can enforce clang check in github CI so every future PR will be clang-checked.

Run `bazel run -s --verbose_failures //tools/lint:check -- bazel clang` with pre-formatting codebase and it failed:

```
(base) ➜  io git:(7c7d56d) ✗ bazel run -s --verbose_failures //tools/lint:check -- bazel  clang
WARNING: /Users/chren/linkedin/work/tensorflow_io_oss/io/tools/lint/BUILD:28:1: target 'pyupgrade' is both a rule and a file; please choose another name for the rule
WARNING: /Users/chren/linkedin/work/tensorflow_io_oss/io/tools/lint/BUILD:54:1: target 'black' is both a rule and a file; please choose another name for the rule
INFO: Analyzed target //tools/lint:check (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tools/lint:check up-to-date:
  bazel-bin/tools/lint/check.bash
INFO: Elapsed time: 0.168s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
check:  bazel clang
check:  bazel
check:  clang
Selected: Bazel=true Black=no Clang=true Pyupgrade=no [Entries]: all
mode: check
black: /private/var/tmp/_bazel_chren/9ff8017297efcf2f0990cbc6f13405f7/execroot/org_tensorflow_io/bazel-out/host/bin/tools/lint/black
buildifier: /private/var/tmp/_bazel_chren/9ff8017297efcf2f0990cbc6f13405f7/execroot/org_tensorflow_io/bazel-out/host/bin/external/com_github_bazelbuild_buildtools/buildifier/darwin_amd64_stripped/buildifier
clang-format: /private/var/tmp/_bazel_chren/9ff8017297efcf2f0990cbc6f13405f7/execroot/org_tensorflow_io/bazel-out/host/bin/tools/lint/clang-format
pyupgrade: /private/var/tmp/_bazel_chren/9ff8017297efcf2f0990cbc6f13405f7/execroot/org_tensorflow_io/bazel-out/host/bin/tools/lint/pyupgrade
Run Bazel Buildifier
check ./tools/lint/BUILD
check ./tools/lint/defs.bzl
check ./tools/build/swift/BUILD
check ./tools/build/tensorflow_io.bzl
check ./WORKSPACE
check ./tensorflow_io/core/kernels/avro/utils/BUILD
check ./tensorflow_io/core/grpc/BUILD
check ./tensorflow_io/core/BUILD
check ./tensorflow_io/ignite/BUILD
check ./tensorflow_io/arrow/BUILD
check ./tensorflow_io/bigquery/BUILD
check ./tensorflow_io/BUILD
check ./tensorflow_io/gcs/BUILD
check ./third_party/libtiff.BUILD
check ./third_party/uuid.BUILD
check ./third_party/zlib.BUILD
check ./third_party/hdf5.BUILD
check ./third_party/libapr1.BUILD
check ./third_party/dcmtk.BUILD
check ./third_party/freetype.BUILD
check ./third_party/fmjpeg2koj.BUILD
check ./third_party/sqlite.BUILD
check ./third_party/dav1d.BUILD
check ./third_party/mxml.BUILD
check ./third_party/lz4.BUILD
check ./third_party/lmdb.BUILD
check ./third_party/ffmpeg_2_8.BUILD
check ./third_party/minimp4.BUILD
check ./third_party/vorbis.BUILD
check ./third_party/libaprutil1.BUILD
check ./third_party/minimp3.BUILD
check ./third_party/avro.BUILD
check ./third_party/kafka.BUILD
check ./third_party/nucleus.BUILD
check ./third_party/ogg.BUILD
check ./third_party/easyexif.BUILD
check ./third_party/aws-c-event-stream.BUILD
check ./third_party/openexr.BUILD
check ./third_party/libgeotiff.BUILD
check ./third_party/zstd.BUILD
check ./third_party/libjpeg_turbo.BUILD
check ./third_party/libpng.BUILD
check ./third_party/arrow.BUILD
check ./third_party/libwebp.BUILD
check ./third_party/postgresql.BUILD
check ./third_party/speexdsp.BUILD
check ./third_party/aws-checksums.BUILD
check ./third_party/thrift.BUILD
check ./third_party/htslib.BUILD
check ./third_party/rapidjson.BUILD
check ./third_party/aws-c-common.BUILD
check ./third_party/flac.BUILD
check ./third_party/libarchive.BUILD
check ./third_party/libavif.BUILD
check ./third_party/oss_c_sdk.BUILD
check ./third_party/azure.BUILD
check ./third_party/BUILD
check ./third_party/libgav1.BUILD
check ./third_party/stb.BUILD
check ./third_party/boost.BUILD
check ./third_party/snappy.BUILD
check ./third_party/brotli.BUILD
check ./third_party/libexpat.BUILD
check ./third_party/bzip2.BUILD
check ./third_party/xz.BUILD
check ./third_party/openjpeg.BUILD
check ./third_party/toolchains/gpu/crosstool/BUILD
check ./third_party/toolchains/gpu/cuda/BUILD
check ./third_party/toolchains/gpu/cuda_configure.bzl
check ./third_party/toolchains/gpu/BUILD
check ./third_party/toolchains/gcc7_manylinux2010-nvcc-cuda10.1/BUILD
check ./third_party/toolchains/gcc7_manylinux2010-nvcc-cuda10.1/cc_toolchain_config.bzl
check ./third_party/toolchains/gcc7_manylinux2010/WORKSPACE
check ./third_party/toolchains/gcc7_manylinux2010/dummy_toolchain.bzl
check ./third_party/toolchains/gcc7_manylinux2010/BUILD
check ./third_party/toolchains/gcc7_manylinux2010/cc_toolchain_config.bzl
check ./third_party/toolchains/tf/tf_configure.bzl
check ./third_party/toolchains/tf/BUILD
check ./third_party/libyuv.BUILD
check ./third_party/proj.BUILD
check ./third_party/ffmpeg_3_4.BUILD
check ./third_party/jsoncpp.BUILD
check ./third_party/aws-sdk-cpp.BUILD
check ./third_party/curl.BUILD
check ./BUILD.bazel
Run Clang Format
check tensorflow_io/core/kernels/image_pnm_kernels.cc
check tensorflow_io/core/kernels/kinesis_kernels.cc
--- /dev/fd/63	2020-06-25 17:37:24.000000000 -0700
+++ /dev/fd/62	2020-06-25 17:37:24.000000000 -0700
@@ -13,12 +13,6 @@
 limitations under the License.
 ==============================================================================*/

-#include "tensorflow/core/framework/resource_mgr.h"
-#include "tensorflow/core/framework/resource_op_kernel.h"
-
-#include <openssl/hmac.h>
-#include <openssl/sha.h>
-
 #include <aws/core/Aws.h>
 #include <aws/core/config/AWSProfileConfigLoader.h>
 #include <aws/core/utils/Outcome.h>
@@ -32,6 +26,11 @@
 #include <aws/kinesis/model/GetShardIteratorRequest.h>
 #include <aws/kinesis/model/PutRecordsRequest.h>
 #include <aws/kinesis/model/ShardIteratorType.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/resource_op_kernel.h"

 namespace tensorflow {
 namespace data {
```