### PR TITLE
Add tfio.experimental.color for colorspace conversion support

### DIFF
--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -6,7 +6,7 @@ run_test() {
   entry=$1
   CPYTHON_VERSION=$($entry -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
   (cd wheelhouse && $entry -m pip install tensorflow_io-*-cp${CPYTHON_VERSION}-*.whl)
-  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.16.0 pandas==0.24.2 scikit-learn==0.20.4 google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro avro-python3
+  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.16.0 pandas==0.24.2 scikit-learn==0.20.4 google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro avro-python3 scikit-image
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*.py" ! \( -iname "test_*_eager.py" \) \)))
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \)))
   # GRPC and test_bigquery_eager tests have to be executed separately because of https://github.com/grpc/grpc/issues/20034

--- a/tensorflow_io/core/python/api/experimental/__init__.py
+++ b/tensorflow_io/core/python/api/experimental/__init__.py
@@ -23,4 +23,5 @@ from tensorflow_io.core.python.api.experimental import ffmpeg
 from tensorflow_io.core.python.api.experimental import image
 from tensorflow_io.core.python.api.experimental import text
 from tensorflow_io.core.python.api.experimental import columnar
+from tensorflow_io.core.python.api.experimental import color
 from tensorflow_io.core.python.api.experimental import audio

