### PR TITLE
Add null handling by consuming default

### DIFF
--- a/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
+++ b/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
@@ -126,13 +126,12 @@ int ResolveDefaultShape(TensorShape* resolved,
 }
 
 std::map<string, Tensor> CreateTensorDefaults(const AvroParserConfig& config) {
-    std::map<string, Tensor> defaults;
-    for (const AvroParserConfig::Dense& dense : config.dense) {
-        defaults[dense.feature_name] = dense.default_value;
-    }
-    return defaults;
+  std::map<string, Tensor> defaults;
+  for (const AvroParserConfig::Dense& dense : config.dense) {
+    defaults[dense.feature_name] = dense.default_value;
+  }
+  return defaults;
 }
-
 
 class StringDatumRangeReader {
  public:
@@ -247,8 +246,8 @@ Status ParseAvro(const AvroParserConfig& config,
       return range_reader.read(d);
     };
 
-    status_of_minibatch[minibatch] =
-        parser_tree.ParseValues(&buffers[minibatch], read_value, reader_schema, defaults);
+    status_of_minibatch[minibatch] = parser_tree.ParseValues(
+        &buffers[minibatch], read_value, reader_schema, defaults);
   };
 
   ParallelFor(ProcessMiniBatch, num_minibatches, thread_pool);

--- a/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
+++ b/tensorflow_io/core/kernels/avro/parse_avro_kernels.cc
@@ -125,6 +125,15 @@ int ResolveDefaultShape(TensorShape* resolved,
   return full_shape.AsTensorShape(resolved);
 }
 
