### PR TITLE
Added test cases to tests/test_kafka.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tfio_*.tar.gz
 # Prometheus
 .coredns
 .prometheus
+
+# Kafka
+/confluent*

--- a/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/kafka/python/ops/kafka_dataset_ops.py
@@ -54,7 +54,11 @@ class KafkaDataset(data.Dataset):
             topics: A `tf.string` tensor containing one or more subscriptions,
                     in the format of [topic:partition:offset:length],
                     by default length is -1 for unlimited.
-                    eg. ["sampleTopic:0:0:10"]
+                    eg. ["sampleTopic:0:0:10"] will fetch the first 10 messages from
+                    the 0th partition of sampleTopic.
+                    eg. ["sampleTopic:0:0:10","sampleTopic:1:0:10"] will fetch
+                    the first 10 messages from the 0th partition followed
+                    by the first 10 messages from the 1st partition of sampleTopic.
             servers: A list of bootstrap servers.
             group: The consumer group id.
             eof: If True, the kafka reader will stop on EOF.

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -408,7 +408,7 @@ class KafkaDatasetTest(test.TestCase):
             )
             for i in range(5):
                 self.assertEqual(
-                    (("D" + str(i * 2)).encode(), ("K0")), sess.run(get_next),
+                    (("D" + str(i * 2)).encode(), (b"K0")), sess.run(get_next),
                 )
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -408,7 +408,7 @@ class KafkaDatasetTest(test.TestCase):
             )
             for i in range(5):
                 self.assertEqual(
-                    (("D" + str(i * 2)).encode(), ("K0").encode()), sess.run(get_next),
+                    (("D" + str(i * 2)).encode(), ("K0")), sess.run(get_next),
                 )
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)
@@ -420,8 +420,7 @@ class KafkaDatasetTest(test.TestCase):
             )
             for i in range(5):
                 self.assertEqual(
-                    (("D" + str(i * 2 + 1)).encode(), ("K1").encode()),
-                    sess.run(get_next),
+                    (("D" + str(i * 2 + 1)).encode(), (b"K1")), sess.run(get_next),
                 )
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -40,11 +40,12 @@ class KafkaDatasetTest(test.TestCase):
     # To setup the Kafka server:
     # $ bash kafka_test.sh start kafka
     #
-    # To team down the Kafka server:
+    # To tear down the Kafka server:
     # $ bash kafka_test.sh stop kafka
 
     def test_kafka_dataset(self):
-        """Tests for KafkaDataset."""
+        """Tests for KafkaDataset when reading non-keyed messages
+        from a single-partitioned topic"""
         topics = tf.compat.v1.placeholder(dtypes.string, shape=[None])
         num_epochs = tf.compat.v1.placeholder(dtypes.int64, shape=[])
         batch_size = tf.compat.v1.placeholder(dtypes.int64, shape=[])
@@ -60,21 +61,21 @@ class KafkaDatasetTest(test.TestCase):
         get_next = iterator.get_next()
 
         with self.cached_session() as sess:
-            # Basic test: read from topic 0.
+            # Basic test: read a limited number of messages from the topic.
             sess.run(init_op, feed_dict={topics: ["test:0:0:4"], num_epochs: 1})
             for i in range(5):
                 self.assertEqual(("D" + str(i)).encode(), sess.run(get_next))
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)
 
-            # Basic test: read from topic 1.
+            # Basic test: read all the messages from the topic from offset 5.
             sess.run(init_op, feed_dict={topics: ["test:0:5:-1"], num_epochs: 1})
             for i in range(5):
                 self.assertEqual(("D" + str(i + 5)).encode(), sess.run(get_next))
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)
 
-            # Basic test: read from both topics.
+            # Basic test: read from different subscriptions of the same topic.
             sess.run(
                 init_op,
                 feed_dict={topics: ["test:0:0:4", "test:0:5:-1"], num_epochs: 1},
@@ -87,7 +88,7 @@ class KafkaDatasetTest(test.TestCase):
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)
 
