### PR TITLE
Experimental support for kafka consumer group based offset management and message consumption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,10 +312,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8.3
+          python-version: 3.8.4
       - name: Bazel on Windows
         env:
-          PYTHON_VERSION: 3.8.3
+          PYTHON_VERSION: 3.8.4
           BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
         shell: cmd
         run: |

--- a/tensorflow_io/core/ops/kafka_ops.cc
+++ b/tensorflow_io/core/ops/kafka_ops.cc
@@ -103,6 +103,28 @@ REGISTER_OP("IO>LayerKafkaSync")
     .Input("resource: resource")
     .SetShapeFn(shape_inference::ScalarShape);
 
+REGISTER_OP("IO>KafkaGroupReadableInit")
+    .Input("topics: string")
+    .Input("metadata: string")
+    .Output("resource: resource")
+    .Attr("container: string = ''")
+    .Attr("shared_name: string = ''")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Scalar());
+      return Status::OK();
+    });
+
+REGISTER_OP("IO>KafkaGroupReadableNext")
+    .Input("input: resource")
+    .Input("index: int64")
+    .Output("message: string")
+    .Output("key: string")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->MakeShape({c->UnknownDim()}));
+      c->set_output(1, c->MakeShape({c->UnknownDim()}));
+      return Status::OK();
+    });
+
 }  // namespace
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/python/api/experimental/__init__.py
+++ b/tensorflow_io/core/python/api/experimental/__init__.py
@@ -25,3 +25,4 @@ from tensorflow_io.core.python.api.experimental import text
 from tensorflow_io.core.python.api.experimental import columnar
 from tensorflow_io.core.python.api.experimental import color
 from tensorflow_io.core.python.api.experimental import audio
+from tensorflow_io.core.python.api.experimental import streaming

--- a/tensorflow_io/core/python/api/experimental/streaming.py
+++ b/tensorflow_io/core/python/api/experimental/streaming.py
@@ -1,0 +1,19 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""tensorflow_io.experimental.streaming"""
+
+from tensorflow_io.core.python.experimental.kafka_group_io_dataset_ops import (  # pylint: disable=unused-import
+    KafkaGroupIODataset,
+)

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -38,13 +38,13 @@ class KafkaGroupIODataset(tf.data.Dataset):
         can be changed to `7000ms`. However, the value for `session.timeout.ms` should be
         according to the following relation:
 
-        `group.max.session.timeout.ms` in server.properties > `session.timeout.ms` in the
+        - `group.max.session.timeout.ms` in server.properties > `session.timeout.ms` in the
         consumer.properties.
-        `group.min.session.timeout.ms` in server.properties < `session.timeout.ms` in the
+        - `group.min.session.timeout.ms` in server.properties < `session.timeout.ms` in the
         consumer.properties
 
         Args:
-          topic: A `tf.string` tensor containing topic names in [topic] format.
+          topics: A `tf.string` tensor containing topic names in [topic] format.
             For example: ["topic1"]
           group_id: The id of the consumer group. For example: cgstream
           servers: An optional list of bootstrap servers.

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -1,0 +1,96 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""KafkaGroupIODatasets"""
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
+
+
+class KafkaGroupIODataset(tf.data.Dataset):
+    """KafkaGroupIODataset"""
+
+    def __init__(self, topics, group_id, servers, configuration, internal=True):
+        """Creates an `IODataset` from kafka server by joining a consumer group
+        and maintaining offsets of all the partitions without explicit initialization.
+        If the consumer joins an existing consumer group, it will start fetching
+        messages based on the already committed offsets. To start fetching the messages
+        from the beginning, please join a different consumer group. The dataset will be prepared
+        from the committed/start offset until the last offset.
+
+        NOTE: Cases may arise where the consumer read time out issues arise due to
+        the consumer group being in a rebalancing state. In order to address that, please
+        set `session.timeout.ms` and `max.poll.interval.ms` values in the configuration tensor
+        and try again after the group rebalances. For example: considering your kafka cluster
+        has been setup with the default settings, `max.poll.interval.ms` would be `300000ms`.
+        It can be changed to `8000ms` to reduce the time between pools. Also, the `session.timeout.ms`
+        can be changed to `7000ms`. However, the value for `session.timeout.ms` should be
+        according to the following relation:
+
+        `group.max.session.timeout.ms` in server.properties > `session.timeout.ms` in the
+        consumer.properties.
+        `group.min.session.timeout.ms` in server.properties < `session.timeout.ms` in the
+        consumer.properties
+
+        Args:
+          topic: A `tf.string` tensor containing topic names in [topic] format.
+            For example: ["topic1"]
+          group_id: The id of the consumer group. For example: cgstream
+          servers: An optional list of bootstrap servers.
+            For example: `localhost:9092`.
+          configuration: An optional `tf.string` tensor containing
+            configurations in [Key=Value] format.
+            Global configuration: please refer to 'Global configuration properties'
+              in librdkafka doc. Examples include
+              ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
+            Topic configuration: please refer to 'Topic configuration properties'
+              in librdkafka doc. Note all topic configurations should be
+              prefixed with `configuration.topic.`. Examples include
+              ["conf.topic.auto.offset.reset=earliest"]
+          internal: Whether the dataset is being created from within the named scope.
+            Default: True
+        """
+        with tf.name_scope("KafkaGroupIODataset"):
+            assert internal
+
+            metadata = list(configuration or [])
+            if group_id is not None:
+                metadata.append("group.id=%s" % group_id)
+            if servers is not None:
+                metadata.append("bootstrap.servers=%s" % servers)
+            resource = core_ops.io_kafka_group_readable_init(topics, metadata=metadata)
+
+            self._resource = resource
+            dataset = tf.data.experimental.Counter()
+            dataset = dataset.map(
+                lambda i: core_ops.io_kafka_group_readable_next(self._resource, i)
+            )
+            dataset = dataset.apply(
+                tf.data.experimental.take_while(
+                    lambda v: tf.greater(tf.shape(v.message)[0], 0)
+                )
+            )
+            dataset = dataset.unbatch()
+
+            self._dataset = dataset
+            super().__init__(
+                self._dataset._variant_tensor
+            )  # pylint: disable=protected-access
+
+    def _inputs(self):
+        return []
+
+    @property
+    def element_spec(self):
+        return self._dataset.element_spec

