### PR TITLE
adjusted docstrings: tensorflow_io/core/python/ops

### DIFF
--- a/tensorflow_io/core/python/ops/arrow_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/arrow_io_tensor_ops.py
@@ -23,16 +23,16 @@ from tensorflow_io.core.python.ops import core_ops
 
 def _extract_table_arrays(table):
     """Get buffer info from arrays in table, outputs are padded so dim sizes
-     are rectangular.
+       are rectangular.
 
-     Args:
-       table: A pyarrow.Table
-     Return:
-       tuple of:
-         array_buffer_addrs: 3-dim list of buffer addresses where dims are
+    Args:
+        table: A pyarrow.Table
+    Return:
+        tuple of:
+        array_buffer_addrs: 3-dim list of buffer addresses where dims are
                              columns, chunks, buffer addresses
-         array_buffer_sizes: 3-dim list of buffer sizes, follows addrs layout
-         array_lengths: 3-dim list of array lengths where dims are columns,
+        array_buffer_sizes: 3-dim list of buffer sizes, follows addrs layout
+        array_lengths: 3-dim list of array lengths where dims are columns,
                         chunks, length of array followed by child array lengths
     """
     array_buffer_addrs = []

--- a/tensorflow_io/core/python/ops/audio_ops.py
+++ b/tensorflow_io/core/python/ops/audio_ops.py
@@ -284,7 +284,7 @@ class AudioIOTensor:
 
         Returns:
           A `Tensor` with value obtained from this `IOTensor`.
-        1"""
+        """
         return core_ops.io_audio_readable_read(self._resource, 0, -1, dtype=self._dtype)
 
     # =============================================================================

