### PR TITLE
Change `pip install tensorflow-io-nightly` to `pip install tensorflow-io`

### DIFF
--- a/docs/tutorials/audio.ipynb
+++ b/docs/tutorials/audio.ipynb
@@ -138,7 +138,7 @@
         "colab": {}
       },
       "source": [
-        "!pip install tensorflow-io-nightly"
+        "!pip install tensorflow-io"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Change `pip install tensorflow-io-nightly` to `pip install tensorflow-io`,
as the new version has been released so nightly build is not needed anymore.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>