-            # Test repeated iteration through both files.
+            # Test repeated iteration through both subscriptions.
             sess.run(
                 init_op,
                 feed_dict={topics: ["test:0:0:4", "test:0:5:-1"], num_epochs: 10},
@@ -101,7 +102,7 @@ class KafkaDatasetTest(test.TestCase):
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)
 
-            # Test batched and repeated iteration through both files.
+            # Test batched and repeated iteration through both subscriptions.
             sess.run(
                 init_batch_op,
                 feed_dict={
@@ -276,7 +277,8 @@ class KafkaDatasetTest(test.TestCase):
                 sess.run(get_next)
 
     def test_kafka_dataset_with_key(self):
-        """Tests for KafkaDataset."""
+        """Tests for KafkaDataset when reading keyed-messages
+        from a single-partitioned topic"""
         topics = tf.compat.v1.placeholder(dtypes.string, shape=[None])
         num_epochs = tf.compat.v1.placeholder(dtypes.int64, shape=[])
         batch_size = tf.compat.v1.placeholder(dtypes.int64, shape=[])
@@ -288,10 +290,11 @@ class KafkaDatasetTest(test.TestCase):
 
         iterator = data.Iterator.from_structure(batch_dataset.output_types)
         init_op = iterator.make_initializer(repeat_dataset)
+        init_batch_op = iterator.make_initializer(batch_dataset)
         get_next = iterator.get_next()
 
         with self.cached_session() as sess:
-            # Basic test: read from topic 0.
+            # Basic test: read a limited number of keyed messages from the topic.
             sess.run(init_op, feed_dict={topics: ["key-test:0:0:4"], num_epochs: 1})
             for i in range(5):
                 self.assertEqual(
@@ -300,6 +303,182 @@ class KafkaDatasetTest(test.TestCase):
                 )
             with self.assertRaises(errors.OutOfRangeError):
                 sess.run(get_next)
+
+            # Basic test: read all the keyed messages from the topic from offset 5.
+            sess.run(init_op, feed_dict={topics: ["key-test:0:5:-1"], num_epochs: 1})
+            for i in range(5):
+                self.assertEqual(
+                    (("D" + str(i + 5)).encode(), ("K" + str((i + 5) % 2)).encode()),
+                    sess.run(get_next),
+                )
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
+
+            # Basic test: read from different subscriptions of the same topic.
+            sess.run(
+                init_op,
+                feed_dict={
+                    topics: ["key-test:0:0:4", "key-test:0:5:-1"],
+                    num_epochs: 1,
+                },
+            )
+            for j in range(2):
+                for i in range(5):
+                    self.assertEqual(
+                        (
+                            ("D" + str(i + j * 5)).encode(),
+                            ("K" + str((i + j * 5) % 2)).encode(),
+                        ),
+                        sess.run(get_next),
+                    )
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
+
+            # Test repeated iteration through both subscriptions.
+            sess.run(
+                init_op,
+                feed_dict={
+                    topics: ["key-test:0:0:4", "key-test:0:5:-1"],
+                    num_epochs: 10,
+                },
+            )
+            for _ in range(10):
+                for j in range(2):
+                    for i in range(5):
+                        self.assertEqual(
+                            (
+                                ("D" + str(i + j * 5)).encode(),
+                                ("K" + str((i + j * 5) % 2)).encode(),
+                            ),
+                            sess.run(get_next),
+                        )
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
+
+            # Test batched and repeated iteration through both subscriptions.
+            sess.run(
+                init_batch_op,
+                feed_dict={
+                    topics: ["key-test:0:0:4", "key-test:0:5:-1"],
+                    num_epochs: 10,
+                    batch_size: 5,
+                },
+            )
+            for _ in range(10):
+                self.assertAllEqual(
+                    [
+                        [("D" + str(i)).encode() for i in range(5)],
+                        [("K" + str(i % 2)).encode() for i in range(5)],
+                    ],
+                    sess.run(get_next),
+                )
+                self.assertAllEqual(
+                    [
+                        [("D" + str(i + 5)).encode() for i in range(5)],
+                        [("K" + str((i + 5) % 2)).encode() for i in range(5)],
+                    ],
+                    sess.run(get_next),
+                )
+
+    def test_kafka_dataset_with_partitioned_key(self):
+        """Tests for KafkaDataset when reading keyed-messages
+        from a multi-partitioned topic"""
+        topics = tf.compat.v1.placeholder(dtypes.string, shape=[None])
+        num_epochs = tf.compat.v1.placeholder(dtypes.int64, shape=[])
+        batch_size = tf.compat.v1.placeholder(dtypes.int64, shape=[])
+
+        repeat_dataset = kafka_io.KafkaDataset(
+            topics, group="test", eof=True, message_key=True
+        ).repeat(num_epochs)
+        batch_dataset = repeat_dataset.batch(batch_size)
+
+        iterator = data.Iterator.from_structure(batch_dataset.output_types)
+        init_op = iterator.make_initializer(repeat_dataset)
+        init_batch_op = iterator.make_initializer(batch_dataset)
+        get_next = iterator.get_next()
+
+        with self.cached_session() as sess:
+            # Basic test: read first 5 messages from the first partition of the topic.
+            # NOTE: The key-partition mapping occurs based on the order in which the data
+            # is being stored in kafka. Please check kafka_test.sh for the sample data.
+
+            sess.run(
+                init_op,
+                feed_dict={topics: ["key-partition-test:0:0:5"], num_epochs: 1},
+            )
+            for i in range(5):
+                self.assertEqual(
+                    (("D" + str(i * 2)).encode(), ("K0").encode()), sess.run(get_next),
+                )
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
+
+            # Basic test: read first 5 messages from the second partition of the topic.
+            sess.run(
+                init_op,
+                feed_dict={topics: ["key-partition-test:1:0:5"], num_epochs: 1},
+            )
+            for i in range(5):
+                self.assertEqual(
+                    (("D" + str(i * 2 + 1)).encode(), ("K1").encode()),
+                    sess.run(get_next),
+                )
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
+
+            # Basic test: read from different subscriptions to the same topic.
+            sess.run(
+                init_op,
+                feed_dict={
+                    topics: ["key-partition-test:0:0:5", "key-partition-test:1:0:5"],
+                    num_epochs: 1,
+                },
+            )
+            for j in range(2):
+                for i in range(5):
+                    self.assertEqual(
+                        (("D" + str(i * 2 + j)).encode(), ("K" + str(j)).encode()),
+                        sess.run(get_next),
+                    )
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
+
+            # Test repeated iteration through both subscriptions.
+            sess.run(
+                init_op,
+                feed_dict={
+                    topics: ["key-partition-test:0:0:5", "key-partition-test:1:0:5"],
+                    num_epochs: 10,
+                },
+            )
+            for _ in range(10):
+                for j in range(2):
+                    for i in range(5):
+                        self.assertEqual(
+                            (("D" + str(i * 2 + j)).encode(), ("K" + str(j)).encode()),
+                            sess.run(get_next),
+                        )
+            with self.assertRaises(errors.OutOfRangeError):
+                sess.run(get_next)
+
+            # Test batched and repeated iteration through both subscriptions.
+            sess.run(
+                init_batch_op,
+                feed_dict={
+                    topics: ["key-partition-test:0:0:5", "key-partition-test:1:0:5"],
+                    num_epochs: 10,
+                    batch_size: 5,
+                },
+            )
+            for _ in range(10):
+                for j in range(2):
+                    self.assertAllEqual(
+                        [
+                            [("D" + str(i * 2 + j)).encode() for i in range(5)],
+                            [("K" + str(j)).encode() for i in range(5)],
+                        ],
+                        sess.run(get_next),
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/test_kafka/kafka_test.sh
+++ b/tests/test_kafka/kafka_test.sh
@@ -19,25 +19,41 @@ set -o pipefail
 
 VERSION=5.4.1
 
+echo "Downloading the confluent packages"
 curl -sSOL http://packages.confluent.io/archive/5.4/confluent-community-5.4.1-2.12.tar.gz
 tar -xzf confluent-community-5.4.1-2.12.tar.gz
+
 (cd confluent-$VERSION/ && sudo bin/zookeeper-server-start -daemon etc/kafka/zookeeper.properties)
-echo Wait 10 secs until zookeeper is up and running
+echo "Waiting for 10 secs until zookeeper is up and running"
 sleep 10
+
 (cd confluent-$VERSION/ && sudo bin/kafka-server-start -daemon etc/kafka/server.properties)
-echo Wait 10 secs until kafka is up and running
+echo "Waiting for 10 secs until kafka is up and running"
 sleep 10
+
 (cd confluent-$VERSION/ && sudo bin/schema-registry-start -daemon etc/schema-registry/schema-registry.properties)
 echo -e "D0\nD1\nD2\nD3\nD4\nD5\nD6\nD7\nD8\nD9" > confluent-$VERSION/test
 echo -e "K0:D0\nK1:D1\nK0:D2\nK1:D3\nK0:D4\nK1:D5\nK0:D6\nK1:D7\nK0:D8\nK1:D9" > confluent-$VERSION/key-test
-echo Wait 15 secs until all is up and running
+echo -e "K0:D0\nK1:D1\nK0:D2\nK1:D3\nK0:D4\nK1:D5\nK0:D6\nK1:D7\nK0:D8\nK1:D9" > confluent-$VERSION/key-partition-test
+echo "Waiting for 15 secs until schema registry is ready and other services are up and running"
 sleep 15
+
+echo "Creating and populating 'test' topic with sample non-keyed messages"
 sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test
 sudo confluent-$VERSION/bin/kafka-console-producer --topic test --broker-list 127.0.0.1:9092 < confluent-$VERSION/test
+
+echo "Creating and populating 'key-test' topic with sample keyed messages"
 sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic key-test
 sudo confluent-$VERSION/bin/kafka-console-producer --topic key-test --property "parse.key=true" --property "key.separator=:" --broker-list 127.0.0.1:9092 < confluent-$VERSION/key-test
+
+echo "Creating and populating 'key-partition-test' multi-partition topic with sample keyed messages"
+sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 2 --topic key-partition-test
+sudo confluent-$VERSION/bin/kafka-console-producer --topic key-partition-test --property "parse.key=true" --property "key.separator=:" --broker-list 127.0.0.1:9092 < confluent-$VERSION/key-partition-test
+
+echo "Creating and populating 'avro-test' topic with sample messages."
 sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic avro-test
 echo -e "{\"f1\":\"value1\",\"f2\":1,\"f3\":null}\n{\"f1\":\"value2\",\"f2\":2,\"f3\":{\"string\":\"2\"}}\n{\"f1\":\"value3\",\"f2\":3,\"f3\":null}" > confluent-$VERSION/avro-test
 sudo confluent-$VERSION/bin/kafka-avro-console-producer --broker-list localhost:9092 --topic avro-test --property value.schema="{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"long\"},{\"name\":\"f3\",\"type\":[\"null\",\"string\"],\"default\":null}]}" < confluent-$VERSION/avro-test
-echo Everything started
+
+echo "Kafka test setup completed."
 exit 0


### PR DESCRIPTION
This PR extends the testing of `KafkaDataset` functionality by:

- [x] extending `test_kafka_dataset_with_key` method.
- [x] creating and populating a new topic `key-partition-test` with 2 partitions.
- [x] creating a new `test_kafka_dataset_with_partitioned_key` method to test partition based data storage and retrieval.

