### PR TITLE
Use bool flag for ffmpeg initialization

### DIFF
--- a/tensorflow_io/core/kernels/ffmpeg_kernels_deprecated.cc
+++ b/tensorflow_io/core/kernels/ffmpeg_kernels_deprecated.cc
@@ -33,11 +33,11 @@ namespace tensorflow {
 namespace data {
 
 static mutex mu(LINKER_INITIALIZED);
-static unsigned count(0);
+static bool initialized(false);
+
 void FFmpegInit() {
   mutex_lock lock(mu);
-  count++;
-  if (count == 1) {
+  if (!initialized) {
     // Set log level if needed
     static const struct {
       const char* name;
@@ -63,6 +63,7 @@ void FFmpegInit() {
 
     // Register all formats and codecs
     av_register_all();
+    initialized = true;
   }
 }
 


### PR DESCRIPTION
This PR fixes potential multiple initialization calls when unsigned count goes out of range.

Fix #1077 