+std::map<string, Tensor> CreateTensorDefaults(const AvroParserConfig& config) {
+    std::map<string, Tensor> defaults;
+    for (const AvroParserConfig::Dense& dense : config.dense) {
+        defaults[dense.feature_name] = dense.default_value;
+    }
+    return defaults;
+}
+
+
 class StringDatumRangeReader {
  public:
   StringDatumRangeReader(const gtl::ArraySlice<tstring>& serialized,
@@ -228,6 +237,8 @@ Status ParseAvro(const AvroParserConfig& config,
 
   std::vector<Status> status_of_minibatch(num_minibatches);
 
+  const std::map<string, Tensor>& defaults = CreateTensorDefaults(config);
+
   auto ProcessMiniBatch = [&](size_t minibatch) {
     size_t start = first_of_minibatch(minibatch);
     size_t end = first_of_minibatch(minibatch + 1);
@@ -237,7 +248,7 @@ Status ParseAvro(const AvroParserConfig& config,
     };
 
     status_of_minibatch[minibatch] =
-        parser_tree.ParseValues(&buffers[minibatch], read_value, reader_schema);
+        parser_tree.ParseValues(&buffers[minibatch], read_value, reader_schema, defaults);
   };
 
   ParallelFor(ProcessMiniBatch, num_minibatches, thread_pool);

--- a/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
@@ -65,8 +65,6 @@ class AvroDataInputStream : public avro::InputStream {
 
 }  // namespace
 
-
-
 namespace tensorflow {
 namespace data {
 
@@ -105,11 +103,11 @@ Status AvroFileStreamReader::OnWorkStartup() {
 }
 
 std::map<string, Tensor> CreateTensorDefaults(const AvroParseConfig& config) {
-    std::map<string, Tensor> defaults;
-    for (const AvroParseConfig::Dense& dense : config.dense) {
-        defaults[dense.feature_name] = dense.default_value;
-    }
-    return defaults;
+  std::map<string, Tensor> defaults;
+  for (const AvroParseConfig::Dense& dense : config.dense) {
+    defaults[dense.feature_name] = dense.default_value;
+  }
+  return defaults;
 }
 
 Status AvroFileStreamReader::Read(AvroResult* result) {

--- a/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_file_stream_reader.cc
@@ -65,6 +65,8 @@ class AvroDataInputStream : public avro::InputStream {
 
 }  // namespace
 
+
+
 namespace tensorflow {
 namespace data {
 
@@ -102,14 +104,23 @@ Status AvroFileStreamReader::OnWorkStartup() {
   return Status::OK();
 }
 
+std::map<string, Tensor> CreateTensorDefaults(const AvroParseConfig& config) {
+    std::map<string, Tensor> defaults;
+    for (const AvroParseConfig::Dense& dense : config.dense) {
+        defaults[dense.feature_name] = dense.default_value;
+    }
+    return defaults;
+}
+
 Status AvroFileStreamReader::Read(AvroResult* result) {
   std::map<string, ValueStoreUniquePtr> key_to_value;
+  const std::map<string, Tensor>& defaults = CreateTensorDefaults(config_);
 
   auto read_value = [&](avro::GenericDatum& d) { return reader_->read(d); };
   uint64 batch_size = 0;
   TF_RETURN_IF_ERROR(
       avro_parser_tree_.ParseValues(&key_to_value, read_value, reader_schema_,
-                                    config_.batch_size, &batch_size));
+                                    config_.batch_size, &batch_size, defaults));
   VLOG(5) << "Read and parsed " << batch_size << " elements";
 
   // Drop reminder if batch size is not the requested batch size

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser.cc
@@ -68,123 +68,154 @@ string AvroParser::LevelToString(size_t level) const {
   return ss.str();
 }
 
-string AvroParser::SupportedTypesToString(char separator) const {
-  std::stringstream ss;
-  for (avro::Type t : GetSupportedTypes()) {
-    ss << toString(t) << separator << " ";
-  }
-  const string supported_types = ss.str();
-  // strip off the last 2 chars from string
-  return supported_types.substr(0, supported_types.size() - 2);
-}
+// Null will only resolve if
+// -- the null appears in a union with a primitive type -- by construction (otherwise no default)
+// -- the user supplied a scalar default tensor
+// -- the user supplied a type that matches the primitive type
+// For sparse tensors will null entries in their values or indices
+// this will fail which is the correct behavior.
+Status CheckValidDefault(const string& key,
+  const std::map<string, Tensor>& defaults,
+  DataType expected) {
 
-// ------------------------------------------------------------
-// Concrete implementations of avro value parsers
-// ------------------------------------------------------------
-/*
-NullValueParser::NullValueParser(const string& key) : AvroParser(key) { }
-Status NullValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                          const avro_value_t& value) const {
-  // Do nothing, means default will be used for dense tensors and for sparse
-  // tensors no entry is created
+  if (defaults.find(key) == defaults.end()) {
+    return errors::InvalidArgument("For key '", key,
+      "' cannot find a default value.");
+  }
+  const Tensor& default_value = defaults.at(key);
+  if (!TensorShapeUtils::IsScalar(default_value.shape())) {
+    return errors::InvalidArgument("For key '", key,
+      "' expected scalar default but got tensor with shape ", default_value.shape());
+  }
+  if (expected != default_value.dtype()) {
+    return errors::InvalidArgument("For key '", key,
+      "' expected data type ", expected, "' but got data type '", default_value.dtype(), "'.");
+  }
   return Status::OK();
 }
-string NullValueParser::ToString(size_t level) const {
-  return LevelToString(level) + "|---NullValue(" + key_ + ")\n";
-}
-*/
+
+
+// This implementation assumes there is at least one expected type
+string TypeErrorMessage(const std::set<avro::Type>& expected, avro::Type actual) {
+  string message = "";
+  for (avro::Type t : expected) {
+    message += ", '" + toString(t) + "'";
+  }
+  // Remove 2 for leading comma and blank -- here we assume there is at least one
+  return "Expected types: " + message.substr(2) + " but got type " + toString(actual) + ".";
+ }
 
 BoolValueParser::BoolValueParser(const string& key) : AvroParser(key) {}
 Status BoolValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                              const avro::GenericDatum& datum) const {
-  if (datum.type() != avro::AVRO_BOOL) {
-    return errors::InvalidArgument("Expected type '", toString(avro::AVRO_BOOL),
-                                   "' but got type '", toString(datum.type()),
-                                   "'.");
+                              const avro::GenericDatum& datum,
+                              const std::map<string, Tensor>& defaults) const {
+
+  bool value;
+  if (datum.type() == avro::AVRO_BOOL) {
+    value = datum.value<bool>();
+  } else if (datum.type() == avro::AVRO_NULL) {
+    TF_RETURN_IF_ERROR(CheckValidDefault(key_, defaults, DT_BOOL));
+    value = defaults.at(key_).flat<bool>()(0);
+  } else {
+    return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
 
-  // Assumes the key exists
-  (*reinterpret_cast<BoolValueBuffer*>((*values)[key_].get()))
-      .Add(datum.value<bool>());
-
+(*reinterpret_cast<BoolValueBuffer*>((*values).at(key_).get())).Add(value);
   return Status::OK();
 }
 string BoolValueParser::ToString(size_t level) const {
   return LevelToString(level) + "|---BoolValue(" + key_ + ")\n";
 }
 
-LongValueParser::LongValueParser(const string& key) : AvroParser(key) {}
-Status LongValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                              const avro::GenericDatum& datum) const {
-  if (datum.type() != avro::AVRO_LONG) {
-    return errors::InvalidArgument("Expected type '", toString(avro::AVRO_LONG),
-                                   "' but got type '", toString(datum.type()),
-                                   "'.");
+ LongValueParser::LongValueParser(const string& key) : AvroParser(key) { }
+ Status LongValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
+  const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const {
+
+  long value;
+  if (datum.type() == avro::AVRO_LONG) {
+    value = datum.value<long>();
+  } else if (datum.type() == avro::AVRO_NULL) {
+    TF_RETURN_IF_ERROR(CheckValidDefault(key_, defaults, DT_INT64));
+    value = defaults.at(key_).flat<int64>()(0);
+  } else {
+    return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
 
   // Assume the key exists and cast is possible
-  (*reinterpret_cast<LongValueBuffer*>((*values)[key_].get()))
-      .Add(datum.value<long>());
+  (*reinterpret_cast<LongValueBuffer*>((*values).at(key_).get())).Add(value);
 
-  return Status::OK();
-}
+   return Status::OK();
+ }
+
 string LongValueParser::ToString(size_t level) const {
   return LevelToString(level) + "|---LongValue(" + key_ + ")\n";
 }
 
 IntValueParser::IntValueParser(const string& key) : AvroParser(key) {}
-Status IntValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                             const avro::GenericDatum& datum) const {
-  if (datum.type() != avro::AVRO_INT) {
-    return errors::InvalidArgument("Expected type '", toString(avro::AVRO_INT),
-                                   "' but got type '", toString(datum.type()),
-                                   "'.");
+ Status IntValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
+  const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const {
+
+  int value;
+  if (datum.type() == avro::AVRO_INT) {
+    value = datum.value<int>();
+  } else if (datum.type() == avro::AVRO_NULL) {
+    TF_RETURN_IF_ERROR(CheckValidDefault(key_, defaults, DT_INT32));
+    value = defaults.at(key_).flat<int32>()(0);
+  } else {
+    return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
-
   // Assume the key exists and cast is possible
-  (*reinterpret_cast<IntValueBuffer*>((*values)[key_].get()))
-      .Add(datum.value<int>());
+  (*reinterpret_cast<IntValueBuffer*>((*values).at(key_).get())).Add(value);
 
-  return Status::OK();
-}
+   return Status::OK();
+ }
+
 string IntValueParser::ToString(size_t level) const {
   return LevelToString(level) + "|---IntValue(" + key_ + ")\n";
 }
 
 DoubleValueParser::DoubleValueParser(const string& key) : AvroParser(key) {}
-Status DoubleValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                                const avro::GenericDatum& datum) const {
-  if (datum.type() != avro::AVRO_DOUBLE) {
-    return errors::InvalidArgument(
-        "Expected type '", toString(avro::AVRO_DOUBLE), "' but got type '",
-        toString(datum.type()), "'.");
+ Status DoubleValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
+  const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const {
+
+  double value;
+  if (datum.type() == avro::AVRO_DOUBLE) {
+    value = datum.value<double>();
+  } else if (datum.type() == avro::AVRO_NULL) {
+    TF_RETURN_IF_ERROR(CheckValidDefault(key_, defaults, DT_DOUBLE));
+    value = defaults.at(key_).flat<double>()(0);
+  } else {
+    return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
-
   // Assume the key exists and cast is possible
-  (*reinterpret_cast<DoubleValueBuffer*>((*values)[key_].get()))
-      .Add(datum.value<double>());
+  (*reinterpret_cast<DoubleValueBuffer*>((*values)[key_].get())).Add(value);
 
-  return Status::OK();
-}
+   return Status::OK();
+ }
+
 string DoubleValueParser::ToString(size_t level) const {
   return LevelToString(level) + "|---DoubleValue(" + key_ + ")\n";
 }
 
 FloatValueParser::FloatValueParser(const string& key) : AvroParser(key) {}
 Status FloatValueParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                               const avro::GenericDatum& datum) const {
-  if (datum.type() != avro::AVRO_FLOAT) {
-    return errors::InvalidArgument(
-        "Expected type '", toString(avro::AVRO_FLOAT), "' but got type '",
-        toString(datum.type()), "'.");
+  const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const {
+
+  float value;
+  if (datum.type() == avro::AVRO_FLOAT) {
+    value = datum.value<float>();
+  } else if (datum.type() == avro::AVRO_NULL) {
+    TF_RETURN_IF_ERROR(CheckValidDefault(key_, defaults, DT_FLOAT));
+    value = defaults.at(key_).flat<float>()(0);
+  } else {
+    return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
-
   // Assume the key exists and cast is possible
-  (*reinterpret_cast<FloatValueBuffer*>((*values)[key_].get()))
-      .Add(datum.value<float>());
+  (*reinterpret_cast<FloatValueBuffer*>((*values)[key_].get())).Add(value);
 
-  return Status::OK();
-}
+   return Status::OK();
+ }
+
 string FloatValueParser::ToString(size_t level) const {
   return LevelToString(level) + "|---FloatValue(" + key_ + ")\n";
 }
@@ -194,40 +225,47 @@ StringBytesEnumFixedValueParser::StringBytesEnumFixedValueParser(
     : AvroParser(key) {}
 Status StringBytesEnumFixedValueParser::Parse(
     std::map<string, ValueStoreUniquePtr>* values,
-    const avro::GenericDatum& datum) const {
-  string v;
-  switch (datum.type()) {
-    case avro::AVRO_STRING:
-      v = datum.value<string>();
-      break;
-    case avro::AVRO_BYTES: {
-      const std::vector<uint8_t>& value = datum.value<std::vector<uint8_t>>();
-      if (value.size() > 0) {
-        v.resize(value.size());
-        memcpy(&v[0], &value[0], value.size());
-      }
-    } break;
-    case avro::AVRO_ENUM:
-      v = datum.value<avro::GenericEnum>().symbol();
-      break;
-    case avro::AVRO_FIXED: {
-      const std::vector<uint8_t>& value =
-          datum.value<avro::GenericFixed>().value();
-      if (value.size() > 0) {
-        v.resize(value.size());
-        memcpy(&v[0], &value[0], value.size());
-      }
-    } break;
-    default:
-      return errors::Internal("Expected one of these types ",
-                              SupportedTypesToString(','), " but got type '",
-                              datum.type(), "'.");
-  }
+    const avro::GenericDatum& datum,
+    const std::map<string, Tensor>& defaults) const {
 
-  // Assume the key exists and cast is possible
-  (*reinterpret_cast<StringValueBuffer*>((*values)[key_].get())).AddByRef(v);
+ string value;
+ switch (datum.type()) {
+   case avro::AVRO_STRING:
+     value = datum.value<string>();
+     break;
+   case avro::AVRO_BYTES:
+     {
+       const std::vector<uint8_t>& v = datum.value<std::vector<uint8_t>>();
+       if (v.size() > 0) {
+         value.resize(v.size());
+         memcpy(&value[0], &v[0], v.size());
+       }
+     }
+     break;
+   case avro::AVRO_ENUM:
+     value = datum.value<avro::GenericEnum>().symbol();
+     break;
+   case avro::AVRO_FIXED:
+     {
+       const std::vector<uint8_t>& v = datum.value<avro::GenericFixed>().value();
+       if (v.size() > 0) {
+         value.resize(v.size());
+         memcpy(&value[0], &v[0], v.size());
+       }
+     }
+     break;
+   case avro::AVRO_NULL:
+     TF_RETURN_IF_ERROR(CheckValidDefault(key_, defaults, DT_STRING));
+     value = defaults.at(key_).flat<tstring>()(0);
+     break;
+   default:
+     return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
+ }
+ // Assume the key exists and cast is possible
+ (*reinterpret_cast<StringValueBuffer*>((*values)[key_].get())).AddByRef(value);
 
-  return Status::OK();
+   return Status::OK();
+
 }
 string StringBytesEnumFixedValueParser::ToString(size_t level) const {
   return LevelToString(level) + "|---StringBytesEnumFixedValue(" + key_ + ")\n";
@@ -238,12 +276,12 @@ string StringBytesEnumFixedValueParser::ToString(size_t level) const {
 // ------------------------------------------------------------
 ArrayAllParser::ArrayAllParser() : AvroParser("") {}
 Status ArrayAllParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                             const avro::GenericDatum& datum) const {
-  if (datum.type() != avro::AVRO_ARRAY) {
-    return errors::InvalidArgument(
-        "Expected type '", toString(avro::AVRO_ARRAY), "' but got type '",
-        toString(datum.type()), "'.");
-  }
+                             const avro::GenericDatum& datum,
+                             const std::map<string, Tensor>& defaults) const {
+
+   if (datum.type() != avro::AVRO_ARRAY) {
+      return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
+   }
 
   std::vector<avro::GenericDatum> data =
       datum.value<avro::GenericArray>().value();
@@ -262,7 +300,7 @@ Status ArrayAllParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
   for (const avro::GenericDatum& d : data) {
     // For all children
     for (const AvroParserSharedPtr& child : children) {
-      TF_RETURN_IF_ERROR((*child).Parse(values, d));
+      TF_RETURN_IF_ERROR((*child).Parse(values, d, defaults));
     }
   }
 
@@ -284,11 +322,10 @@ string ArrayAllParser::ToString(size_t level) const {
 ArrayIndexParser::ArrayIndexParser(size_t index)
     : AvroParser(""), index_(index) {}
 Status ArrayIndexParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                               const avro::GenericDatum& datum) const {
+                               const avro::GenericDatum& datum,
+                               const std::map<string, Tensor>& defaults) const {
   if (datum.type() != avro::AVRO_ARRAY) {
-    return errors::InvalidArgument(
-        "Expected type '", toString(avro::AVRO_ARRAY), "' but got type '",
-        toString(datum.type()), "'.");
+      return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
 
   // Check for valid index
@@ -307,22 +344,10 @@ Status ArrayIndexParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
   const std::vector<AvroParserSharedPtr>& final_descendents(
       GetFinalDescendents());
 
-  /*  // Add a begin mark to all value buffers under this array
-    for (const AvroParserSharedPtr& value_parser : final_descendents) {
-      // Assumes the key exists in the map
-      (*(*values)[(*value_parser).GetKey()]).BeginMark();
-    }*/
-
   // For all children same datum
   for (const AvroParserSharedPtr& child : children) {
-    TF_RETURN_IF_ERROR((*child).Parse(values, d));
+    TF_RETURN_IF_ERROR((*child).Parse(values, d, defaults));
   }
-
-  /*  // Add a finish mark to all value buffers under this array
-    for (const AvroParserSharedPtr& value_parser : final_descendents) {
-      // Assumes the key exists in the map
-      (*(*values)[(*value_parser).GetKey()]).FinishMark();
-    }*/
 
   return Status::OK();
 }
@@ -352,11 +377,10 @@ ArrayFilterParser::ArrayFilterType ArrayFilterParser::ToArrayFilterType(
 }
 
 Status ArrayFilterParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                                const avro::GenericDatum& datum) const {
+                                const avro::GenericDatum& datum,
+                                const std::map<string, Tensor>& defaults) const {
   if (datum.type() != avro::AVRO_ARRAY) {
-    return errors::InvalidArgument(
-        "Expected type '", toString(avro::AVRO_ARRAY), "' but got type '",
-        toString(datum.type()), "'.");
+    return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
 
   const std::vector<AvroParserSharedPtr>& final_descendents =
@@ -396,7 +420,7 @@ Status ArrayFilterParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
       const avro::GenericDatum& d = data[i_elements];
       // For all children
       for (const AvroParserSharedPtr& child : children) {
-        TF_RETURN_IF_ERROR((*child).Parse(values, d));
+        TF_RETURN_IF_ERROR((*child).Parse(values, d, defaults));
       }
     }
   }
@@ -419,11 +443,10 @@ string ArrayFilterParser::ToString(size_t level) const {
 
 MapKeyParser::MapKeyParser(const string& key) : AvroParser(""), key_(key) {}
 Status MapKeyParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                           const avro::GenericDatum& datum) const {
+                           const avro::GenericDatum& datum,
+                           const std::map<string, Tensor>& defaults) const {
   if (datum.type() != avro::AVRO_MAP) {
-    return errors::InvalidArgument("Expected type '", toString(avro::AVRO_MAP),
-                                   "' but got type '", toString(datum.type()),
-                                   "'.");
+      return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
 
   std::vector<std::pair<std::string, avro::GenericDatum>> data =
@@ -439,7 +462,7 @@ Status MapKeyParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
       // For all children
       const std::vector<AvroParserSharedPtr>& children(GetChildren());
       for (const AvroParserSharedPtr& child : children) {
-        TF_RETURN_IF_ERROR((*child).Parse(values, keyValue.second));
+        TF_RETURN_IF_ERROR((*child).Parse(values, keyValue.second, defaults));
       }
     }
   }
@@ -459,11 +482,9 @@ string MapKeyParser::ToString(size_t level) const {
 
 RecordParser::RecordParser(const string& name) : AvroParser(""), name_(name) {}
 Status RecordParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                           const avro::GenericDatum& datum) const {
+                           const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const {
   if (datum.type() != avro::AVRO_RECORD) {
-    return errors::InvalidArgument(
-        "Expected type '", toString(avro::AVRO_RECORD), "' but got type '",
-        toString(datum.type()), "'.");
+      return errors::InvalidArgument(TypeErrorMessage(GetSupportedTypes(), datum.type()));
   }
 
   // Convert to record
@@ -480,7 +501,7 @@ Status RecordParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
   // Parse all children with this datum
   const std::vector<AvroParserSharedPtr>& children(GetChildren());
   for (const AvroParserSharedPtr& child : children) {
-    TF_RETURN_IF_ERROR((*child).Parse(values, d));
+    TF_RETURN_IF_ERROR((*child).Parse(values, d, defaults));
   }
 
   return Status::OK();
@@ -496,7 +517,8 @@ string RecordParser::ToString(size_t level) const {
 UnionParser::UnionParser(const string& type_name)
     : AvroParser(""), type_name_(type_name) {}
 Status UnionParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                          const avro::GenericDatum& datum) const {
+                          const avro::GenericDatum& datum,
+                          const std::map<string, Tensor>& defaults) const {
   // Note, in this case we don't know the type
   // 2nd note, we don't need to resolve the branch, it's done already by the
   // read datum
@@ -505,11 +527,15 @@ Status UnionParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
   // Find the right child for this type
   const std::vector<AvroParserSharedPtr>& children(GetChildren());
   for (const AvroParserSharedPtr& child : children) {
-    // Check if the child parser supports the data type
     const std::set<avro::Type>& supported_types = (*child).GetSupportedTypes();
+    // The child parser supports the data type, could be Null as well
     if (supported_types.find(datum_type) != supported_types.end()) {
-      TF_RETURN_IF_ERROR((*child).Parse(values, datum));
-      return Status::OK();
+          VLOG(5) << "For key '" << child->GetKey() << "' parse datum type '" << toString(datum_type) << "'.";
+          TF_RETURN_IF_ERROR((*child).Parse(values, datum, defaults));
+        // For any other type that is part of the branch resolve the null type
+        } else if (supported_types.find(avro::AVRO_NULL) != supported_types.end()) {
+          VLOG(5) << "For key '" << child->GetKey() << "' parse by using default";
+          TF_RETURN_IF_ERROR((*child).Parse(values, avro::GenericDatum(), defaults));
     }
   }
   // We could not find the right child, log a warning since this datum is lost
@@ -526,10 +552,11 @@ string UnionParser::ToString(size_t level) const {
 
 RootParser::RootParser() : AvroParser("") {}
 Status RootParser::Parse(std::map<string, ValueStoreUniquePtr>* values,
-                         const avro::GenericDatum& datum) const {
+                         const avro::GenericDatum& datum,
+                         const std::map<string, Tensor>& defaults) const {
   const std::vector<AvroParserSharedPtr>& children(GetChildren());
   for (const AvroParserSharedPtr& child : children) {
-    TF_RETURN_IF_ERROR((*child).Parse(values, datum));
+    TF_RETURN_IF_ERROR((*child).Parse(values, datum, defaults));
   }
   return Status::OK();
 }

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser.h
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser.h
@@ -46,7 +46,8 @@ class AvroParser {
   // Parse will traverse the sub-tree of this value and fill all values into
   // `parsed_values` may also read from parsed values if filtering
   virtual Status Parse(std::map<string, ValueStoreUniquePtr>* parsed_values,
-                       const avro::GenericDatum& datum) const = 0;
+                       const avro::GenericDatum& datum,
+                       const std::map<string, Tensor>& defaults) const = 0;
 
   // Add a child to this avro parser
   inline void AddChild(const AvroParserSharedPtr& child) {
@@ -75,9 +76,6 @@ class AvroParser {
   // Convert the level into a string
   string LevelToString(size_t level) const;
 
-  // Convert the supported types into a string representation
-  string SupportedTypesToString(char separator) const;
-
   // The key for this avro parser
   string key_;
 
@@ -94,30 +92,16 @@ class AvroParser {
 };
 
 // Parser for primitive types
-/*
-// TODO(fraudies): Use this null value parser to resolve to default value
-// if provided
-class NullValueParser : public AvroParser {
-public:
-  NullValueParser(const string& key);
-  // Don't do anything, meaning for dense tensors the default will be filled
-  // and for sparse tensors no entry will be generated
-  Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-    const avro_value_t& value) const override;
-  virtual string ToString(int level = 0) const;
-  inline avro_type_t GetSupportedTypes() const override { return AVRO_NULL; }
-};
-*/
-
 // Parser for boolean values
 class BoolValueParser : public AvroParser {
  public:
   BoolValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
-    return {avro::AVRO_BOOL};
+    return {avro::AVRO_BOOL, avro::AVRO_NULL};
   }
 };
 
@@ -126,10 +110,10 @@ class LongValueParser : public AvroParser {
  public:
   LongValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
-    return {avro::AVRO_LONG};
+    return {avro::AVRO_LONG, avro::AVRO_NULL};
   }
 };
 
@@ -138,10 +122,11 @@ class IntValueParser : public AvroParser {
  public:
   IntValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
-    return {avro::AVRO_INT};
+    return {avro::AVRO_INT, avro::AVRO_NULL};
   }
 };
 
@@ -150,10 +135,11 @@ class DoubleValueParser : public AvroParser {
  public:
   DoubleValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
-    return {avro::AVRO_DOUBLE};
+    return {avro::AVRO_DOUBLE, avro::AVRO_NULL};
   }
 };
 
@@ -162,10 +148,11 @@ class FloatValueParser : public AvroParser {
  public:
   FloatValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
-    return {avro::AVRO_FLOAT};
+    return {avro::AVRO_FLOAT, avro::AVRO_NULL};
   }
 };
 
@@ -176,11 +163,11 @@ class StringBytesEnumFixedValueParser : public AvroParser {
  public:
   StringBytesEnumFixedValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_STRING, avro::AVRO_BYTES, avro::AVRO_ENUM,
-            avro::AVRO_FIXED};
+            avro::AVRO_FIXED, avro::AVRO_NULL};
   }
 };
 
@@ -189,7 +176,7 @@ class ArrayAllParser : public AvroParser {
  public:
   ArrayAllParser();
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_ARRAY};
@@ -201,7 +188,7 @@ class ArrayIndexParser : public AvroParser {
  public:
   ArrayIndexParser(size_t index);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_ARRAY};
@@ -218,7 +205,7 @@ class ArrayFilterParser : public AvroParser {
   ArrayFilterParser(const tstring& lhs, const tstring& rhs,
                     ArrayFilterType type);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   static ArrayFilterType ToArrayFilterType(bool lhs_is_constant,
                                            bool rhs_is_constant);
@@ -237,7 +224,7 @@ class MapKeyParser : public AvroParser {
  public:
   MapKeyParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_MAP};
@@ -256,7 +243,7 @@ class RecordParser : public AvroParser {
   // get the the attribute for the name and return it in the vector as single
   // element
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_RECORD};
@@ -271,7 +258,7 @@ class UnionParser : public AvroParser {
  public:
   UnionParser(const string& type_name);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_UNION};
@@ -286,7 +273,7 @@ class RootParser : public AvroParser {
  public:
   RootParser();
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum) const override;
+               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   // Note, abuse of unknown symbol
   inline std::set<avro::Type> GetSupportedTypes() const override {

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser.h
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser.h
@@ -110,7 +110,8 @@ class LongValueParser : public AvroParser {
  public:
   LongValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_LONG, avro::AVRO_NULL};
@@ -163,7 +164,8 @@ class StringBytesEnumFixedValueParser : public AvroParser {
  public:
   StringBytesEnumFixedValueParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_STRING, avro::AVRO_BYTES, avro::AVRO_ENUM,
@@ -176,7 +178,8 @@ class ArrayAllParser : public AvroParser {
  public:
   ArrayAllParser();
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_ARRAY};
@@ -188,7 +191,8 @@ class ArrayIndexParser : public AvroParser {
  public:
   ArrayIndexParser(size_t index);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_ARRAY};
@@ -205,7 +209,8 @@ class ArrayFilterParser : public AvroParser {
   ArrayFilterParser(const tstring& lhs, const tstring& rhs,
                     ArrayFilterType type);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   static ArrayFilterType ToArrayFilterType(bool lhs_is_constant,
                                            bool rhs_is_constant);
@@ -224,7 +229,8 @@ class MapKeyParser : public AvroParser {
  public:
   MapKeyParser(const string& key);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_MAP};
@@ -243,7 +249,8 @@ class RecordParser : public AvroParser {
   // get the the attribute for the name and return it in the vector as single
   // element
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_RECORD};
@@ -258,7 +265,8 @@ class UnionParser : public AvroParser {
  public:
   UnionParser(const string& type_name);
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   inline std::set<avro::Type> GetSupportedTypes() const override {
     return {avro::AVRO_UNION};
@@ -273,7 +281,8 @@ class RootParser : public AvroParser {
  public:
   RootParser();
   Status Parse(std::map<string, ValueStoreUniquePtr>* values,
-               const avro::GenericDatum& datum, const std::map<string, Tensor>& defaults) const override;
+               const avro::GenericDatum& datum,
+               const std::map<string, Tensor>& defaults) const override;
   virtual string ToString(size_t level = 0) const;
   // Note, abuse of unknown symbol
   inline std::set<avro::Type> GetSupportedTypes() const override {

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
@@ -29,7 +29,7 @@ Status AvroParserTree::ParseValues(
     std::map<string, ValueStoreUniquePtr>* key_to_value,
     const std::function<bool(avro::GenericDatum&)> read_value,
     const avro::ValidSchema& reader_schema, uint64 values_to_parse,
-    uint64* values_parsed) const {
+    uint64* values_parsed, const std::map<string, Tensor>& defaults) const {
   // See if we have any data in this batch
   avro::GenericDatum datum(reader_schema);
   bool has_value = false;
@@ -51,7 +51,7 @@ Status AvroParserTree::ParseValues(
   TF_RETURN_IF_ERROR(AddBeginMarks(key_to_value));
 
   // Parse first value
-  TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum));
+  TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum, defaults));
   uint64 values_read = 1;
   // Increment before compare because we already read one value
   while (values_read < values_to_parse) {
@@ -61,7 +61,7 @@ Status AvroParserTree::ParseValues(
       return errors::InvalidArgument("Error reading value: ", e.what());
     }
     if (has_value) {
-      TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum));
+      TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum,  defaults));
       values_read++;
     } else {
       break;
@@ -79,7 +79,7 @@ Status AvroParserTree::ParseValues(
 Status AvroParserTree::ParseValues(
     std::map<string, ValueStoreUniquePtr>* key_to_value,
     const std::function<bool(avro::GenericDatum&)> read_value,
-    const avro::ValidSchema& reader_schema) const {
+    const avro::ValidSchema& reader_schema, const std::map<string, Tensor>& defaults) const {
   // new assignment of all buffers
   TF_RETURN_IF_ERROR(InitializeValueBuffers(key_to_value));
 
@@ -91,7 +91,7 @@ Status AvroParserTree::ParseValues(
   bool has_value = false;
 
   while ((has_value = read_value(datum))) {
-    TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum));
+    TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum, defaults));
   }
 
   // add end marks to all buffers for batch

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.cc
@@ -61,7 +61,7 @@ Status AvroParserTree::ParseValues(
       return errors::InvalidArgument("Error reading value: ", e.what());
     }
     if (has_value) {
-      TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum,  defaults));
+      TF_RETURN_IF_ERROR((*root_).Parse(key_to_value, datum, defaults));
       values_read++;
     } else {
       break;
@@ -79,7 +79,8 @@ Status AvroParserTree::ParseValues(
 Status AvroParserTree::ParseValues(
     std::map<string, ValueStoreUniquePtr>* key_to_value,
     const std::function<bool(avro::GenericDatum&)> read_value,
-    const avro::ValidSchema& reader_schema, const std::map<string, Tensor>& defaults) const {
+    const avro::ValidSchema& reader_schema,
+    const std::map<string, Tensor>& defaults) const {
   // new assignment of all buffers
   TF_RETURN_IF_ERROR(InitializeValueBuffers(key_to_value));
 

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.h
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.h
@@ -68,11 +68,11 @@ class AvroParserTree {
   Status ParseValues(std::map<string, ValueStoreUniquePtr>* key_to_value,
                      const std::function<bool(avro::GenericDatum&)> read_value,
                      const avro::ValidSchema& reader_schema,
-                     uint64 values_to_parse, uint64* values_parsed) const;
+                     uint64 values_to_parse, uint64* values_parsed, const std::map<string, Tensor>& defaults) const;
 
   Status ParseValues(std::map<string, ValueStoreUniquePtr>* key_to_value,
                      const std::function<bool(avro::GenericDatum&)> read_value,
-                     const avro::ValidSchema& reader_schema) const;
+                     const avro::ValidSchema& reader_schema, const std::map<string, Tensor>& defaults) const;
 
   // Returns the root of the parser tree -- exposed for testing
   inline AvroParserSharedPtr getRoot() const { return root_; }

--- a/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.h
+++ b/tensorflow_io/core/kernels/avro/utils/avro_parser_tree.h
@@ -68,11 +68,13 @@ class AvroParserTree {
   Status ParseValues(std::map<string, ValueStoreUniquePtr>* key_to_value,
                      const std::function<bool(avro::GenericDatum&)> read_value,
                      const avro::ValidSchema& reader_schema,
-                     uint64 values_to_parse, uint64* values_parsed, const std::map<string, Tensor>& defaults) const;
+                     uint64 values_to_parse, uint64* values_parsed,
+                     const std::map<string, Tensor>& defaults) const;
 
   Status ParseValues(std::map<string, ValueStoreUniquePtr>* key_to_value,
                      const std::function<bool(avro::GenericDatum&)> read_value,
-                     const avro::ValidSchema& reader_schema, const std::map<string, Tensor>& defaults) const;
+                     const avro::ValidSchema& reader_schema,
+                     const std::map<string, Tensor>& defaults) const;
 
   // Returns the root of the parser tree -- exposed for testing
   inline AvroParserSharedPtr getRoot() const { return root_; }

--- a/tensorflow_io/core/python/experimental/parse_avro_ops.py
+++ b/tensorflow_io/core/python/experimental/parse_avro_ops.py
@@ -540,13 +540,7 @@ def _process_raw_parameters(
 
         # ************* START difference: This part is different from the originally copied code ***************
         if default_value is None:
-            if dense_types[i] == tf.string:
-                default_value = ""
-            elif dense_types[i] == tf.bool:
-                default_value = False
-            else:  # Should be numeric type
-                default_value = 0
-            default_value = tf.convert_to_tensor(default_value, dtype=dense_types[i])
+            default_value = tf.constant([], dtype=dense_types[i])
         elif not isinstance(default_value, tf.Tensor):
             key_name = "key_" + re.sub("[^A-Za-z0-9_.\\-/]", "_", key)
             default_value = tf.convert_to_tensor(

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -30,8 +30,8 @@ from avro.datafile import DataFileReader, DataFileWriter
 from avro.schema import Parse as parse
 import tensorflow_io as tfio
 
-# if sys.platform == "darwin":
-#    pytest.skip("TODO: skip macOS", allow_module_level=True)
+if sys.platform == "darwin":
+   pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
 class AvroRecordsToFile:

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -30,8 +30,8 @@ from avro.datafile import DataFileReader, DataFileWriter
 from avro.schema import Parse as parse
 import tensorflow_io as tfio
 
-if sys.platform == "darwin":
-    pytest.skip("TODO: skip macOS", allow_module_level=True)
+#if sys.platform == "darwin":
+#    pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
 class AvroRecordsToFile:
@@ -304,7 +304,7 @@ class AvroRecordDatasetTest(AvroDatasetTestBase):
             {
                 "index": 2,
                 "string_value": "ABCDEFGHIJKLMNOPQRSTUVW"
-                + "Zabcdefghijklmnopqrstuvwz0123456789",
+                                + "Zabcdefghijklmnopqrstuvwz0123456789",
             },
         ]
         self._test_pass_dataset(writer_schema=writer_schema, record_data=record_data)
@@ -341,7 +341,7 @@ class AvroRecordDatasetTest(AvroDatasetTestBase):
             {
                 "index": 2,
                 "string_value": "ABCDEFGHIJKLMNOPQRSTUVWZabcde"
-                + "fghijklmnopqrstuvwz0123456789",
+                                + "fghijklmnopqrstuvwz0123456789",
             },
         ]
         self._test_pass_dataset_resolved(
@@ -686,9 +686,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
             {
                 "string_value": "ABCDEFGHIJKLMNOPQRSTUVWZabcdefghi"
-                + "jklmnopqrstuvwz0123456789",
+                                + "jklmnopqrstuvwz0123456789",
                 "bytes_value": b"ABCDEFGHIJKLMNOPQRSTUVWZab"
-                + "cdefghijklmnopqrstuvwz0123456789",
+                               + "cdefghijklmnopqrstuvwz0123456789",
                 "double_value": 1.0,
                 "float_value": 1.0,
                 "long_value": -9223372036854775807 - 1,
@@ -898,125 +898,151 @@ class AvroDatasetTest(AvroDatasetTestBase):
             batch_size=2,
         )
 
-    # TODO(fraudies): Need to rethink on how we should solve union handling
-    # Currently, this changes the batch size dynamically which I disallowed
-    # It may also cause problems when TF assumes a fixed batch size
-    # def test_null_union_primitive_type(self):
-    #    """test_null_union_primitive_type"""
-    #     reader_schema = """{
-    #          "type":"record",
-    #          "name":"data_row",
-    #          "fields":[
-    #             {
-    #                "name":"multi_type",
-    #                "type":[
-    #                   "null",
-    #                   "boolean",
-    #                   "int",
-    #                   "long",
-    #                   "float",
-    #                   "double",
-    #                   "string"
-    #                ]
-    #             }
-    #          ]
-    #       }
-    #       """
-    #     record_data = [
-    #         {
-    #             "multi_type": 1.0
-    #         },
-    #         {
-    #             "multi_type": 2.0
-    #         },
-    #         {
-    #             "multi_type": 3.0
-    #         },
-    #         {
-    #             "multi_type": True  # converted by py avro implementation into 1
-    #         },
-    #         {
-    #             "multi_type": "abc"
-    #         },
-    #         {
-    #             "multi_type": None
-    #         }
-    #     ]
-    #     features = {
-    #         "multi_type:boolean": tf.io.FixedLenFeature([], tf.dtypes.bool),
-    #         "multi_type:int": tf.io.FixedLenFeature([], tf.dtypes.int32),
-    #         "multi_type:long": tf.io.FixedLenFeature([], tf.dtypes.int64),
-    #         "multi_type:float": tf.io.FixedLenFeature([], tf.dtypes.float32),
-    #         "multi_type:double": tf.io.FixedLenFeature([], tf.dtypes.float64),
-    #         "multi_type:string": tf.io.FixedLenFeature([], tf.dtypes.string)
-    #     }
-    #     expected_data = [
-    #         {
-    #             "multi_type:boolean":
-    #                 tf.convert_to_tensor([]),
-    #             "multi_type:int":
-    #                 tf.convert_to_tensor([]),
-    #             "multi_type:long":
-    #                 tf.convert_to_tensor([]),
-    #             "multi_type:float":
-    #                 tf.convert_to_tensor([]),
-    #             "multi_type:double":
-    #                 tf.convert_to_tensor([1.0, 2.0, 3.0, 1.0]),
-    #             "multi_type:string":
-    #                 tf.convert_to_tensor([tf.compat.as_bytes("abc")])
-    #         }
-    #     ]
-    #     self._test_pass_dataset(reader_schema=reader_schema,
-    #                             record_data=record_data,
-    #                             expected_data=expected_data,
-    #                             features=features,
-    #                             batch_size=6)
 
-    # TODO(fraudies): Provide proper handling of default value aka use default when null
-    # If no default is provided fail there
-    # def test_union_with_null(self):
-    #    """test_union_with_null"""
-    #     reader_schema = """{
-    #          "type": "record",
-    #          "name": "data_row",
-    #          "fields": [
-    #             {
-    #                "name": "possible_float_type",
-    #                "type": [
-    #                   "null",
-    #                   "float"
-    #                ]
-    #             }
-    #          ]
-    #       }
-    #       """
-    #     record_data = [
-    #         {
-    #             "possible_float_type": 1.0
-    #         },
-    #         {
-    #             "possible_float_type": None
-    #         },
-    #         {
-    #             "possible_float_type": -1.0
-    #         }
-    #     ]
-    #     features = {
-    #         "possible_float_type:float": tf.io.FixedLenFeature([],
-    #                                                                  tf.dtypes.float32)
-    #     }
-    #     # TODO(fraudies): If we have a default, then we use that in the place of
-    #     #  the None
-    #     expected_data = [
-    #         {
-    #             "possible_float_type:float": tf.convert_to_tensor([1.0, -1.0])
-    #         }
-    #     ]
-    #     self._test_pass_dataset(reader_schema=reader_schema,
-    #                             record_data=record_data,
-    #                             expected_data=expected_data,
-    #                             features=features,
-    #                             batch_size=3)
+    def test_union_with_null(self):
+        reader_schema = """{
+             "type": "record",
+             "name": "data_row",
+             "fields": [
+                {
+                   "name": "possible_float_type",
+                   "type": [
+                      "null",
+                      "float"
+                   ]
+                }
+             ]
+          }
+          """
+        record_data = [
+            {
+                "possible_float_type": 1.0
+            },
+            {
+                "possible_float_type": None
+            },
+            {
+                "possible_float_type": -1.0
+            }
+        ]
+        features = {
+            "possible_float_type:float": tf.io.FixedLenFeature([], tf.dtypes.float32, default_value=0.0)
+        }
+        # If we have a default, then we use that in the place of the None
+        expected_data = [
+            {
+                "possible_float_type:float": tf.convert_to_tensor([1.0, 0.0,
+                                                                   -1.0])
+            }
+        ]
+        self._test_pass_dataset(reader_schema=reader_schema,
+                                record_data=record_data,
+                                expected_data=expected_data,
+                                features=features,
+                                batch_size=3)
+
+    def test_null_union_primitive_type(self):
+        reader_schema = """{
+             "type":"record",
+             "name":"data_row",
+             "fields":[
+                {
+                   "name":"multi_type",
+                   "type":[
+                      "null",
+                      "boolean",
+                      "int",
+                      "long",
+                      "float",
+                      "double",
+                      "string"
+                   ]
+                }
+             ]
+          }
+          """
+        record_data = [
+            {
+                "multi_type": None
+            },
+            {
+                "multi_type": True   # written as double(1.0)
+            },
+            {
+                "multi_type": int(1)  # written as double(1.0)
+            },
+            {
+                "multi_type": 2  # written as double(2.0)
+            },
+            {
+                "multi_type": float(3.0)  # written as double(3.0)
+            },
+            {
+                "multi_type": 4.0  # written as double (4.0)
+            },
+            {
+                "multi_type": "abc"
+            }
+        ]
+        features = {
+            "multi_type:boolean": tf.io.FixedLenFeature([], tf.dtypes.bool,
+                                                        default_value=False),
+            "multi_type:int": tf.io.FixedLenFeature([], tf.dtypes.int32, default_value=int(0)),
+            "multi_type:long": tf.io.FixedLenFeature([], tf.dtypes.int64, default_value=0),
+            "multi_type:float": tf.io.FixedLenFeature([], tf.dtypes.float32, default_value=float(0.0)),
+            "multi_type:double": tf.io.FixedLenFeature([], tf.dtypes.float64, default_value=0.0),
+            "multi_type:string": tf.io.FixedLenFeature([], tf.dtypes.string, default_value="")
+        }
+        expected_data = [
+            {
+                "multi_type:boolean":
+                    tf.convert_to_tensor([False, False, False, False, False,
+                                          False, False], dtype=tf.dtypes.bool),
+                "multi_type:int":
+                    tf.convert_to_tensor([0, 0, 0, 0, 0, 0, 0], dtype=tf.dtypes.int32),
+                "multi_type:long":
+                    tf.convert_to_tensor([0, 0, 0, 0, 0, 0, 0], dtype=tf.dtypes.int64),
+                "multi_type:float":
+                    tf.convert_to_tensor([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=tf.dtypes.float32),
+                "multi_type:double":
+                    tf.convert_to_tensor([0.0, 1.0, 1.0, 2.0, 3.0, 4.0, 0.0], dtype=tf.dtypes.float64),
+                "multi_type:string":
+                    tf.convert_to_tensor([tf.compat.as_bytes(""), tf.compat.as_bytes(""), tf.compat.as_bytes(""),
+                                          tf.compat.as_bytes(""), tf.compat.as_bytes(""), tf.compat.as_bytes(""),
+                                          tf.compat.as_bytes("abc")])
+            }
+        ]
+        self._test_pass_dataset(reader_schema=reader_schema,
+                                record_data=record_data,
+                                expected_data=expected_data,
+                                features=features,
+                                batch_size=7)
+
+    def test_union_without_default(self):
+        reader_schema = """{
+             "type": "record",
+             "name": "data_row",
+             "fields": [
+                {
+                   "name": "possible_float_type",
+                   "type": [
+                      "null",
+                      "float"
+                   ]
+                }
+             ]
+          }
+          """
+        record_data = [
+            {
+                "possible_float_type": None
+            }
+        ]
+        features = {
+            "possible_float_type:float": tf.io.FixedLenFeature([], tf.dtypes.float32)
+        }
+        self._test_fail_dataset(reader_schema, record_data, features, 1)
+
 
     @pytest.mark.skipif(sys.platform == "darwin", reason="macOS fails now")
     def test_fixed_length_list(self):

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -30,7 +30,7 @@ from avro.datafile import DataFileReader, DataFileWriter
 from avro.schema import Parse as parse
 import tensorflow_io as tfio
 
-#if sys.platform == "darwin":
+# if sys.platform == "darwin":
 #    pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
@@ -304,7 +304,7 @@ class AvroRecordDatasetTest(AvroDatasetTestBase):
             {
                 "index": 2,
                 "string_value": "ABCDEFGHIJKLMNOPQRSTUVW"
-                                + "Zabcdefghijklmnopqrstuvwz0123456789",
+                + "Zabcdefghijklmnopqrstuvwz0123456789",
             },
         ]
         self._test_pass_dataset(writer_schema=writer_schema, record_data=record_data)
@@ -341,7 +341,7 @@ class AvroRecordDatasetTest(AvroDatasetTestBase):
             {
                 "index": 2,
                 "string_value": "ABCDEFGHIJKLMNOPQRSTUVWZabcde"
-                                + "fghijklmnopqrstuvwz0123456789",
+                + "fghijklmnopqrstuvwz0123456789",
             },
         ]
         self._test_pass_dataset_resolved(
@@ -686,9 +686,9 @@ class AvroDatasetTest(AvroDatasetTestBase):
             },
             {
                 "string_value": "ABCDEFGHIJKLMNOPQRSTUVWZabcdefghi"
-                                + "jklmnopqrstuvwz0123456789",
+                + "jklmnopqrstuvwz0123456789",
                 "bytes_value": b"ABCDEFGHIJKLMNOPQRSTUVWZab"
-                               + "cdefghijklmnopqrstuvwz0123456789",
+                + "cdefghijklmnopqrstuvwz0123456789",
                 "double_value": 1.0,
                 "float_value": 1.0,
                 "long_value": -9223372036854775807 - 1,
@@ -898,7 +898,6 @@ class AvroDatasetTest(AvroDatasetTestBase):
             batch_size=2,
         )
 
-
     def test_union_with_null(self):
         reader_schema = """{
              "type": "record",
@@ -915,31 +914,26 @@ class AvroDatasetTest(AvroDatasetTestBase):
           }
           """
         record_data = [
-            {
-                "possible_float_type": 1.0
-            },
-            {
-                "possible_float_type": None
-            },
-            {
-                "possible_float_type": -1.0
-            }
+            {"possible_float_type": 1.0},
+            {"possible_float_type": None},
+            {"possible_float_type": -1.0},
         ]
         features = {
-            "possible_float_type:float": tf.io.FixedLenFeature([], tf.dtypes.float32, default_value=0.0)
+            "possible_float_type:float": tf.io.FixedLenFeature(
+                [], tf.dtypes.float32, default_value=0.0
+            )
         }
         # If we have a default, then we use that in the place of the None
         expected_data = [
-            {
-                "possible_float_type:float": tf.convert_to_tensor([1.0, 0.0,
-                                                                   -1.0])
-            }
+            {"possible_float_type:float": tf.convert_to_tensor([1.0, 0.0, -1.0])}
         ]
-        self._test_pass_dataset(reader_schema=reader_schema,
-                                record_data=record_data,
-                                expected_data=expected_data,
-                                features=features,
-                                batch_size=3)
+        self._test_pass_dataset(
+            reader_schema=reader_schema,
+            record_data=record_data,
+            expected_data=expected_data,
+            features=features,
+            batch_size=3,
+        )
 
     def test_null_union_primitive_type(self):
         reader_schema = """{
@@ -962,61 +956,72 @@ class AvroDatasetTest(AvroDatasetTestBase):
           }
           """
         record_data = [
-            {
-                "multi_type": None
-            },
-            {
-                "multi_type": True   # written as double(1.0)
-            },
-            {
-                "multi_type": int(1)  # written as double(1.0)
-            },
-            {
-                "multi_type": 2  # written as double(2.0)
-            },
-            {
-                "multi_type": float(3.0)  # written as double(3.0)
-            },
-            {
-                "multi_type": 4.0  # written as double (4.0)
-            },
-            {
-                "multi_type": "abc"
-            }
+            {"multi_type": None},
+            {"multi_type": True},  # written as double(1.0)
+            {"multi_type": int(1)},  # written as double(1.0)
+            {"multi_type": 2},  # written as double(2.0)
+            {"multi_type": float(3.0)},  # written as double(3.0)
+            {"multi_type": 4.0},  # written as double (4.0)
+            {"multi_type": "abc"},
         ]
         features = {
-            "multi_type:boolean": tf.io.FixedLenFeature([], tf.dtypes.bool,
-                                                        default_value=False),
-            "multi_type:int": tf.io.FixedLenFeature([], tf.dtypes.int32, default_value=int(0)),
-            "multi_type:long": tf.io.FixedLenFeature([], tf.dtypes.int64, default_value=0),
-            "multi_type:float": tf.io.FixedLenFeature([], tf.dtypes.float32, default_value=float(0.0)),
-            "multi_type:double": tf.io.FixedLenFeature([], tf.dtypes.float64, default_value=0.0),
-            "multi_type:string": tf.io.FixedLenFeature([], tf.dtypes.string, default_value="")
+            "multi_type:boolean": tf.io.FixedLenFeature(
+                [], tf.dtypes.bool, default_value=False
+            ),
+            "multi_type:int": tf.io.FixedLenFeature(
+                [], tf.dtypes.int32, default_value=int(0)
+            ),
+            "multi_type:long": tf.io.FixedLenFeature(
+                [], tf.dtypes.int64, default_value=0
+            ),
+            "multi_type:float": tf.io.FixedLenFeature(
+                [], tf.dtypes.float32, default_value=float(0.0)
+            ),
+            "multi_type:double": tf.io.FixedLenFeature(
+                [], tf.dtypes.float64, default_value=0.0
+            ),
+            "multi_type:string": tf.io.FixedLenFeature(
+                [], tf.dtypes.string, default_value=""
+            ),
         }
         expected_data = [
             {
-                "multi_type:boolean":
-                    tf.convert_to_tensor([False, False, False, False, False,
-                                          False, False], dtype=tf.dtypes.bool),
-                "multi_type:int":
-                    tf.convert_to_tensor([0, 0, 0, 0, 0, 0, 0], dtype=tf.dtypes.int32),
-                "multi_type:long":
-                    tf.convert_to_tensor([0, 0, 0, 0, 0, 0, 0], dtype=tf.dtypes.int64),
-                "multi_type:float":
-                    tf.convert_to_tensor([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=tf.dtypes.float32),
-                "multi_type:double":
-                    tf.convert_to_tensor([0.0, 1.0, 1.0, 2.0, 3.0, 4.0, 0.0], dtype=tf.dtypes.float64),
-                "multi_type:string":
-                    tf.convert_to_tensor([tf.compat.as_bytes(""), tf.compat.as_bytes(""), tf.compat.as_bytes(""),
-                                          tf.compat.as_bytes(""), tf.compat.as_bytes(""), tf.compat.as_bytes(""),
-                                          tf.compat.as_bytes("abc")])
+                "multi_type:boolean": tf.convert_to_tensor(
+                    [False, False, False, False, False, False, False],
+                    dtype=tf.dtypes.bool,
+                ),
+                "multi_type:int": tf.convert_to_tensor(
+                    [0, 0, 0, 0, 0, 0, 0], dtype=tf.dtypes.int32
+                ),
+                "multi_type:long": tf.convert_to_tensor(
+                    [0, 0, 0, 0, 0, 0, 0], dtype=tf.dtypes.int64
+                ),
+                "multi_type:float": tf.convert_to_tensor(
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=tf.dtypes.float32
+                ),
+                "multi_type:double": tf.convert_to_tensor(
+                    [0.0, 1.0, 1.0, 2.0, 3.0, 4.0, 0.0], dtype=tf.dtypes.float64
+                ),
+                "multi_type:string": tf.convert_to_tensor(
+                    [
+                        tf.compat.as_bytes(""),
+                        tf.compat.as_bytes(""),
+                        tf.compat.as_bytes(""),
+                        tf.compat.as_bytes(""),
+                        tf.compat.as_bytes(""),
+                        tf.compat.as_bytes(""),
+                        tf.compat.as_bytes("abc"),
+                    ]
+                ),
             }
         ]
-        self._test_pass_dataset(reader_schema=reader_schema,
-                                record_data=record_data,
-                                expected_data=expected_data,
-                                features=features,
-                                batch_size=7)
+        self._test_pass_dataset(
+            reader_schema=reader_schema,
+            record_data=record_data,
+            expected_data=expected_data,
+            features=features,
+            batch_size=7,
+        )
 
     def test_union_without_default(self):
         reader_schema = """{
@@ -1033,16 +1038,11 @@ class AvroDatasetTest(AvroDatasetTestBase):
              ]
           }
           """
-        record_data = [
-            {
-                "possible_float_type": None
-            }
-        ]
+        record_data = [{"possible_float_type": None}]
         features = {
             "possible_float_type:float": tf.io.FixedLenFeature([], tf.dtypes.float32)
         }
         self._test_fail_dataset(reader_schema, record_data, features, 1)
-
 
     @pytest.mark.skipif(sys.platform == "darwin", reason="macOS fails now")
     def test_fixed_length_list(self):

--- a/tests/test_parse_avro_eager.py
+++ b/tests/test_parse_avro_eager.py
@@ -31,7 +31,7 @@ from avro.schema import Parse as parse
 import tensorflow_io as tfio
 
 if sys.platform == "darwin":
-   pytest.skip("TODO: skip macOS", allow_module_level=True)
+    pytest.skip("TODO: skip macOS", allow_module_level=True)
 
 
 class AvroRecordsToFile:


### PR DESCRIPTION
Why?
Dropping values when a null is encountered does not work for dense tensors which makes them variable length in a batch
What? 
Need to consume default and check types and put them in place of the null.

That is also the expected user behavior.

This change is made by @fraudies in our internal fork and backported here.