### PR TITLE
Add CIE LAB colorspace support

### DIFF
--- a/tensorflow_io/core/python/api/experimental/color.py
+++ b/tensorflow_io/core/python/api/experimental/color.py
@@ -33,5 +33,7 @@ from tensorflow_io.core.python.experimental.color_ops import (  # pylint: disabl
     yuv_to_rgb,
     rgb_to_xyz,
     xyz_to_rgb,
+    rgb_to_lab,
+    lab_to_rgb,
     rgb_to_grayscale,
 )

--- a/tensorflow_io/core/python/experimental/color_ops.py
+++ b/tensorflow_io/core/python/experimental/color_ops.py
@@ -395,6 +395,136 @@ def xyz_to_rgb(input, name=None):
     return tf.clip_by_value(value, 0, 1)
 
 
+def rgb_to_lab(input, illuminant="D65", observer="2", name=None):
+    """
+    Convert a RGB image to CIE LAB.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      illuminant : {"A", "D50", "D55", "D65", "D75", "E"}, optional
+        The name of the illuminant (the function is NOT case sensitive).
+      observer : {"2", "10"}, optional
+        The aperture angle of the observer.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    illuminants = {
+        "A": {
+            "2": (1.098466069456375, 1, 0.3558228003436005),
+            "10": (1.111420406956693, 1, 0.3519978321919493),
+        },
+        "D50": {
+            "2": (0.9642119944211994, 1, 0.8251882845188288),
+            "10": (0.9672062750333777, 1, 0.8142801513128616),
+        },
+        "D55": {
+            "2": (0.956797052643698, 1, 0.9214805860173273),
+            "10": (0.9579665682254781, 1, 0.9092525159847462),
+        },
+        "D65": {
+            "2": (0.95047, 1.0, 1.08883),
+            "10": (0.94809667673716, 1, 1.0730513595166162),
+        },
+        "D75": {
+            "2": (0.9497220898840717, 1, 1.226393520724154),
+            "10": (0.9441713925645873, 1, 1.2064272211720228),
+        },
+        "E": {"2": (1.0, 1.0, 1.0), "10": (1.0, 1.0, 1.0)},
+    }
+    coords = tf.constant(illuminants[illuminant.upper()][observer], input.dtype)
+
+    xyz = rgb_to_xyz(input)
+
+    xyz = xyz / coords
+
+    xyz = tf.where(
+        tf.math.greater(xyz, 0.008856),
+        tf.math.pow(xyz, 1.0 / 3.0),
+        xyz * 7.787 + 16.0 / 116.0,
+    )
+
+    xyz = tf.unstack(xyz, axis=-1)
+    x, y, z = xyz[0], xyz[1], xyz[2]
+
+    # Vector scaling
+    l = (y * 116.0) - 16.0
+    a = (x - y) * 500.0
+    b = (y - z) * 200.0
+
+    return tf.stack([l, a, b], axis=-1)
+
+
+def lab_to_rgb(input, illuminant="D65", observer="2", name=None):
+    """
+    Convert a CIE LAB image to RGB.
+
+    Args:
+      input: A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+      illuminant : {"A", "D50", "D55", "D65", "D75", "E"}, optional
+        The name of the illuminant (the function is NOT case sensitive).
+      observer : {"2", "10"}, optional
+        The aperture angle of the observer.
+      name: A name for the operation (optional).
+
+    Returns:
+      A 3-D (`[H, W, 3]`) or 4-D (`[N, H, W, 3]`) Tensor.
+    """
+    input = tf.convert_to_tensor(input)
+    assert input.dtype in (tf.float16, tf.float32, tf.float64)
+
+    lab = input
+    lab = tf.unstack(lab, axis=-1)
+    l, a, b = lab[0], lab[1], lab[2]
+
+    y = (l + 16.0) / 116.0
+    x = (a / 500.0) + y
+    z = y - (b / 200.0)
+
+    z = tf.math.maximum(z, 0)
+
+    xyz = tf.stack([x, y, z], axis=-1)
+
+    xyz = tf.where(
+        tf.math.greater(xyz, 0.2068966),
+        tf.math.pow(xyz, 3.0),
+        (xyz - 16.0 / 116.0) / 7.787,
+    )
+
+    illuminants = {
+        "A": {
+            "2": (1.098466069456375, 1, 0.3558228003436005),
+            "10": (1.111420406956693, 1, 0.3519978321919493),
+        },
+        "D50": {
+            "2": (0.9642119944211994, 1, 0.8251882845188288),
+            "10": (0.9672062750333777, 1, 0.8142801513128616),
+        },
+        "D55": {
+            "2": (0.956797052643698, 1, 0.9214805860173273),
+            "10": (0.9579665682254781, 1, 0.9092525159847462),
+        },
+        "D65": {
+            "2": (0.95047, 1.0, 1.08883),
+            "10": (0.94809667673716, 1, 1.0730513595166162),
+        },
+        "D75": {
+            "2": (0.9497220898840717, 1, 1.226393520724154),
+            "10": (0.9441713925645873, 1, 1.2064272211720228),
+        },
+        "E": {"2": (1.0, 1.0, 1.0), "10": (1.0, 1.0, 1.0)},
+    }
+    coords = tf.constant(illuminants[illuminant.upper()][observer], input.dtype)
+
+    xyz = xyz * coords
+
+    return xyz_to_rgb(xyz)
+
+
 def rgb_to_grayscale(input, name=None):
     """
     Convert a RGB image to Grayscale (ITU-R).

--- a/tests/test_color_eager.py
+++ b/tests/test_color_eager.py
@@ -123,6 +123,16 @@ import tensorflow_io as tfio
         ),
         pytest.param(
             lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.rgb_to_lab,
+            skimage.color.rgb2lab,
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
+            tfio.experimental.color.lab_to_rgb,
+            skimage.color.lab2rgb,
+        ),
+        pytest.param(
+            lambda: (np.random.random((10, 20, 3))).astype(np.float32),
             tfio.experimental.color.rgb_to_grayscale,
             lambda e: tf.expand_dims(skimage.color.rgb2gray(e), axis=-1),
         ),
@@ -146,11 +156,15 @@ import tensorflow_io as tfio
         "yuv_to_rgb",
         "rgb_to_xyz",
         "xyz_to_rgb",
+        "rgb_to_lab",
+        "lab_to_rgb",
         "rgb_to_grayscale",
     ],
 )
 def test_color(data, func, check):
     """test_io_color"""
+
+    np.random.seed(1000)
 
     input_3d = data()
     expected_3d = check(input_3d)


### PR DESCRIPTION
This PR adds CIE LAB colorspace support with `tfio.experimental.color.[rgb_to_lab|lab_to_rgb]`.

CIE LAB is commonly seen in image processing such as [skimage](https://scikit-image.org/docs/stable/api/skimage.color.html) and [matlab](https://www.mathworks.com/help/images/color.html).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>