### PR TITLE
Updated docstrings: tensorflow_io/kafka/python/ops

### DIFF
--- a/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
@@ -35,8 +35,7 @@ warnings.warn(
 
 
 class KafkaDataset(data.Dataset):
-    """A Kafka Dataset that consumes the message.
-  """
+    """A Kafka Dataset that consumes the messages."""
 
     def __init__(
         self,
@@ -51,28 +50,29 @@ class KafkaDataset(data.Dataset):
     ):
         """Create a KafkaReader.
 
-    Args:
-      topics: A `tf.string` tensor containing one or more subscriptions,
-              in the format of [topic:partition:offset:length],
-              by default length is -1 for unlimited.
-      servers: A list of bootstrap servers.
-      group: The consumer group id.
-      eof: If True, the kafka reader will stop on EOF.
-      timeout: The timeout value for the Kafka Consumer to wait
-               (in millisecond).
-      config_global: A `tf.string` tensor containing global configuration
-                     properties in [Key=Value] format,
-                     eg. ["enable.auto.commit=false",
-                          "heartbeat.interval.ms=2000"],
-                     please refer to 'Global configuration properties'
-                     in librdkafka doc.
-      config_topic: A `tf.string` tensor containing topic configuration
-                    properties in [Key=Value] format,
-                    eg. ["auto.offset.reset=earliest"],
-                    please refer to 'Topic configuration properties'
-                    in librdkafka doc.
-      message_key: If True, the kafka will output both message value and key.
-    """
+        Args:
+            topics: A `tf.string` tensor containing one or more subscriptions,
+                    in the format of [topic:partition:offset:length],
+                    by default length is -1 for unlimited.
+                    eg. ["sampleTopic:0:0:10"]
+            servers: A list of bootstrap servers.
+            group: The consumer group id.
+            eof: If True, the kafka reader will stop on EOF.
+            timeout: The timeout value for the Kafka Consumer to wait
+                    (in milliseconds).
+            config_global: A `tf.string` tensor containing global configuration
+                            properties in [Key=Value] format,
+                            eg. ["enable.auto.commit=false",
+                                "heartbeat.interval.ms=2000"],
+                            please refer to 'Global configuration properties'
+                            in librdkafka doc.
+            config_topic: A `tf.string` tensor containing topic configuration
+                            properties in [Key=Value] format,
+                            eg. ["auto.offset.reset=earliest"],
+                            please refer to 'Topic configuration properties'
+                            in librdkafka doc.
+            message_key: If True, the kafka will output both message value and key.
+        """
         self._topics = tf.convert_to_tensor(topics, dtype=dtypes.string, name="topics")
         self._servers = tf.convert_to_tensor(
             servers, dtype=dtypes.string, name="servers"
@@ -128,16 +128,18 @@ class KafkaDataset(data.Dataset):
 
 
 def write_kafka(message, topic, servers="localhost", name=None):
+    """Write messages to the kafka topic
+
+    Args:
+        message: The `tf.string` tensor containing the message
+            to be written into the topic.
+        topic: A `tf.string` tensor containing one subscription,
+            in the format of topic:partition.
+        servers: A list of bootstrap servers.
+        name: A name for the operation (optional).
+    Returns:
+        A `Tensor` of type `string`. 0-D.
     """
-  Args:
-      message: A `Tensor` of type `string`. 0-D.
-      topic: A `tf.string` tensor containing one subscription,
-        in the format of topic:partition.
-      servers: A list of bootstrap servers.
-      name: A name for the operation (optional).
-  Returns:
-      A `Tensor` of type `string`. 0-D.
-  """
     return core_ops.io_write_kafka(
         message=message, topic=topic, servers=servers, name=name
     )

--- a/tensorflow_io/kafka/python/ops/kafka_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_ops.py
@@ -22,7 +22,18 @@ class KafkaOutputSequence:
 
     def __init__(self, topic, servers="localhost", configuration=None):
         """Create a `KafkaOutputSequence`.
-    """
+
+        Args:
+            topic: A `tf.string` tensor containing one subscription,
+                in the format of topic:partition.
+            servers: A list of bootstrap servers.
+            configuration: A `tf.string` tensor containing global configuration
+                            properties in [Key=Value] format,
+                            eg. ["enable.auto.commit=false",
+                                "heartbeat.interval.ms=2000"],
+                            please refer to 'Global configuration properties'
+                            in librdkafka doc.
+        """
         self._topic = topic
         metadata = list(configuration or [])
         if servers is not None:
@@ -32,7 +43,15 @@ class KafkaOutputSequence:
         )
 
     def setitem(self, index, item):
+        """Set an indexed item in the `KafkaOutputSequence`.
+
+        Args:
+            index: An index in the sequence. The index tensor must be a scalar.
+            item: the item which is associated with the index in the output sequence.
+                    The item tensor must be a scalar.
+        """
         core_ops.io_kafka_output_sequence_set_item(self._resource, index, item)
 
     def flush(self):
+        """Flush the `KafkaOutputSequence`."""
         core_ops.io_kafka_output_sequence_flush(self._resource)


### PR DESCRIPTION
This PR addresses the issue: https://github.com/tensorflow/io/issues/861 and also updates the content of the docstrings for the modules in `tensorflow_io/kafka/python/ops` sub-package.

- [x] tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
- [x] tensorflow_io/kafka/python/ops/kafka_ops.py

This hopefully fixes the API docs view in:
1. https://www.tensorflow.org/io/api_docs/python/tfio/kafka/KafkaOutputSequence
2. https://www.tensorflow.org/io/api_docs/python/tfio/kafka/write_kafka