--- a/tensorflow_io/core/python/ops/dicom_ops.py
+++ b/tensorflow_io/core/python/ops/dicom_ops.py
@@ -32,55 +32,55 @@ def decode_dicom_image(
 ):
     """Getting DICOM Image Data.
 
-  This package has two operations which wrap `DCMTK` functions.
-  `decode_dicom_image` decodes the pixel data from DICOM files, and
-  `decode_dicom_data` decodes tag information.
-  `dicom_tags` contains useful DICOM tags such as `dicom_tags.PatientsName`.
-  We borrow the same tag notation from the
-  [`pydicom`](https://pydicom.github.io/) dicom package.
+    This package has two operations which wrap `DCMTK` functions.
+    `decode_dicom_image` decodes the pixel data from DICOM files, and
+    `decode_dicom_data` decodes tag information.
+    `dicom_tags` contains useful DICOM tags such as `dicom_tags.PatientsName`.
+    We borrow the same tag notation from the
+    [`pydicom`](https://pydicom.github.io/) dicom package.
 
-  The detailed usage of DICOM is available in
-  [tutorial](https://www.tensorflow.org/io/tutorials/dicom).
+    The detailed usage of DICOM is available in
+    [tutorial](https://www.tensorflow.org/io/tutorials/dicom).
 
-  If this package helped, please kindly cite the below:
-  ```
-  @misc{marcelo_lerendegui_2019_3337331,
-    author       = {Marcelo Lerendegui and Ouwen Huang},
-    title        = {Tensorflow Dicom Decoder},
-    month        = jul,
-    year         = 2019,
-    doi          = {10.5281/zenodo.3337331},
-    url          = {https://doi.org/10.5281/zenodo.3337331}
-  }
-  ```
+    If this package helped, please kindly cite the below:
+    ```
+    @misc{marcelo_lerendegui_2019_3337331,
+        author       = {Marcelo Lerendegui and Ouwen Huang},
+        title        = {Tensorflow Dicom Decoder},
+        month        = jul,
+        year         = 2019,
+        doi          = {10.5281/zenodo.3337331},
+        url          = {https://doi.org/10.5281/zenodo.3337331}
+    }
+    ```
 
-  Args:
-    contents: A Tensor of type string. 0-D. The byte string encoded DICOM file.
-    color_dim: An optional `bool`. Defaults to `False`. If `True`, a third
-      channel will be appended to all images forming a 3-D tensor.
-      A 1024 x 1024 grayscale image will be 1024 x 1024 x 1.
-    on_error: Defaults to `skip`. This attribute establishes the behavior in
-      case an error occurs on opening the image or if the output type cannot
-      accomodate all the possible input values. For example if the user sets
-      the output dtype to `tf.uint8`, but a dicom image stores a `tf.uint16`
-      type. `strict` throws an error. `skip` returns a 1-D empty tensor.
-      `lossy` continues with the operation scaling the value via the `scale`
-      attribute.
-    scale:  Defaults to `preserve`. This attribute establishes what to do with
-      the scale of the input values. `auto` will autoscale the input values,
-      if the output type is integer, `auto` will use the maximum output scale
-      for example a `uint8` which stores values from [0, 255] can be linearly
-      stretched to fill a `uint16` that is [0,65535]. If the output is float,
-      `auto` will scale to [0,1]. `preserve` keeps the values as they are, an
-      input value greater than the maximum possible output will be clipped.
-    dtype: An optional `tf.DType` from: `tf.uint8`, `tf.uint16`, `tf.uint32`,
-      `tf.uint64`, `tf.float16`, `tf.float32`, `tf.float64`. Defaults to
-      `tf.uint16`.
-    name: A name for the operation (optional).
+    Args:
+        contents: A Tensor of type string. 0-D. The byte string encoded DICOM file.
+        color_dim: An optional `bool`. Defaults to `False`. If `True`, a third
+        channel will be appended to all images forming a 3-D tensor.
+        A 1024 x 1024 grayscale image will be 1024 x 1024 x 1.
+        on_error: Defaults to `skip`. This attribute establishes the behavior in
+        case an error occurs on opening the image or if the output type cannot
+        accomodate all the possible input values. For example if the user sets
+        the output dtype to `tf.uint8`, but a dicom image stores a `tf.uint16`
+        type. `strict` throws an error. `skip` returns a 1-D empty tensor.
+        `lossy` continues with the operation scaling the value via the `scale`
+        attribute.
+        scale:  Defaults to `preserve`. This attribute establishes what to do with
+        the scale of the input values. `auto` will autoscale the input values,
+        if the output type is integer, `auto` will use the maximum output scale
+        for example a `uint8` which stores values from [0, 255] can be linearly
+        stretched to fill a `uint16` that is [0,65535]. If the output is float,
+        `auto` will scale to [0,1]. `preserve` keeps the values as they are, an
+        input value greater than the maximum possible output will be clipped.
+        dtype: An optional `tf.DType` from: `tf.uint8`, `tf.uint16`, `tf.uint32`,
+        `tf.uint64`, `tf.float16`, `tf.float32`, `tf.float64`. Defaults to
+        `tf.uint16`.
+        name: A name for the operation (optional).
 
-  Returns:
-    A `Tensor` of type `dtype` and the shape is determined by the DICOM file.
-  """
+    Returns:
+        A `Tensor` of type `dtype` and the shape is determined by the DICOM file.
+    """
     return core_ops.io_decode_dicom_image(
         contents=contents,
         color_dim=color_dim,
@@ -94,41 +94,41 @@ def decode_dicom_image(
 def decode_dicom_data(contents, tags=None, name=None):
     """Getting DICOM Tag Data.
 
