### PR TITLE
BugFix: KafkaGroupIODataset retrieving messages from non-committed offsets.

### DIFF
--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -184,3 +184,32 @@ def test_avro_encode_decode():
     entries = tfio.experimental.serialization.decode_avro(message, schema=schema)
     assert np.all(entries["f1"].numpy() == f1.numpy())
     assert np.all(entries["f2"].numpy() == f2.numpy())
+
+
+def test_kafka_group_io_dataset_new_cg():
+    """Test the functionality of the KafkaGroupIODataset when the consumer group
+    is being newly created.
+    """
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtest",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i % 10)).encode() for i in range(10)])
+    )
+
+
+def test_kafka_group_io_dataset_no_lag():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer group has read all the messages and committed the offsets.
+    """
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtest",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(sorted([k.numpy() for (k, _) in dataset]) == [])


### PR DESCRIPTION
This PR addresses a bug while consuming messages from kafka topics using `tfio.experimental.streaming.KafkaGroupIODataset` . and adds two basic test cases.

**BugFix:**

**Current Scenario**: When a new consumer group is created, there are no committed offsets that are being maintained. In such cases, the dataset fails to read messages.

**Fix**: Before starting to retrieve the messages, I am checking for already committed offsets and based on the retrieved info, defaulting to the beginning offset if I don't find any. Setting it to latest offset will not return any messages. However, I will consider both the options when I implement a different variant of the dataset. (One where we can wait for the new messages to come in.)

**NOTE**: This is due to the following reasons:

1. Registering a rebalance_cb turns off librdkafka's automatic partition assignment/revocation and instead delegates that responsibility to the application's rebalance_cb.
2. Without a rebalance callback this is done automatically by librdkafka but registering a rebalance callback gives the application flexibility in performing other operations along with the assinging/revocation, such as fetching offsets from an alternate location (on assign) or manually committing offsets (on revoke).

**Reference**: https://docs.confluent.io/3.3.1/clients/librdkafka/classRdKafka_1_1RebalanceCb.html#a490a91c52724382a72380af621958741

**Tests:**

- [x] Start a new consumer by joining a new consumer group and read all the messages.
- [x] Start a new consumer by joining an existing consumer group and find no messages due to 0 lag.