### PR TITLE
Added support for stream timeout in KafkaGroupIODataset

### DIFF
--- a/tensorflow_io/core/ops/kafka_ops.cc
+++ b/tensorflow_io/core/ops/kafka_ops.cc
@@ -117,6 +117,8 @@ REGISTER_OP("IO>KafkaGroupReadableInit")
 REGISTER_OP("IO>KafkaGroupReadableNext")
     .Input("input: resource")
     .Input("index: int64")
+    .Input("message_timeout: int64")
+    .Input("stream_timeout: int64")
     .Output("message: string")
     .Output("key: string")
     .SetShapeFn([](shape_inference::InferenceContext* c) {

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -59,7 +59,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
           servers: An optional list of bootstrap servers.
             For example: `localhost:9092`.
           message_timeout: An optional timeout value (in milliseconds) for retrieving messages
-            from kafka. Default value in 5000.
+            from kafka. Default value is 5000.
           stream_timeout: An optional timeout value (in milliseconds) to wait for the new messages
             from kafka to be retrieved by the consumers. Default value in 5000.
             NOTE: The stream_timeout value should always be greater than or equal to the message_timeout

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -62,7 +62,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
             from kafka. Default value is 5000.
           stream_timeout: An optional timeout value (in milliseconds) to wait for the new messages
             from kafka to be retrieved by the consumers. Default value is 5000.
-            NOTE: The stream_timeout value should always be greater than or equal to the message_timeout
+            NOTE: The `stream_timeout` value should always be greater than or equal to the `message_timeout`.
             value.
           configuration: An optional `tf.string` tensor containing
             configurations in [Key=Value] format.

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -81,7 +81,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
 
             if stream_timeout < message_timeout:
                 raise ValueError(
-                    "stream_timeout {0} is less than the message_timeout {1}".format(
+                    "stream_timeout {} is less than the message_timeout {}".format(
                         stream_timeout, message_timeout
                     )
                 )

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -61,7 +61,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
           message_timeout: An optional timeout value (in milliseconds) for retrieving messages
             from kafka. Default value is 5000.
           stream_timeout: An optional timeout value (in milliseconds) to wait for the new messages
-            from kafka to be retrieved by the consumers. Default value in 5000.
+            from kafka to be retrieved by the consumers. Default value is 5000.
             NOTE: The stream_timeout value should always be greater than or equal to the message_timeout
             value.
           configuration: An optional `tf.string` tensor containing

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -74,7 +74,9 @@ class KafkaGroupIODataset(tf.data.Dataset):
             self._resource = resource
             dataset = tf.data.experimental.Counter()
             dataset = dataset.map(
-                lambda i: core_ops.io_kafka_group_readable_next(self._resource, i)
+                lambda i: core_ops.io_kafka_group_readable_next(
+                    self._resource, i, message_timeout=5000, stream_timeout=15000
+                )
             )
             dataset = dataset.apply(
                 tf.data.experimental.take_while(

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -21,7 +21,16 @@ from tensorflow_io.core.python.ops import core_ops
 class KafkaGroupIODataset(tf.data.Dataset):
     """KafkaGroupIODataset"""
 
-    def __init__(self, topics, group_id, servers, configuration, internal=True):
+    def __init__(
+        self,
+        topics,
+        group_id,
+        servers,
+        message_timeout=5000,
+        stream_timeout=5000,
+        configuration=None,
+        internal=True,
+    ):
         """Creates an `IODataset` from kafka server by joining a consumer group
         and maintaining offsets of all the partitions without explicit initialization.
         If the consumer joins an existing consumer group, it will start fetching
@@ -49,6 +58,12 @@ class KafkaGroupIODataset(tf.data.Dataset):
           group_id: The id of the consumer group. For example: cgstream
           servers: An optional list of bootstrap servers.
             For example: `localhost:9092`.
+          message_timeout: An optional timeout value (in milliseconds) for retrieving messages
+            from kafka. Default value in 5000.
+          stream_timeout: An optional timeout value (in milliseconds) to wait for the new messages
+            from kafka to be retrieved by the consumers. Default value in 5000.
+            NOTE: The stream_timeout value should always be greater than or equal to the message_timeout
+            value.
           configuration: An optional `tf.string` tensor containing
             configurations in [Key=Value] format.
             Global configuration: please refer to 'Global configuration properties'
@@ -64,18 +79,29 @@ class KafkaGroupIODataset(tf.data.Dataset):
         with tf.name_scope("KafkaGroupIODataset"):
             assert internal
 
+            if stream_timeout < message_timeout:
+                raise ValueError(
+                    "stream_timeout {0} is less than the message_timeout {1}".format(
+                        stream_timeout, message_timeout
+                    )
+                )
             metadata = list(configuration or [])
             if group_id is not None:
                 metadata.append("group.id=%s" % group_id)
             if servers is not None:
                 metadata.append("bootstrap.servers=%s" % servers)
-            resource = core_ops.io_kafka_group_readable_init(topics, metadata=metadata)
+            resource = core_ops.io_kafka_group_readable_init(
+                topics=topics, metadata=metadata
+            )
 
             self._resource = resource
             dataset = tf.data.experimental.Counter()
             dataset = dataset.map(
                 lambda i: core_ops.io_kafka_group_readable_next(
-                    self._resource, i, message_timeout=5000, stream_timeout=15000
+                    input=self._resource,
+                    index=i,
+                    message_timeout=message_timeout,
+                    stream_timeout=stream_timeout,
                 )
             )
             dataset = dataset.apply(

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -383,4 +383,3 @@ def test_kafka_group_io_dataset_stream_timeout_check():
         sorted([k.numpy() for (k, _) in dataset])
         == sorted([("D" + str(i)).encode() for i in range(200)])
     )
-

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -18,6 +18,7 @@
 import time
 import pytest
 import numpy as np
+import threading
 
 import tensorflow as tf
 import tensorflow_io as tfio
@@ -326,3 +327,60 @@ def test_kafka_group_io_dataset_tertiary_cg_multiple_topics():
         sorted([k.numpy() for (k, _) in dataset])
         == sorted([("D" + str(i)).encode() for i in range(100)] * 2)
     )
+
+
+def test_kafka_group_io_dataset_invalid_stream_timeout():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer is configured to have an invalid stream_timeout value which is
+    less than the message_timeout value.
+    NOTE: The default value for message_timeout=5000
+    """
+
+    try:
+        tfio.experimental.streaming.KafkaGroupIODataset(
+            topics=["key-partition-test", "key-test"],
+            group_id="cgteststreaminvalid",
+            servers="localhost:9092",
+            stream_timeout=1000,
+            configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        )
+    except ValueError as e:
+        assert str(e) == "stream_timeout 1000 is less than the message_timeout 5000"
+
+
+def test_kafka_group_io_dataset_stream_timeout_check():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer is configured to have a valid stream_timeout value and thus waits
+    for the new messages from kafka.
+    NOTE: The default value for message_timeout=5000
+    """
+
+    def write_messages_background():
+        # Write new messages to the topic in a background thread
+        time.sleep(6)
+        for i in range(100, 200):
+            message = "D{}".format(i)
+            kafka_io.write_kafka(message=message, topic="key-partition-test")
+
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgteststreamvalid",
+        servers="localhost:9092",
+        stream_timeout=10000,
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+
+    # start writing the new messages to kafka using the background job.
+    # the job sleep's for some time (< stream_timeout) and then writes the
+    # messages into the topic.
+    thread = threading.Thread(target=write_messages_background, args=())
+    thread.daemon = True
+    thread.start()
+
+    # At the end, after the timeout has occurred, we must have the old 100 messages
+    # along with the new 100 messages
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(200)])
+    )
+


### PR DESCRIPTION
This PR addresses the issue https://github.com/tensorflow/io/issues/947 by adding the following functionality:

- Allows users to pass a value for the `stream_timeout` argument in `KafkaGroupIODataset` which prevents the users from rebuilding the generator again when the consumer is waiting for new messages.
- Allows users to pass a value for the `message_timeout` argument in `KafkaGroupIODataset` when the default value might be less/more than needed, based on the cluster connectivity.
- Relevant tests for the wait functionality (can be extended).

**NOTE/INFO:** The functionality of `message_timeout` in Kafka works in such a way that, when a consumer is trying to fetch a new message with a timeout of let's say 5000 milliseconds and it doesn't find the message, then the consumer will always wait for 5000 milliseconds even though a new message was available to be fetched after let's say 2000 milliseconds. 