-  This package has two operations which wrap `DCMTK` functions.
-  `decode_dicom_image` decodes the pixel data from DICOM files, and
-  `decode_dicom_data` decodes tag information.
-  `dicom_tags` contains useful DICOM tags such as `dicom_tags.PatientsName`.
-  We borrow the same tag notation from the
-  [`pydicom`](https://pydicom.github.io/) dicom package.
+    This package has two operations which wrap `DCMTK` functions.
+    `decode_dicom_image` decodes the pixel data from DICOM files, and
+    `decode_dicom_data` decodes tag information.
+    `dicom_tags` contains useful DICOM tags such as `dicom_tags.PatientsName`.
+    We borrow the same tag notation from the
+    [`pydicom`](https://pydicom.github.io/) dicom package.
 
-  The detailed usage of DICOM is available in
-  [tutorial](https://www.tensorflow.org/io/tutorials/dicom).
+    The detailed usage of DICOM is available in
+    [tutorial](https://www.tensorflow.org/io/tutorials/dicom).
 
-  If this package helped, please kindly cite the below:
-  ```
-  @misc{marcelo_lerendegui_2019_3337331,
-    author       = {Marcelo Lerendegui and Ouwen Huang},
-    title        = {Tensorflow Dicom Decoder},
-    month        = jul,
-    year         = 2019,
-    doi          = {10.5281/zenodo.3337331},
-    url          = {https://doi.org/10.5281/zenodo.3337331}
-  }
-  ```
+    If this package helped, please kindly cite the below:
+    ```
+    @misc{marcelo_lerendegui_2019_3337331,
+        author       = {Marcelo Lerendegui and Ouwen Huang},
+        title        = {Tensorflow Dicom Decoder},
+        month        = jul,
+        year         = 2019,
+        doi          = {10.5281/zenodo.3337331},
+        url          = {https://doi.org/10.5281/zenodo.3337331}
+    }
+    ```
 
-  Args:
-    contents: A Tensor of type string. 0-D. The byte string encoded DICOM file.
-    tags: A Tensor of type `tf.uint32` of any dimension.
-      These `uint32` numbers map directly to DICOM tags.
-    name: A name for the operation (optional).
+    Args:
+        contents: A Tensor of type string. 0-D. The byte string encoded DICOM file.
+        tags: A Tensor of type `tf.uint32` of any dimension.
+        These `uint32` numbers map directly to DICOM tags.
+        name: A name for the operation (optional).
 
-  Returns:
-    A `Tensor` of type `tf.string` and same shape as `tags`. If a dicom tag is
-      a list of strings, they are combined into one string and seperated by a
-      double backslash `\\`. There is a bug in
-      [DCMTK](https://support.dcmtk.org/docs/) if the tag is a list of numbers,
-      only the zeroth element will be returned as a string.
-  """
+    Returns:
+        A `Tensor` of type `tf.string` and same shape as `tags`. If a dicom tag is
+        a list of strings, they are combined into one string and seperated by a
+        double backslash `\\`. There is a bug in
+        [DCMTK](https://support.dcmtk.org/docs/) if the tag is a list of numbers,
+        only the zeroth element will be returned as a string.
+    """
     return core_ops.io_decode_dicom_data(contents=contents, tags=tags, name=name)
 
 

--- a/tensorflow_io/core/python/ops/genome_ops.py
+++ b/tensorflow_io/core/python/ops/genome_ops.py
@@ -21,14 +21,14 @@ from tensorflow_io.core.python.ops import core_ops
 def read_fastq(filename, name=None):
     """Read FastQ file into Tensor
 
-  Args:
-    filename: Filename of the FastQ file.
-    name: A name for the operation (optional).
+    Args:
+        filename: Filename of the FastQ file.
+        name: A name for the operation (optional).
 
-  Returns:
-    sequences: A string `Tensor`.
-    raw_quality: A string `Tensor`.
-  """
+    Returns:
+        sequences: A string `Tensor`.
+        raw_quality: A string `Tensor`.
+    """
     return core_ops.io_read_fastq(filename, name=name)
 
 
@@ -58,21 +58,21 @@ def _nucleotide_to_onehot(nucleotide):
 def sequences_to_onehot(sequences):
     """Convert DNA sequences into a one hot nucleotide encoding.
 
-  Each nucleotide in each sequence is mapped as follows:
-  A -> [1, 0, 0, 0]
-  C -> [0, 1, 0, 0]
-  G -> [0 ,0 ,1, 0]
-  T -> [0, 0, 0, 1]
+    Each nucleotide in each sequence is mapped as follows:
+    A -> [1, 0, 0, 0]
+    C -> [0, 1, 0, 0]
+    G -> [0 ,0 ,1, 0]
+    T -> [0, 0, 0, 1]
 
-  If for some reason a non (A, T, C, G) character exists in the string, it is
-  currently mapped to a error one hot encoding [1, 1, 1, 1].
+    If for some reason a non (A, T, C, G) character exists in the string, it is
+    currently mapped to a error one hot encoding [1, 1, 1, 1].
 
-  Args:
-    sequences: A tf.string tensor where each string represents a DNA sequence
+    Args:
+        sequences: A tf.string tensor where each string represents a DNA sequence
 
-  Returns:
-    tf.RaggedTensor: The output sequences with nucleotides one hot encoded.
-  """
+    Returns:
+        tf.RaggedTensor: The output sequences with nucleotides one hot encoded.
+    """
     all_onehot_nucleotides = tf.TensorArray(dtype=tf.int32, size=0, dynamic_size=True)
     sequence_splits = tf.TensorArray(dtype=tf.int32, size=0, dynamic_size=True)
 
@@ -115,28 +115,28 @@ def _phred_sequence_to_probability(seq_quality):
 def phred_sequences_to_probability(phred_qualities):
     """Converts raw phred quality scores into base-calling error probabilities.
 
-  For each ASCII encoded phred quality score (X), the probability that there
-  was an error calling that base is computed by:
+    For each ASCII encoded phred quality score (X), the probability that there
+    was an error calling that base is computed by:
 
-  P = 10 ^ (-(X - 33) / 10)
+    P = 10 ^ (-(X - 33) / 10)
 
-  This is assuming an "ASCII base" of 33.
+    This is assuming an "ASCII base" of 33.
 
-  The input is a tf.string tensor of ASCII encoded phred qualities,
-  one string per DNA sequence, with each character representing the quality
-  of a nucelotide.
+    The input is a tf.string tensor of ASCII encoded phred qualities,
+    one string per DNA sequence, with each character representing the quality
+    of a nucelotide.
 
-  For example:
-  phred_qualities = [["BB<"], ["BBBB"]]
+    For example:
+    phred_qualities = [["BB<"], ["BBBB"]]
 
-  Args:
-    phred_qualities: A tf.string tensor where each string represents the phred
-                     quality of a DNA sequence. Each character in the string
-                     is the ASCII representation of the phred quality number.
+    Args:
+        phred_qualities: A tf.string tensor where each string represents the phred
+                        quality of a DNA sequence. Each character in the string
+                        is the ASCII representation of the phred quality number.
 
-  Returns:
-    tf.RaggedTensor: The quality scores for each base in each sequence provided.
-  """
+    Returns:
+        tf.RaggedTensor: The quality scores for each base in each sequence provided.
+    """
     return tf.ragged.map_flat_values(
         _phred_sequence_to_probability, tf.strings.bytes_split(phred_qualities)
     )

--- a/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/hdf5_io_tensor_ops.py
@@ -63,12 +63,12 @@ class BaseHDF5GraphIOTensor:
     def to_tensor(self):
         """Converts this `IOTensor` into a `tf.Tensor`.
 
-    Args:
-      name: A name prefix for the returned tensors (optional).
+        Args:
+            name: A name prefix for the returned tensors (optional).
 
-    Returns:
-      A `Tensor` with value obtained from this `IOTensor`.
-    """
+        Returns:
+            A `Tensor` with value obtained from this `IOTensor`.
+        """
         return core_ops.io_hdf5_readable_read(
             input=self._filename,
             shared=self._filename,

--- a/tensorflow_io/core/python/ops/image_ops.py
+++ b/tensorflow_io/core/python/ops/image_ops.py
@@ -19,27 +19,27 @@ from tensorflow_io.core.python.ops import core_ops
 
 def decode_webp(contents, name=None):
     """
-  Decode a WebP-encoded image to a uint8 tensor.
+    Decode a WebP-encoded image to a uint8 tensor.
 
-  Args:
-    contents: A `Tensor` of type `string`. 0-D.  The WebP-encoded image.
-    name: A name for the operation (optional).
+    Args:
+      contents: A `Tensor` of type `string`. 0-D.  The WebP-encoded image.
+      name: A name for the operation (optional).
 
-  Returns:
-    A `Tensor` of type `uint8` and shape of `[height, width, 4]` (RGBA).
-  """
+    Returns:
+      A `Tensor` of type `uint8` and shape of `[height, width, 4]` (RGBA).
+    """
     return core_ops.io_decode_web_p(contents, name=name)
 
 
 def encode_bmp(image, name=None):
     """
-  Encode a uint8 tensor to bmp image.
+    Encode a uint8 tensor to bmp image.
 
-  Args:
-    image: A Tensor. 3-D uint8 with shape [height, width, channels].
-    name: A name for the operation (optional).
+    Args:
+      image: A Tensor. 3-D uint8 with shape [height, width, channels].
+      name: A name for the operation (optional).
 
-  Returns:
-    A `Tensor` of type `string`.
-  """
+    Returns:
+      A `Tensor` of type `string`.
+    """
     return core_ops.io_encode_bmp(image, name=name)

--- a/tensorflow_io/core/python/ops/io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/io_tensor_ops.py
@@ -190,18 +190,18 @@ class _IOTensor:
 class BaseIOTensor(_IOTensor):
     """BaseIOTensor
 
-  A `BaseIOTensor` is a basic `IOTensor` with only one component.
-  It is associated with a `Tensor` of `shape` and `dtype`, with
-  data backed by IO. It is the building block for `IOTensor`.
-  For example, a `CSVIOTensor` consists of multiple `BaseIOTensor`
-  where each one is a column of the CSV.
+    A `BaseIOTensor` is a basic `IOTensor` with only one component.
+    It is associated with a `Tensor` of `shape` and `dtype`, with
+    data backed by IO. It is the building block for `IOTensor`.
+    For example, a `CSVIOTensor` consists of multiple `BaseIOTensor`
+    where each one is a column of the CSV.
 
-  All `IOTensor` types are either a subclass of `BaseIOTensor`,
-  or are a composite of a collection of `BaseIOTensor`.
+    All `IOTensor` types are either a subclass of `BaseIOTensor`,
+    or are a composite of a collection of `BaseIOTensor`.
 
-  The additional properties exposed by `BaseIOTensor` are `shape`
-  and `dtype` associated with counterparts in `Tensor`.
-  """
+    The additional properties exposed by `BaseIOTensor` are `shape`
+    and `dtype` associated with counterparts in `Tensor`.
+    """
 
     def __init__(self, spec, function, internal=False):
         # function used for dataset should not be partitioned.
@@ -283,17 +283,17 @@ class BaseIOTensor(_IOTensor):
     def to_tensor(self, **kwargs):
         """Converts this `IOTensor` into a `tf.Tensor`.
 
-    Example:
+        Example:
 
-    ```python
-    ```
+        ```python
+        ```
 
-    Args:
-      name: A name prefix for the returned tensors (optional).
+        Args:
+            name: A name prefix for the returned tensors (optional).
 
-    Returns:
-      A `Tensor` with value obtained from this `IOTensor`.
-    """
+        Returns:
+            A `Tensor` with value obtained from this `IOTensor`.
+        """
         with tf.name_scope(kwargs.get("name", "IOToTensor")):
             return self.__getitem__(slice(None, None))
 
@@ -301,8 +301,8 @@ class BaseIOTensor(_IOTensor):
 class ScalarIOTensor(BaseIOTensor):
     """ScalarIOTensor
 
-  A `ScalarIOTensor` is an `IOTensor` from a scalar `Tensor`.
-  """
+    A `ScalarIOTensor` is an `IOTensor` from a scalar `Tensor`.
+    """
 
     def __init__(self, spec, tensor, internal=False):
         tensor = tf.convert_to_tensor(tensor)
@@ -317,17 +317,17 @@ class ScalarIOTensor(BaseIOTensor):
     def to_tensor(self, **kwargs):
         """Converts this `IOTensor` into a `tf.Tensor`.
 
-    Example:
+        Example:
 
-    ```python
-    ```
+        ```python
+        ```
 
-    Args:
-      name: A name prefix for the returned tensors (optional).
+        Args:
+            name: A name prefix for the returned tensors (optional).
 
-    Returns:
-      A `Tensor` with value obtained from this `IOTensor`.
-    """
+        Returns:
+            A `Tensor` with value obtained from this `IOTensor`.
+        """
         with tf.name_scope(kwargs.get("name", "IOToTensor")):
             return self._tensor
 
@@ -335,8 +335,8 @@ class ScalarIOTensor(BaseIOTensor):
 class TensorIOTensor(BaseIOTensor):
     """TensorIOTensor
 
-  A `TensorIOTensor` is an `IOTensor` from a regular `Tensor`.
-  """
+    A `TensorIOTensor` is an `IOTensor` from a regular `Tensor`.
+    """
 
     def __init__(self, tensor, internal=False):
         tensor = tf.convert_to_tensor(tensor)
@@ -379,17 +379,17 @@ class TensorIOTensor(BaseIOTensor):
     def to_tensor(self, **kwargs):
         """Converts this `IOTensor` into a `tf.Tensor`.
 
-    Example:
+        Example:
 
-    ```python
-    ```
+        ```python
+        ```
 
-    Args:
-      name: A name prefix for the returned tensors (optional).
+        Args:
+            name: A name prefix for the returned tensors (optional).
 
-    Returns:
-      A `Tensor` with value obtained from this `IOTensor`.
-    """
+        Returns:
+            A `Tensor` with value obtained from this `IOTensor`.
+        """
         with tf.name_scope(kwargs.get("name", "IOToTensor")):
             return self._tensor
 
@@ -420,14 +420,14 @@ class _TableIOTensor(_IOTensor):
 class _CollectionIOTensor(_IOTensor):
     """_CollectionIOTensor
 
-  `CollectionIOTensor` is differnt from `TableIOTensor` in that each
-  component could have different shapes. While additional table-wide
-  operations are planned to be supported for `TableIOTensor` so that
-  the same operations could be applied to every column, there is no plan
-  to support the same in `CollectionIOTensor`. In other words,
-  `CollectionIOTensor` is only a dictionary with values consisting
-  of `BaseIOTensor`.
-  """
+    `CollectionIOTensor` is different from `TableIOTensor` in that each
+    component could have different shapes. While additional table-wide
+    operations are planned to be supported for `TableIOTensor` so that
+    the same operations could be applied to every column, there is no plan
+    to support the same in `CollectionIOTensor`. In other words,
+    `CollectionIOTensor` is only a dictionary with values consisting
+    of `BaseIOTensor`.
+    """
 
     def __init__(self, spec, keys, values, internal=False):
         self._keys = keys

--- a/tensorflow_io/core/python/ops/kafka_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_io_tensor_ops.py
@@ -67,12 +67,12 @@ class KafkaIOTensor:
     def to_tensor(self):
         """Converts this `IOTensor` into a `tf.Tensor`.
 
-    Args:
-      name: A name prefix for the returned tensors (optional).
+        Args:
+            name: A name prefix for the returned tensors (optional).
 
-    Returns:
-      A `Tensor` with value obtained from this `IOTensor`.
-    """
+        Returns:
+            A `Tensor` with value obtained from this `IOTensor`.
+        """
         item, _ = core_ops.io_kafka_readable_read(self._resource, start=0, stop=-1)
         return item
 

--- a/tensorflow_io/core/python/ops/mnist_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/mnist_dataset_ops.py
@@ -23,9 +23,10 @@ class MNISTLabelIODataset(tf.data.Dataset):
 
     def __init__(self, filename):
         """Create a MNISTLabelDataset.
-    Args:
-      filename: A `tf.string` tensor containing filename.
-    """
+        
+        Args:
+            filename: A `tf.string` tensor containing filename.
+        """
         _, compression = core_ops.io_file_info(filename)
         dataset = tf.data.FixedLengthRecordDataset(
             filename, 1, header_bytes=8, compression_type=compression
@@ -52,9 +53,10 @@ class MNISTImageIODataset(tf.data.Dataset):
 
     def __init__(self, filename):
         """Create a MNISTImageDataset.
-    Args:
-      filename: A `tf.string` tensor containing filename.
-    """
+        
+        Args:
+            filename: A `tf.string` tensor containing filename.
+        """
         _, compression = core_ops.io_file_info(filename)
         rows = tf.io.decode_raw(
             core_ops.io_file_read(filename, 8, 4, compression=compression),

--- a/tensorflow_io/core/python/ops/parquet_io_tensor_ops.py
+++ b/tensorflow_io/core/python/ops/parquet_io_tensor_ops.py
@@ -62,11 +62,12 @@ class BaseParquetGraphIOTensor:
 
     def to_tensor(self):
         """Converts this `IOTensor` into a `tf.Tensor`.
-    Args:
-      name: A name prefix for the returned tensors (optional).
-    Returns:
-      A `Tensor` with value obtained from this `IOTensor`.
-    """
+
+        Args:
+            name: A name prefix for the returned tensors (optional).
+        Returns:
+            A `Tensor` with value obtained from this `IOTensor`.
+        """
         return core_ops.io_parquet_readable_read(
             input=self._filename,
             shared=self._filename,


### PR DESCRIPTION
This PR addresses the issue:https://github.com/tensorflow/io/issues/861 by adjusting the docstrings of modules in `tensorflow_io/core/python/ops`.