### PR TITLE
Fix failing build on master due to TF C++ API changes

### DIFF
--- a/tensorflow_io/arrow/kernels/arrow_dataset_ops.cc
+++ b/tensorflow_io/arrow/kernels/arrow_dataset_ops.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "arrow/util/io_util.h"
 #include "tensorflow/core/framework/dataset.h"
 #include "tensorflow/core/graph/graph.h"
+#include "tensorflow/core/public/version.h"
 #include "tensorflow_io/arrow/kernels/arrow_kernels.h"
 #include "tensorflow_io/arrow/kernels/arrow_stream_client.h"
 #include "tensorflow_io/arrow/kernels/arrow_util.h"
@@ -260,6 +261,10 @@ class ArrowDatasetBase : public DatasetBase {
       switch (element.dtype()) {
         TF_CALL_ALL_TYPES(HANDLE_TYPE);
         TF_CALL_QUANTIZED_TYPES(HANDLE_TYPE);
+#if TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION == 3
+        TF_CALL_uint32(HANDLE_TYPE);
+        TF_CALL_uint64(HANDLE_TYPE);
+#endif
 #undef HANDLE_TYPE
         default:
           return errors::Unimplemented(

--- a/tensorflow_io/arrow/kernels/arrow_dataset_ops.cc
+++ b/tensorflow_io/arrow/kernels/arrow_dataset_ops.cc
@@ -260,8 +260,6 @@ class ArrowDatasetBase : public DatasetBase {
       switch (element.dtype()) {
         TF_CALL_ALL_TYPES(HANDLE_TYPE);
         TF_CALL_QUANTIZED_TYPES(HANDLE_TYPE);
-        TF_CALL_uint32(HANDLE_TYPE);
-        TF_CALL_uint64(HANDLE_TYPE);
 #undef HANDLE_TYPE
         default:
           return errors::Unimplemented(

--- a/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
+++ b/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
@@ -91,7 +91,7 @@ class BigQueryClientOp : public OpKernel {
     }
     OP_REQUIRES_OK(ctx, MakeResourceHandleToOutput(
                             ctx, 0, cinfo_.container(), cinfo_.name(),
-                            MakeTypeIndex<BigQueryClientResource>()));
+                            TypeIndex::Make<BigQueryClientResource>()));
   }
 
  private:

--- a/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
+++ b/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
@@ -89,7 +89,7 @@ class BigQueryTestClientOp : public OpKernel {
     }
     OP_REQUIRES_OK(ctx, MakeResourceHandleToOutput(
                             ctx, 0, cinfo_.container(), cinfo_.name(),
-                            MakeTypeIndex<BigQueryClientResource>()));
+                            TypeIndex::Make<BigQueryClientResource>()));
   }
 
  private:


### PR DESCRIPTION
I've been building against TF nightly, and my repo wasn't building due to some TF changes.  Attached are the fixes with the references to the breaking TF commits.

I've also just signed the Google Contributor Agreement.

The TF version I was building against is `2.4.0.dev20200718`