### PR TITLE
Update docs to use `pip install tensorflow-io`, replacing `pip install tensorflow-io-nightly`

### DIFF
--- a/docs/tutorials/colorspace.ipynb
+++ b/docs/tutorials/colorspace.ipynb
@@ -111,7 +111,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install tensorflow-io-nightly"
+        "!pip install tensorflow-io"
       ]
     },
     {


### PR DESCRIPTION
As tensorflow-io 0.15.0 has been released, the docs needs
to be updated to use `pip install tensorflow-io`
(replacing `pip install tensorflow-io-nightly`)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>