### PR TITLE
Fix typo in dbscale log10(x) => log(x) / log(10)

### DIFF
--- a/tensorflow_io/core/python/experimental/audio_ops.py
+++ b/tensorflow_io/core/python/experimental/audio_ops.py
@@ -90,7 +90,7 @@ def dbscale(input, top_db, name=None):
       A tensor of mel spectrogram with shape [frames, mels].
     """
     power = tf.math.square(input)
-    log_spec = 10.0 * (tf.math.log(power) - tf.math.log(10.0))
+    log_spec = 10.0 * (tf.math.log(power) / tf.math.log(10.0))
     log_spec = tf.math.maximum(log_spec, tf.math.reduce_max(log_spec) - top_db)
     return log_spec
 


### PR DESCRIPTION
This PR fixes an issue raised in #1035 where the dbscale calculation
had a typo, should be log(x) / log(10) for log10(x)


This PR fixes #1035 

/cc @agkphysics 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>