--- a/tensorflow_io/core/python/api/experimental/color.py
+++ b/tensorflow_io/core/python/api/experimental/color.py
@@ -1,0 +1,30 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""tensorflow_io.experimental.color"""
+
+from tensorflow_io.core.python.experimental.color_ops import (  # pylint: disable=unused-import
+    rgb_to_bgr,
+    bgr_to_rgb,
+    rgb_to_rgba,
+    rgba_to_rgb,
+    rgb_to_ycbcr,
+    ycbcr_to_rgb,
+    rgb_to_ypbpr,
+    ypbpr_to_rgb,
+    rgb_to_ydbdr,
+    ydbdr_to_rgb,
+    rgb_to_xyz,
+    xyz_to_rgb,
+)

--- a/tensorflow_io/core/python/experimental/color_ops.py
+++ b/tensorflow_io/core/python/experimental/color_ops.py
@@ -1,0 +1,299 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Color Space Ops."""
+
+import tensorflow as tf
+
+
+def rgb_to_bgr(input, name=None):
+    """
+    Convert a RGB image to BGR.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    rgb = tf.unstack(input, axis=-1)
+    r, g, b = rgb[0], rgb[1], rgb[2]
+    return tf.stack([b, g, r], axis=-1)
+
+
+def bgr_to_rgb(input, name=None):
+    """
+    Convert a BGR image to RGB.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    bgr = tf.unstack(input, axis=-1)
+    b, g, r = bgr[0], bgr[1], bgr[2]
+    return tf.stack([r, g, b], axis=-1)
+
+
+def rgb_to_rgba(input, name=None):
+    """
+    Convert a RGB image to RGBA.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 4]`) or 4-D (`[N, H, W, 4]`) Tensor.
+    """
+    rgb = tf.unstack(input, axis=-1)
+    r, g, b = rgb[0], rgb[1], rgb[2]
+    a = tf.zeros_like(r)
+    return tf.stack([r, g, b, a], axis=-1)
+
+
+def rgba_to_rgb(input, name=None):
+    """
+    Convert a RGBA image to RGB.
+
+    Args:
+      input: A 3-D (`[H, W, 4]`) or 4-D (`[N, H, W, 4]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    rgba = tf.unstack(input, axis=-1)
+    r, g, b, a = rgba[0], rgba[1], rgba[2], rgba[3]
+    return tf.stack([r, g, b], axis=-1)
+
+
+def rgb_to_ycbcr(input, name=None):
+    """
+    Convert a RGB image to YCbCr.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+
+    assert input.dtype == tf.uint8
+    value = tf.cast(input, tf.float32)
+    value = value / 255.0
+    value = rgb_to_ypbpr(value)
+    value = value * tf.constant([219, 224, 224], value.dtype)
+    value = value + tf.constant([16, 128, 128], value.dtype)
+    return tf.cast(value, input.dtype)
+
+
+def ycbcr_to_rgb(input, name=None):
+    """
+    Convert a YCbCr image to RGB.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+
+    assert input.dtype == tf.uint8
+    value = tf.cast(input, tf.float32)
+    value = value - tf.constant([16, 128, 128], value.dtype)
+    value = value / tf.constant([219, 224, 224], value.dtype)
+    value = ypbpr_to_rgb(value)
+    value = value * 255.0
+    return tf.cast(value, input.dtype)
+
+
+def rgb_to_ypbpr(input, name=None):
+    """
+    Convert a RGB image to YPbPr.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    kernel = tf.constant(
+        [
+            [0.299, 0.587, 0.114],
+            [-0.168736, -0.331264, 0.5],
+            [0.5, -0.418688, -0.081312],
+        ],
+        input.dtype,
+    )
+
+    return tf.tensordot(input, tf.transpose(kernel), axes=((-1,), (0,)))
+
+
+def ypbpr_to_rgb(input, name=None):
+    """
+    Convert a YPbPr image to RGB.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    # inv of:
+    # [[ 0.299   , 0.587   , 0.114   ],
+    #  [-0.168736,-0.331264, 0.5     ],
+    #  [ 0.5     ,-0.418688,-0.081312]]
+    kernel = tf.constant(
+        [
+            [1.00000000e00, -1.21889419e-06, 1.40199959e00],
+            [1.00000000e00, -3.44135678e-01, -7.14136156e-01],
+            [1.00000000e00, 1.77200007e00, 4.06298063e-07],
+        ],
+        input.dtype,
+    )
+
+    return tf.tensordot(input, tf.transpose(kernel), axes=((-1,), (0,)))
+
+
+def rgb_to_ydbdr(input, name=None):
+    """
+    Convert a RGB image to YDbDr.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    kernel = tf.constant(
+        [[0.299, 0.587, 0.114], [-0.45, -0.883, 1.333], [-1.333, 1.116, 0.217]],
+        input.dtype,
+    )
+
+    return tf.tensordot(input, tf.transpose(kernel), axes=((-1,), (0,)))
+
+
+def ydbdr_to_rgb(input, name=None):
+    """
+    Convert a YDbDr image to RGB.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    # inv of:
+    # [[    0.299,   0.587,    0.114],
+    #  [   -0.45 ,  -0.883,    1.333],
+    #  [   -1.333,   1.116,    0.217]]
+    kernel = tf.constant(
+        [
+            [1.00000000e00, 9.23037161e-05, -5.25912631e-01],
+            [1.00000000e00, -1.29132899e-01, 2.67899328e-01],
+            [1.00000000e00, 6.64679060e-01, -7.92025435e-05],
+        ],
+        input.dtype,
+    )
+
+    return tf.tensordot(input, tf.transpose(kernel), axes=((-1,), (0,)))
+
+
+def rgb_to_xyz(input, name=None):
+    """
+    Convert a RGB image to CIE XYZ.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    kernel = tf.constant(
+        [
+            [0.412453, 0.357580, 0.180423],
+            [0.212671, 0.715160, 0.072169],
+            [0.019334, 0.119193, 0.950227],
+        ],
+        input.dtype,
+    )
+    value = tf.where(
+        tf.math.greater(input, 0.04045),
+        tf.math.pow((input + 0.055) / 1.055, 2.4),
+        input / 12.92,
+    )
+    return tf.tensordot(value, tf.transpose(kernel), axes=((-1,), (0,)))
+
+
+def xyz_to_rgb(input, name=None):
+    """
+    Convert a CIE XYZ image to RGB.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    # inv of:
+    # [[0.412453, 0.35758 , 0.180423],
+    #  [0.212671, 0.71516 , 0.072169],
+    #  [0.019334, 0.119193, 0.950227]]
+    kernel = tf.constant(
+        [
+            [3.24048134, -1.53715152, -0.49853633],
+            [-0.96925495, 1.87599, 0.04155593],
+            [0.05564664, -0.20404134, 1.05731107],
+        ],
+        input.dtype,
+    )
+    value = tf.tensordot(input, tf.transpose(kernel), axes=((-1,), (0,)))
+    value = tf.where(
+        tf.math.greater(value, 0.0031308),
+        tf.math.pow(value, 1.0 / 2.4) * 1.055 - 0.055,
+        value * 12.92,
+    )
+    return tf.clip_by_value(value, 0, 1)

--- a/tests/test_color_eager.py
+++ b/tests/test_color_eager.py
@@ -1,0 +1,129 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Test tfio.experimental.color"""
+
+import os
+import shutil
+import tempfile
+import numpy as np
+import pytest
+
+import skimage.color
+
+import tensorflow as tf
+import tensorflow_io as tfio
+
+
+@pytest.mark.parametrize(
+    ("data", "func", "check"),
+    [
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3)) * 256.0).astype(np.uint8),
+            tfio.experimental.color.rgb_to_bgr,
+            lambda e: e[..., ::-1],
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3)) * 256.0).astype(np.uint8),
+            tfio.experimental.color.bgr_to_rgb,
+            lambda e: e[..., ::-1],
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3)) * 256.0).astype(np.uint8),
+            tfio.experimental.color.rgb_to_rgba,
+            lambda e: np.dstack([e, np.zeros(shape=[10, 20])]),
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 4)) * 256.0).astype(np.uint8),
+            tfio.experimental.color.rgba_to_rgb,
+            lambda e: e[..., 0:3],
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3)) * 256.0).astype(np.uint8),
+            tfio.experimental.color.rgb_to_ycbcr,
+            lambda e: skimage.color.rgb2ycbcr(e).astype(np.uint8),
+        ),
+        pytest.param(
+            lambda: np.array([[[117, 147, 67]]], np.uint8),
+            tfio.experimental.color.ycbcr_to_rgb,
+            lambda e: (skimage.color.ycbcr2rgb(e.astype(np.float32)) * 255.0).astype(
+                np.uint8
+            ),
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.rgb_to_ypbpr,
+            skimage.color.rgb2ypbpr,
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.ypbpr_to_rgb,
+            skimage.color.ypbpr2rgb,
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.rgb_to_ydbdr,
+            skimage.color.rgb2ydbdr,
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.ydbdr_to_rgb,
+            skimage.color.ydbdr2rgb,
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.rgb_to_xyz,
+            skimage.color.rgb2xyz,
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.xyz_to_rgb,
+            skimage.color.xyz2rgb,
+        ),
+    ],
+    ids=[
+        "rgb_to_bgr",
+        "bgr_to_rgb",
+        "rgb_to_rgba",
+        "rgba_to_rgb",
+        "rgb_to_ycbcr",
+        "ycbcr_to_rgb",
+        "rgb_to_ypbpr",
+        "ypbpr_to_rgb",
+        "rgb_to_ydbdr",
+        "ydbdr_to_rgb",
+        "rgb_to_xyz",
+        "xyz_to_rgb",
+    ],
+)
+def test_color(data, func, check):
+    """test_io_color"""
+
+    input_3d = data()
+    expected_3d = check(input_3d)
+
+    output_3d = func(input_3d)
+    if input_3d.dtype == np.float32:
+        assert np.allclose(output_3d, expected_3d, rtol=0.005)
+    else:
+        assert np.array_equal(output_3d, expected_3d)
+
+    input_4d = tf.expand_dims(input_3d, axis=0)
+    expected_4d = tf.expand_dims(expected_3d, axis=0)
+
+    output_4d = func(input_4d)
+    if input_4d.dtype == np.float32:
+        assert np.allclose(output_4d, expected_4d, rtol=0.005)
+    else:
+        assert np.array_equal(output_4d, expected_4d)


### PR DESCRIPTION
This PR adds colorspace conversion support under tfio.experimental.color:
- tfio.experimental.color.[rgb_to_bgr|bgr_to_rgb]: BGR
- tfio.experimental.color.[rgb_to_rgba|rgba_to_rgb]: RGBA
- tfio.experimental.color.[rgb_to_ycbcr|ycbcr_to_rgb]: YCbCr
- tfio.experimental.color.[rgb_to_ypbpr|ypbpr_to_rgb]: YPbPr
- tfio.experimental.color.[rgb_to_ydbdr|ydbdr_to_rgb]: YDbDr
- tfio.experimental.color.[rgb_to_xyz|xyz_to_rgb]: CIE XYZ

Most of the implementation conforms to skimage's colorspace conversion.

This is a compliment to `tf.image.rgb_to_[hsv|yiq|yuv]` and `tf.image.[hsv|yiq|yuv]_to_rgb`
(It might make sense to alias `tf.image.rgb_to_...` and `tf.image...._to_rgb` here?)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>