--- a/tensorflow_io/core/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_dataset_ops.py
@@ -95,10 +95,10 @@ class KafkaStreamIODataset(tf.data.Dataset):
 
         Args:
           topic: A `tf.string` tensor containing topic subscription.
-          partition: A `tf.int64` tensor containing the partition, by default 0.
-          offset: A `tf.int64` tensor containing the start offset, by default 0.
-          servers: An optional list of bootstrap servers, by default
-             `localhost:9092`.
+          partition: A `tf.int64` tensor containing the partition.
+          offset: A `tf.int64` tensor containing the start offset.
+          servers: An optional list of bootstrap servers.
+             For example: `localhost:9092`.
           configuration: An optional `tf.string` tensor containing
             configurations in [Key=Value] format.
             Global configuration: please refer to 'Global configuration properties'


### PR DESCRIPTION
This PR addresses the enhancement request: https://github.com/tensorflow/io/issues/163.

The necessary ops, kernel classes and an experimental python API has been implemented so that when the new `KafkaGroupIODataset` is created, the consumer joins a consumer group whose offsets are managed by Kafka itself. This enables us to use a Rebalance callback in the consumer configuration and thus, read from all the partitions of a topic instead of explicitly initializing along with the stop/start indices.

Sample usage:

Setup the test kafka cluster
```
$ bash tests/test_kafka/kafka_test.sh
```

After the setup, the topic `key-partition-test` contains 10 messages ( 5 messages in 2 partitions )

```
from tensorflow_io.core.python.experimental import kafka_group_io_dataset_ops

group_dataset = kafka_group_io_dataset_ops.KafkaGroupIODataset(
    topics=["key-partition-test"],
    group_id="cg1",
    servers=None,
    configuration=[
        "auto.offset.reset=earliest",
        "session.timeout.ms=7000",
        "max.poll.interval.ms=8000",
    ],
)

for i in group_dataset:
    print(i)
```

The output will be:
```
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D0'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K0'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D2'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K0'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D4'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K0'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D6'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K0'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D8'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K0'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D1'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K1'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D3'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K1'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D5'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K1'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D7'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K1'>)
IO_KafkaGroupReadableNext(message=<tf.Tensor: shape=(), dtype=string, numpy=b'D9'>, key=<tf.Tensor: shape=(), dtype=string, numpy=b'K1'>)
```

Now, we can add more messages into the kafka topic:

```
$ export VERSION=5.4.1
$ sudo confluent-$VERSION/bin/kafka-console-producer --topic key-partition-test --property "parse.key=true" --property "key.separator=:" --broker-list 127.0.0.1:9092 < confluent-$VERSION/key-partition-test
```

Now, if we run our code snippet again, it will fetch the newly added 10 messages.

NOTE: to fetch all the 20 messages from the beginning, please use a different `group_id` so that the offset starts from 0 until the end.