### PR TITLE
Experimental support for online learning using KakfaBatchIODataset

### DIFF
--- a/tensorflow_io/core/python/api/experimental/streaming.py
+++ b/tensorflow_io/core/python/api/experimental/streaming.py
@@ -17,3 +17,6 @@
 from tensorflow_io.core.python.experimental.kafka_group_io_dataset_ops import (  # pylint: disable=unused-import
     KafkaGroupIODataset,
 )
+from tensorflow_io.core.python.experimental.kafka_batch_io_dataset_ops import (  # pylint: disable=unused-import
+    KafkaBatchIODataset,
+)

--- a/tensorflow_io/core/python/experimental/kafka_batch_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_batch_io_dataset_ops.py
@@ -1,0 +1,135 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""KafkaBatchIODatasets"""
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
+
+
+class KafkaBatchIODataset(tf.data.Dataset):
+    """KafkaBatchIODataset"""
+
+    def __init__(
+        self,
+        topics,
+        group_id,
+        servers,
+        message_timeout=5000,
+        stream_timeout=5000,
+        configuration=None,
+        internal=True,
+    ):
+        """Creates an `IODataset` which contains elements that are of type`tf.data.Dataset`.
+
+        NOTE: This kind of dataset is suitable in scenarios where the 'keys' of 'messages'
+        act as labels for the data elements.
+
+        It reads from kafka server by joining a consumer group
+        and maintaining offsets of all the partitions without explicit initialization.
+        If the consumer joins an existing consumer group, it will start fetching
+        messages based on the already committed offsets. To start fetching the messages
+        from the beginning, please join a different consumer group. The dataset will be prepared
+        from the committed/start offset until the last offset.
+
+        NOTE: Cases may arise where the consumer read time out issues arise due to
+        the consumer group being in a rebalancing state. In order to address that, please
+        set `session.timeout.ms` and `max.poll.interval.ms` values in the configuration tensor
+        and try again after the group rebalances. For example: considering your kafka cluster
+        has been setup with the default settings, `max.poll.interval.ms` would be `300000ms`.
+        It can be changed to `8000ms` to reduce the time between pools. Also, the `session.timeout.ms`
+        can be changed to `7000ms`. However, the value for `session.timeout.ms` should be
+        according to the following relation:
+
+        - `group.max.session.timeout.ms` in server.properties > `session.timeout.ms` in the
+        consumer.properties.
+        - `group.min.session.timeout.ms` in server.properties < `session.timeout.ms` in the
+        consumer.properties
+
+        Args:
+          topics: A `tf.string` tensor containing topic names in [topic] format.
+            For example: ["topic1"]
+          group_id: The id of the consumer group. For example: cgstream
+          servers: An optional list of bootstrap servers.
+            For example: `localhost:9092`.
+          message_timeout: An optional timeout value (in milliseconds) for retrieving messages
+            from kafka. Default value is 5000.
+          stream_timeout: An optional timeout value (in milliseconds) to wait for the new messages
+            from kafka to be retrieved by the consumers. Default value is 5000.
+            NOTE: The `stream_timeout` value should always be greater than or equal to the `message_timeout`.
+            value.
+          configuration: An optional `tf.string` tensor containing
+            configurations in [Key=Value] format.
+            Global configuration: please refer to 'Global configuration properties'
+              in librdkafka doc. Examples include
+              ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
+            Topic configuration: please refer to 'Topic configuration properties'
+              in librdkafka doc. Note all topic configurations should be
+              prefixed with `configuration.topic.`. Examples include
+              ["conf.topic.auto.offset.reset=earliest"]
+          internal: Whether the dataset is being created from within the named scope.
+            Default: True
+        """
+        with tf.name_scope("KafkaBatchIODataset"):
+            assert internal
+
+            if stream_timeout < message_timeout:
+                raise ValueError(
+                    "stream_timeout {} is less than the message_timeout {}".format(
+                        stream_timeout, message_timeout
+                    )
+                )
+            metadata = list(configuration or [])
+            if group_id is not None:
+                metadata.append("group.id=%s" % group_id)
+            if servers is not None:
+                metadata.append("bootstrap.servers=%s" % servers)
+            resource = core_ops.io_kafka_group_readable_init(
+                topics=topics, metadata=metadata
+            )
+
+            self._resource = resource
+            dataset = tf.data.experimental.Counter()
+            dataset = dataset.map(
+                lambda i: core_ops.io_kafka_group_readable_next(
+                    input=self._resource,
+                    index=i,
+                    message_timeout=message_timeout,
+                    stream_timeout=stream_timeout,
+                )
+            )
+            dataset = dataset.apply(
+                tf.data.experimental.take_while(
+                    lambda v: tf.greater(tf.shape(v.message)[0], 0)
+                )
+            )
+            dataset = dataset.map(
+                lambda v: tf.data.Dataset.zip(
+                    (
+                        tf.data.Dataset.from_tensor_slices(v.message),
+                        tf.data.Dataset.from_tensor_slices(v.key),
+                    )
+                )
+            )
+            self._dataset = dataset
+            super().__init__(
+                self._dataset._variant_tensor
+            )  # pylint: disable=protected-access
+
+    def _inputs(self):
+        return []
+
+    @property
+    def element_spec(self):
+        return self._dataset.element_spec

--- a/tests/test_kafka/kafka_test.sh
+++ b/tests/test_kafka/kafka_test.sh
@@ -35,6 +35,7 @@ sleep 10
 echo -e "D0\nD1\nD2\nD3\nD4\nD5\nD6\nD7\nD8\nD9" > confluent-$VERSION/test
 echo -e "K0:D0\nK1:D1\nK0:D2\nK1:D3\nK0:D4\nK1:D5\nK0:D6\nK1:D7\nK0:D8\nK1:D9" > confluent-$VERSION/key-test
 echo -e "K0:D0\nK1:D1\nK0:D2\nK1:D3\nK0:D4\nK1:D5\nK0:D6\nK1:D7\nK0:D8\nK1:D9" > confluent-$VERSION/key-partition-test
+echo -e "0:0\n1:1\n0:2\n1:3\n0:4\n1:5\n0:6\n1:7\n0:8\n1:9" > confluent-$VERSION/mini-batch-test
 echo "Waiting for 15 secs until schema registry is ready and other services are up and running"
 sleep 15
 
@@ -49,6 +50,10 @@ sudo confluent-$VERSION/bin/kafka-console-producer --topic key-test --property "
 echo "Creating and populating 'key-partition-test' multi-partition topic with sample keyed messages"
 sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 2 --topic key-partition-test
 sudo confluent-$VERSION/bin/kafka-console-producer --topic key-partition-test --property "parse.key=true" --property "key.separator=:" --broker-list 127.0.0.1:9092 < confluent-$VERSION/key-partition-test
+
+echo "Creating and populating 'mini-batch-test' multi-partition topic with sample keyed messages"
+sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 2 --topic mini-batch-test
+sudo confluent-$VERSION/bin/kafka-console-producer --topic mini-batch-test --property "parse.key=true" --property "key.separator=:" --broker-list 127.0.0.1:9092 < confluent-$VERSION/mini-batch-test
 
 echo "Creating and populating 'avro-test' topic with sample messages."
 sudo confluent-$VERSION/bin/kafka-topics --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic avro-test

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -28,361 +28,361 @@ from tensorflow_io.kafka.python.ops import (
 import tensorflow_io.kafka as kafka_io  # pylint: disable=wrong-import-position
 
 
-def test_kafka_io_tensor():
-    kafka = tfio.IOTensor.from_kafka("test")
-    assert kafka.dtype == tf.string
-    assert kafka.shape.as_list() == [None]
-    assert np.all(
-        kafka.to_tensor().numpy() == [("D" + str(i)).encode() for i in range(10)]
-    )
-    assert len(kafka.to_tensor()) == 10
+# def test_kafka_io_tensor():
+#     kafka = tfio.IOTensor.from_kafka("test")
+#     assert kafka.dtype == tf.string
+#     assert kafka.shape.as_list() == [None]
+#     assert np.all(
+#         kafka.to_tensor().numpy() == [("D" + str(i)).encode() for i in range(10)]
+#     )
+#     assert len(kafka.to_tensor()) == 10
 
 
-@pytest.mark.skip(reason="TODO")
-def test_kafka_output_sequence():
-    """Test case based on fashion mnist tutorial"""
-    fashion_mnist = tf.keras.datasets.fashion_mnist
-    ((train_images, train_labels), (test_images, _)) = fashion_mnist.load_data()
+# @pytest.mark.skip(reason="TODO")
+# def test_kafka_output_sequence():
+#     """Test case based on fashion mnist tutorial"""
+#     fashion_mnist = tf.keras.datasets.fashion_mnist
+#     ((train_images, train_labels), (test_images, _)) = fashion_mnist.load_data()
 
-    class_names = [
-        "T-shirt/top",
-        "Trouser",
-        "Pullover",
-        "Dress",
-        "Coat",
-        "Sandal",
-        "Shirt",
-        "Sneaker",
-        "Bag",
-        "Ankle boot",
-    ]
+#     class_names = [
+#         "T-shirt/top",
+#         "Trouser",
+#         "Pullover",
+#         "Dress",
+#         "Coat",
+#         "Sandal",
+#         "Shirt",
+#         "Sneaker",
+#         "Bag",
+#         "Ankle boot",
+#     ]
 
-    train_images = train_images / 255.0
-    test_images = test_images / 255.0
+#     train_images = train_images / 255.0
+#     test_images = test_images / 255.0
 
-    model = tf.keras.Sequential(
-        [
-            tf.keras.layers.Flatten(input_shape=(28, 28)),
-            tf.keras.layers.Dense(128, activation=tf.nn.relu),
-            tf.keras.layers.Dense(10, activation=tf.nn.softmax),
-        ]
-    )
+#     model = tf.keras.Sequential(
+#         [
+#             tf.keras.layers.Flatten(input_shape=(28, 28)),
+#             tf.keras.layers.Dense(128, activation=tf.nn.relu),
+#             tf.keras.layers.Dense(10, activation=tf.nn.softmax),
+#         ]
+#     )
 
-    model.compile(
-        optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"]
-    )
+#     model.compile(
+#         optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"]
+#     )
 
-    model.fit(train_images, train_labels, epochs=5)
+#     model.fit(train_images, train_labels, epochs=5)
 
-    class OutputCallback(tf.keras.callbacks.Callback):
-        """KafkaOutputCallback"""
+#     class OutputCallback(tf.keras.callbacks.Callback):
+#         """KafkaOutputCallback"""
 
-        def __init__(
-            self, batch_size, topic, servers
-        ):  # pylint: disable=super-init-not-called
-            self._sequence = kafka_ops.KafkaOutputSequence(topic=topic, servers=servers)
-            self._batch_size = batch_size
+#         def __init__(
+#             self, batch_size, topic, servers
+#         ):  # pylint: disable=super-init-not-called
+#             self._sequence = kafka_ops.KafkaOutputSequence(topic=topic, servers=servers)
+#             self._batch_size = batch_size
 
-        def on_predict_batch_end(self, batch, logs=None):
-            index = batch * self._batch_size
-            for outputs in logs["outputs"]:
-                for output in outputs:
-                    self._sequence.setitem(index, class_names[np.argmax(output)])
-                    index += 1
+#         def on_predict_batch_end(self, batch, logs=None):
+#             index = batch * self._batch_size
+#             for outputs in logs["outputs"]:
+#                 for output in outputs:
+#                     self._sequence.setitem(index, class_names[np.argmax(output)])
+#                     index += 1
 
-        def flush(self):
-            self._sequence.flush()
+#         def flush(self):
+#             self._sequence.flush()
 
-    channel = "e{}e".format(time.time())
-    topic = "test_" + channel
+#     channel = "e{}e".format(time.time())
+#     topic = "test_" + channel
 
-    # By default batch size is 32
-    output = OutputCallback(32, topic, "localhost")
-    predictions = model.predict(test_images, callbacks=[output])
-    output.flush()
+#     # By default batch size is 32
+#     output = OutputCallback(32, topic, "localhost")
+#     predictions = model.predict(test_images, callbacks=[output])
+#     output.flush()
 
-    predictions = [class_names[v] for v in np.argmax(predictions, axis=1)]
+#     predictions = [class_names[v] for v in np.argmax(predictions, axis=1)]
 
-    # Reading from `test_e(time)e` we should get the same result
-    dataset = tfio.kafka.KafkaDataset(topics=[topic], group="test", eof=True)
-    for entry, prediction in zip(dataset, predictions):
-        assert entry.numpy() == prediction.encode()
-
-
-def test_avro_kafka_dataset():
-    """test_avro_kafka_dataset"""
-    schema = (
-        '{"type":"record","name":"myrecord","fields":['
-        '{"name":"f1","type":"string"},'
-        '{"name":"f2","type":"long"},'
-        '{"name":"f3","type":["null","string"],"default":null}'
-        "]}"
-    )
-    dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
-    # remove kafka framing
-    dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
-    # deserialize avro
-    dataset = dataset.map(
-        lambda e: tfio.experimental.serialization.decode_avro(e, schema=schema)
-    )
-    entries = [(e["f1"], e["f2"], e["f3"]) for e in dataset]
-    np.all(entries == [("value1", 1, ""), ("value2", 2, ""), ("value3", 3, "")])
+#     # Reading from `test_e(time)e` we should get the same result
+#     dataset = tfio.kafka.KafkaDataset(topics=[topic], group="test", eof=True)
+#     for entry, prediction in zip(dataset, predictions):
+#         assert entry.numpy() == prediction.encode()
 
 
-def test_avro_kafka_dataset_with_resource():
-    """test_avro_kafka_dataset_with_resource"""
-    schema = (
-        '{"type":"record","name":"myrecord","fields":['
-        '{"name":"f1","type":"string"},'
-        '{"name":"f2","type":"long"},'
-        '{"name":"f3","type":["null","string"],"default":null}'
-        ']}"'
-    )
-    schema_resource = kafka_io.decode_avro_init(schema)
-    dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
-    # remove kafka framing
-    dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
-    # deserialize avro
-    dataset = dataset.map(
-        lambda e: kafka_io.decode_avro(
-            e, schema=schema_resource, dtype=[tf.string, tf.int64, tf.string]
-        )
-    )
-    entries = [(f1.numpy(), f2.numpy(), f3.numpy()) for (f1, f2, f3) in dataset]
-    np.all(entries == [("value1", 1), ("value2", 2), ("value3", 3)])
+# def test_avro_kafka_dataset():
+#     """test_avro_kafka_dataset"""
+#     schema = (
+#         '{"type":"record","name":"myrecord","fields":['
+#         '{"name":"f1","type":"string"},'
+#         '{"name":"f2","type":"long"},'
+#         '{"name":"f3","type":["null","string"],"default":null}'
+#         "]}"
+#     )
+#     dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
+#     # remove kafka framing
+#     dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
+#     # deserialize avro
+#     dataset = dataset.map(
+#         lambda e: tfio.experimental.serialization.decode_avro(e, schema=schema)
+#     )
+#     entries = [(e["f1"], e["f2"], e["f3"]) for e in dataset]
+#     np.all(entries == [("value1", 1, ""), ("value2", 2, ""), ("value3", 3, "")])
 
 
-def test_kafka_stream_dataset():
-    dataset = tfio.IODataset.stream().from_kafka("test").batch(2)
-    assert np.all(
-        [k.numpy().tolist() for (k, _) in dataset]
-        == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
-    )
+# def test_avro_kafka_dataset_with_resource():
+#     """test_avro_kafka_dataset_with_resource"""
+#     schema = (
+#         '{"type":"record","name":"myrecord","fields":['
+#         '{"name":"f1","type":"string"},'
+#         '{"name":"f2","type":"long"},'
+#         '{"name":"f3","type":["null","string"],"default":null}'
+#         ']}"'
+#     )
+#     schema_resource = kafka_io.decode_avro_init(schema)
+#     dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
+#     # remove kafka framing
+#     dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
+#     # deserialize avro
+#     dataset = dataset.map(
+#         lambda e: kafka_io.decode_avro(
+#             e, schema=schema_resource, dtype=[tf.string, tf.int64, tf.string]
+#         )
+#     )
+#     entries = [(f1.numpy(), f2.numpy(), f3.numpy()) for (f1, f2, f3) in dataset]
+#     np.all(entries == [("value1", 1), ("value2", 2), ("value3", 3)])
 
 
-def test_kafka_io_dataset():
-    dataset = tfio.IODataset.from_kafka(
-        "test", configuration=["fetch.min.bytes=2"]
-    ).batch(2)
-    # repeat multiple times will result in the same result
-    for _ in range(5):
-        assert np.all(
-            [k.numpy().tolist() for (k, _) in dataset]
-            == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
-        )
+# def test_kafka_stream_dataset():
+#     dataset = tfio.IODataset.stream().from_kafka("test").batch(2)
+#     assert np.all(
+#         [k.numpy().tolist() for (k, _) in dataset]
+#         == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
+#     )
 
 
-def test_avro_encode_decode():
-    """test_avro_encode_decode"""
-    schema = (
-        '{"type":"record","name":"myrecord","fields":'
-        '[{"name":"f1","type":"string"},{"name":"f2","type":"long"}]}'
-    )
-    value = [("value1", 1), ("value2", 2), ("value3", 3)]
-    f1 = tf.cast([v[0] for v in value], tf.string)
-    f2 = tf.cast([v[1] for v in value], tf.int64)
-    message = tfio.experimental.serialization.encode_avro([f1, f2], schema=schema)
-    entries = tfio.experimental.serialization.decode_avro(message, schema=schema)
-    assert np.all(entries["f1"].numpy() == f1.numpy())
-    assert np.all(entries["f2"].numpy() == f2.numpy())
+# def test_kafka_io_dataset():
+#     dataset = tfio.IODataset.from_kafka(
+#         "test", configuration=["fetch.min.bytes=2"]
+#     ).batch(2)
+#     # repeat multiple times will result in the same result
+#     for _ in range(5):
+#         assert np.all(
+#             [k.numpy().tolist() for (k, _) in dataset]
+#             == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
+#         )
 
 
-def test_kafka_group_io_dataset_primary_cg():
-    """Test the functionality of the KafkaGroupIODataset when the consumer group
-    is being newly created.
-
-    NOTE: After the kafka cluster is setup during the testing phase, 10 messages
-    are written to the 'key-partition-test' topic with 5 in each partition
-    (topic created with 2 partitions, the messages are split based on the keys).
-    And the same 10 messages are written into the 'key-test' topic (topic created
-    with 1 partition, so no splitting of the messages based on the keys).
-
-    K0:D0, K1:D1, K0:D2, K1:D3, K0:D4, K1:D5, K0:D6, K1:D7, K0:D8, K1:D9.
-
-    Here, messages D0, D2, D4, D6 and D8 are written into partition 0 and the rest are written
-    into partition 1.
-
-    Also, since the messages are read from different partitions, the order of retrieval may not be
-    the same as storage. Thus, we sort and compare.
-    """
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-partition-test"],
-        group_id="cgtestprimary",
-        servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
-    assert np.all(
-        sorted([k.numpy() for (k, _) in dataset])
-        == sorted([("D" + str(i)).encode() for i in range(10)])
-    )
+# def test_avro_encode_decode():
+#     """test_avro_encode_decode"""
+#     schema = (
+#         '{"type":"record","name":"myrecord","fields":'
+#         '[{"name":"f1","type":"string"},{"name":"f2","type":"long"}]}'
+#     )
+#     value = [("value1", 1), ("value2", 2), ("value3", 3)]
+#     f1 = tf.cast([v[0] for v in value], tf.string)
+#     f2 = tf.cast([v[1] for v in value], tf.int64)
+#     message = tfio.experimental.serialization.encode_avro([f1, f2], schema=schema)
+#     entries = tfio.experimental.serialization.decode_avro(message, schema=schema)
+#     assert np.all(entries["f1"].numpy() == f1.numpy())
+#     assert np.all(entries["f2"].numpy() == f2.numpy())
 
 
-def test_kafka_group_io_dataset_primary_cg_no_lag():
-    """Test the functionality of the KafkaGroupIODataset when the
-    consumer group has read all the messages and committed the offsets.
-    """
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-partition-test"],
-        group_id="cgtestprimary",
-        servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
-    assert np.all(sorted([k.numpy() for (k, _) in dataset]) == [])
+# def test_kafka_group_io_dataset_primary_cg():
+#     """Test the functionality of the KafkaGroupIODataset when the consumer group
+#     is being newly created.
+
+#     NOTE: After the kafka cluster is setup during the testing phase, 10 messages
+#     are written to the 'key-partition-test' topic with 5 in each partition
+#     (topic created with 2 partitions, the messages are split based on the keys).
+#     And the same 10 messages are written into the 'key-test' topic (topic created
+#     with 1 partition, so no splitting of the messages based on the keys).
+
+#     K0:D0, K1:D1, K0:D2, K1:D3, K0:D4, K1:D5, K0:D6, K1:D7, K0:D8, K1:D9.
+
+#     Here, messages D0, D2, D4, D6 and D8 are written into partition 0 and the rest are written
+#     into partition 1.
+
+#     Also, since the messages are read from different partitions, the order of retrieval may not be
+#     the same as storage. Thus, we sort and compare.
+#     """
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-partition-test"],
+#         group_id="cgtestprimary",
+#         servers="localhost:9092",
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+#     assert np.all(
+#         sorted([k.numpy() for (k, _) in dataset])
+#         == sorted([("D" + str(i)).encode() for i in range(10)])
+#     )
 
 
-def test_kafka_group_io_dataset_primary_cg_new_topic():
-    """Test the functionality of the KafkaGroupIODataset when the existing
-    consumer group reads data from a new topic.
-    """
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-test"],
-        group_id="cgtestprimary",
-        servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
-    assert np.all(
-        sorted([k.numpy() for (k, _) in dataset])
-        == sorted([("D" + str(i)).encode() for i in range(10)])
-    )
+# def test_kafka_group_io_dataset_primary_cg_no_lag():
+#     """Test the functionality of the KafkaGroupIODataset when the
+#     consumer group has read all the messages and committed the offsets.
+#     """
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-partition-test"],
+#         group_id="cgtestprimary",
+#         servers="localhost:9092",
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+#     assert np.all(sorted([k.numpy() for (k, _) in dataset]) == [])
 
 
-def test_kafka_group_io_dataset_resume_primary_cg():
-    """Test the functionality of the KafkaGroupIODataset when the
-    consumer group is yet to catch up with the newly added messages only
-    (Instead of reading from the beginning).
-    """
-
-    # Write new messages to the topic
-    for i in range(10, 100):
-        message = "D{}".format(i)
-        kafka_io.write_kafka(message=message, topic="key-partition-test")
-
-    # Read only the newly sent 100 messages
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-partition-test"],
-        group_id="cgtestprimary",
-        servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
-    assert np.all(
-        sorted([k.numpy() for (k, _) in dataset])
-        == sorted([("D" + str(i)).encode() for i in range(10, 100)])
-    )
+# def test_kafka_group_io_dataset_primary_cg_new_topic():
+#     """Test the functionality of the KafkaGroupIODataset when the existing
+#     consumer group reads data from a new topic.
+#     """
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-test"],
+#         group_id="cgtestprimary",
+#         servers="localhost:9092",
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+#     assert np.all(
+#         sorted([k.numpy() for (k, _) in dataset])
+#         == sorted([("D" + str(i)).encode() for i in range(10)])
+#     )
 
 
-def test_kafka_group_io_dataset_resume_primary_cg_new_topic():
-    """Test the functionality of the KafkaGroupIODataset when the
-    consumer group is yet to catch up with the newly added messages only
-    (Instead of reading from the beginning) from the new topic.
-    """
+# def test_kafka_group_io_dataset_resume_primary_cg():
+#     """Test the functionality of the KafkaGroupIODataset when the
+#     consumer group is yet to catch up with the newly added messages only
+#     (Instead of reading from the beginning).
+#     """
 
-    # Write new messages to the topic
-    for i in range(10, 100):
-        message = "D{}".format(i)
-        kafka_io.write_kafka(message=message, topic="key-test")
+#     # Write new messages to the topic
+#     for i in range(10, 100):
+#         message = "D{}".format(i)
+#         kafka_io.write_kafka(message=message, topic="key-partition-test")
 
-    # Read only the newly sent 100 messages
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-test"],
-        group_id="cgtestprimary",
-        servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
-    assert np.all(
-        sorted([k.numpy() for (k, _) in dataset])
-        == sorted([("D" + str(i)).encode() for i in range(10, 100)])
-    )
-
-
-def test_kafka_group_io_dataset_secondary_cg():
-    """Test the functionality of the KafkaGroupIODataset when a
-    secondary consumer group is created and is yet to catch up all the messages,
-    from the beginning.
-    """
-
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-partition-test"],
-        group_id="cgtestsecondary",
-        servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
-    assert np.all(
-        sorted([k.numpy() for (k, _) in dataset])
-        == sorted([("D" + str(i)).encode() for i in range(100)])
-    )
+#     # Read only the newly sent 100 messages
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-partition-test"],
+#         group_id="cgtestprimary",
+#         servers="localhost:9092",
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+#     assert np.all(
+#         sorted([k.numpy() for (k, _) in dataset])
+#         == sorted([("D" + str(i)).encode() for i in range(10, 100)])
+#     )
 
 
-def test_kafka_group_io_dataset_tertiary_cg_multiple_topics():
-    """Test the functionality of the KafkaGroupIODataset when a new
-    consumer group reads data from multiple topics from the beginning.
-    """
+# def test_kafka_group_io_dataset_resume_primary_cg_new_topic():
+#     """Test the functionality of the KafkaGroupIODataset when the
+#     consumer group is yet to catch up with the newly added messages only
+#     (Instead of reading from the beginning) from the new topic.
+#     """
 
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-partition-test", "key-test"],
-        group_id="cgtesttertiary",
-        servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
-    assert np.all(
-        sorted([k.numpy() for (k, _) in dataset])
-        == sorted([("D" + str(i)).encode() for i in range(100)] * 2)
-    )
+#     # Write new messages to the topic
+#     for i in range(10, 100):
+#         message = "D{}".format(i)
+#         kafka_io.write_kafka(message=message, topic="key-test")
 
-
-def test_kafka_group_io_dataset_invalid_stream_timeout():
-    """Test the functionality of the KafkaGroupIODataset when the
-    consumer is configured to have an invalid stream_timeout value which is
-    less than the message_timeout value.
-    NOTE: The default value for message_timeout=5000
-    """
-
-    try:
-        tfio.experimental.streaming.KafkaGroupIODataset(
-            topics=["key-partition-test", "key-test"],
-            group_id="cgteststreaminvalid",
-            servers="localhost:9092",
-            stream_timeout=1000,
-            configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-        )
-    except ValueError as e:
-        assert str(e) == "stream_timeout 1000 is less than the message_timeout 5000"
+#     # Read only the newly sent 100 messages
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-test"],
+#         group_id="cgtestprimary",
+#         servers="localhost:9092",
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+#     assert np.all(
+#         sorted([k.numpy() for (k, _) in dataset])
+#         == sorted([("D" + str(i)).encode() for i in range(10, 100)])
+#     )
 
 
-def test_kafka_group_io_dataset_stream_timeout_check():
-    """Test the functionality of the KafkaGroupIODataset when the
-    consumer is configured to have a valid stream_timeout value and thus waits
-    for the new messages from kafka.
-    NOTE: The default value for message_timeout=5000
-    """
+# def test_kafka_group_io_dataset_secondary_cg():
+#     """Test the functionality of the KafkaGroupIODataset when a
+#     secondary consumer group is created and is yet to catch up all the messages,
+#     from the beginning.
+#     """
 
-    def write_messages_background():
-        # Write new messages to the topic in a background thread
-        time.sleep(6)
-        for i in range(100, 200):
-            message = "D{}".format(i)
-            kafka_io.write_kafka(message=message, topic="key-partition-test")
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-partition-test"],
+#         group_id="cgtestsecondary",
+#         servers="localhost:9092",
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+#     assert np.all(
+#         sorted([k.numpy() for (k, _) in dataset])
+#         == sorted([("D" + str(i)).encode() for i in range(100)])
+#     )
 
-    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-        topics=["key-partition-test"],
-        group_id="cgteststreamvalid",
-        servers="localhost:9092",
-        stream_timeout=10000,
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-    )
 
-    # start writing the new messages to kafka using the background job.
-    # the job sleep's for some time (< stream_timeout) and then writes the
-    # messages into the topic.
-    thread = threading.Thread(target=write_messages_background, args=())
-    thread.daemon = True
-    thread.start()
+# def test_kafka_group_io_dataset_tertiary_cg_multiple_topics():
+#     """Test the functionality of the KafkaGroupIODataset when a new
+#     consumer group reads data from multiple topics from the beginning.
+#     """
 
-    # At the end, after the timeout has occurred, we must have the old 100 messages
-    # along with the new 100 messages
-    assert np.all(
-        sorted([k.numpy() for (k, _) in dataset])
-        == sorted([("D" + str(i)).encode() for i in range(200)])
-    )
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-partition-test", "key-test"],
+#         group_id="cgtesttertiary",
+#         servers="localhost:9092",
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+#     assert np.all(
+#         sorted([k.numpy() for (k, _) in dataset])
+#         == sorted([("D" + str(i)).encode() for i in range(100)] * 2)
+#     )
+
+
+# def test_kafka_group_io_dataset_invalid_stream_timeout():
+#     """Test the functionality of the KafkaGroupIODataset when the
+#     consumer is configured to have an invalid stream_timeout value which is
+#     less than the message_timeout value.
+#     NOTE: The default value for message_timeout=5000
+#     """
+
+#     try:
+#         tfio.experimental.streaming.KafkaGroupIODataset(
+#             topics=["key-partition-test", "key-test"],
+#             group_id="cgteststreaminvalid",
+#             servers="localhost:9092",
+#             stream_timeout=1000,
+#             configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#         )
+#     except ValueError as e:
+#         assert str(e) == "stream_timeout 1000 is less than the message_timeout 5000"
+
+
+# def test_kafka_group_io_dataset_stream_timeout_check():
+#     """Test the functionality of the KafkaGroupIODataset when the
+#     consumer is configured to have a valid stream_timeout value and thus waits
+#     for the new messages from kafka.
+#     NOTE: The default value for message_timeout=5000
+#     """
+
+#     def write_messages_background():
+#         # Write new messages to the topic in a background thread
+#         time.sleep(6)
+#         for i in range(100, 200):
+#             message = "D{}".format(i)
+#             kafka_io.write_kafka(message=message, topic="key-partition-test")
+
+#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+#         topics=["key-partition-test"],
+#         group_id="cgteststreamvalid",
+#         servers="localhost:9092",
+#         stream_timeout=10000,
+#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+#     )
+
+#     # start writing the new messages to kafka using the background job.
+#     # the job sleep's for some time (< stream_timeout) and then writes the
+#     # messages into the topic.
+#     thread = threading.Thread(target=write_messages_background, args=())
+#     thread.daemon = True
+#     thread.start()
+
+#     # At the end, after the timeout has occurred, we must have the old 100 messages
+#     # along with the new 100 messages
+#     assert np.all(
+#         sorted([k.numpy() for (k, _) in dataset])
+#         == sorted([("D" + str(i)).encode() for i in range(200)])
+#     )
 
 
 def test_kafka_batch_io_dataset():
@@ -416,6 +416,7 @@ def test_kafka_batch_io_dataset():
         loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),
         metrics=["accuracy"],
     )
+    assert issubclass(type(dataset), tf.data.Dataset)
     for mini_d in dataset:
         mini_d = mini_d.map(
             lambda m, k: (
@@ -423,6 +424,7 @@ def test_kafka_batch_io_dataset():
                 tf.strings.to_number(k, out_type=tf.float32),
             )
         ).batch(2)
+        assert issubclass(type(mini_d), tf.data.Dataset)
         # Fits the model as long as the data keeps on streaming
         model.fit(mini_d, epochs=5)
 

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -383,3 +383,46 @@ def test_kafka_group_io_dataset_stream_timeout_check():
         sorted([k.numpy() for (k, _) in dataset])
         == sorted([("D" + str(i)).encode() for i in range(200)])
     )
+
+
+def test_kafka_batch_io_dataset():
+    """Test the functionality of the KafkaBatchIODataset by training a model
+    directly on the incoming kafka message batch(of type tf.data.Dataset), in an
+    online-training fashion.
+
+    NOTE: This kind of dataset is suitable in scenarios where the 'keys' of 'messages'
+        act as labels.
+    """
+
+    dataset = tfio.experimental.streaming.KafkaBatchIODataset(
+        topics=["mini-batch-test"],
+        group_id="cgminibatch",
+        servers=None,
+        stream_timeout=5000,
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+
+    NUM_COLUMNS = 1
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Input(shape=(NUM_COLUMNS,)),
+            tf.keras.layers.Dense(4, activation="relu"),
+            tf.keras.layers.Dropout(0.1),
+            tf.keras.layers.Dense(1, activation="sigmoid"),
+        ]
+    )
+    model.compile(
+        optimizer="adam",
+        loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),
+        metrics=["accuracy"],
+    )
+    for mini_d in dataset:
+        mini_d = mini_d.map(
+            lambda m, k: (
+                tf.strings.to_number(m, out_type=tf.float32),
+                tf.strings.to_number(k, out_type=tf.float32),
+            )
+        ).batch(2)
+        # Fits the model as long as the data keeps on streaming
+        model.fit(mini_d, epochs=5)
+

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -427,4 +427,3 @@ def test_kafka_batch_io_dataset():
         assert issubclass(type(mini_d), tf.data.Dataset)
         # Fits the model as long as the data keeps on streaming
         model.fit(mini_d, epochs=5)
-

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -28,361 +28,361 @@ from tensorflow_io.kafka.python.ops import (
 import tensorflow_io.kafka as kafka_io  # pylint: disable=wrong-import-position
 
 
-# def test_kafka_io_tensor():
-#     kafka = tfio.IOTensor.from_kafka("test")
-#     assert kafka.dtype == tf.string
-#     assert kafka.shape.as_list() == [None]
-#     assert np.all(
-#         kafka.to_tensor().numpy() == [("D" + str(i)).encode() for i in range(10)]
-#     )
-#     assert len(kafka.to_tensor()) == 10
+def test_kafka_io_tensor():
+    kafka = tfio.IOTensor.from_kafka("test")
+    assert kafka.dtype == tf.string
+    assert kafka.shape.as_list() == [None]
+    assert np.all(
+        kafka.to_tensor().numpy() == [("D" + str(i)).encode() for i in range(10)]
+    )
+    assert len(kafka.to_tensor()) == 10
 
 
-# @pytest.mark.skip(reason="TODO")
-# def test_kafka_output_sequence():
-#     """Test case based on fashion mnist tutorial"""
-#     fashion_mnist = tf.keras.datasets.fashion_mnist
-#     ((train_images, train_labels), (test_images, _)) = fashion_mnist.load_data()
+@pytest.mark.skip(reason="TODO")
+def test_kafka_output_sequence():
+    """Test case based on fashion mnist tutorial"""
+    fashion_mnist = tf.keras.datasets.fashion_mnist
+    ((train_images, train_labels), (test_images, _)) = fashion_mnist.load_data()
 
-#     class_names = [
-#         "T-shirt/top",
-#         "Trouser",
-#         "Pullover",
-#         "Dress",
-#         "Coat",
-#         "Sandal",
-#         "Shirt",
-#         "Sneaker",
-#         "Bag",
-#         "Ankle boot",
-#     ]
+    class_names = [
+        "T-shirt/top",
+        "Trouser",
+        "Pullover",
+        "Dress",
+        "Coat",
+        "Sandal",
+        "Shirt",
+        "Sneaker",
+        "Bag",
+        "Ankle boot",
+    ]
 
-#     train_images = train_images / 255.0
-#     test_images = test_images / 255.0
+    train_images = train_images / 255.0
+    test_images = test_images / 255.0
 
-#     model = tf.keras.Sequential(
-#         [
-#             tf.keras.layers.Flatten(input_shape=(28, 28)),
-#             tf.keras.layers.Dense(128, activation=tf.nn.relu),
-#             tf.keras.layers.Dense(10, activation=tf.nn.softmax),
-#         ]
-#     )
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Flatten(input_shape=(28, 28)),
+            tf.keras.layers.Dense(128, activation=tf.nn.relu),
+            tf.keras.layers.Dense(10, activation=tf.nn.softmax),
+        ]
+    )
 
-#     model.compile(
-#         optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"]
-#     )
+    model.compile(
+        optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"]
+    )
 
-#     model.fit(train_images, train_labels, epochs=5)
+    model.fit(train_images, train_labels, epochs=5)
 
-#     class OutputCallback(tf.keras.callbacks.Callback):
-#         """KafkaOutputCallback"""
+    class OutputCallback(tf.keras.callbacks.Callback):
+        """KafkaOutputCallback"""
 
-#         def __init__(
-#             self, batch_size, topic, servers
-#         ):  # pylint: disable=super-init-not-called
-#             self._sequence = kafka_ops.KafkaOutputSequence(topic=topic, servers=servers)
-#             self._batch_size = batch_size
+        def __init__(
+            self, batch_size, topic, servers
+        ):  # pylint: disable=super-init-not-called
+            self._sequence = kafka_ops.KafkaOutputSequence(topic=topic, servers=servers)
+            self._batch_size = batch_size
 
-#         def on_predict_batch_end(self, batch, logs=None):
-#             index = batch * self._batch_size
-#             for outputs in logs["outputs"]:
-#                 for output in outputs:
-#                     self._sequence.setitem(index, class_names[np.argmax(output)])
-#                     index += 1
+        def on_predict_batch_end(self, batch, logs=None):
+            index = batch * self._batch_size
+            for outputs in logs["outputs"]:
+                for output in outputs:
+                    self._sequence.setitem(index, class_names[np.argmax(output)])
+                    index += 1
 
-#         def flush(self):
-#             self._sequence.flush()
+        def flush(self):
+            self._sequence.flush()
 
-#     channel = "e{}e".format(time.time())
-#     topic = "test_" + channel
+    channel = "e{}e".format(time.time())
+    topic = "test_" + channel
 
-#     # By default batch size is 32
-#     output = OutputCallback(32, topic, "localhost")
-#     predictions = model.predict(test_images, callbacks=[output])
-#     output.flush()
+    # By default batch size is 32
+    output = OutputCallback(32, topic, "localhost")
+    predictions = model.predict(test_images, callbacks=[output])
+    output.flush()
 
-#     predictions = [class_names[v] for v in np.argmax(predictions, axis=1)]
+    predictions = [class_names[v] for v in np.argmax(predictions, axis=1)]
 
-#     # Reading from `test_e(time)e` we should get the same result
-#     dataset = tfio.kafka.KafkaDataset(topics=[topic], group="test", eof=True)
-#     for entry, prediction in zip(dataset, predictions):
-#         assert entry.numpy() == prediction.encode()
-
-
-# def test_avro_kafka_dataset():
-#     """test_avro_kafka_dataset"""
-#     schema = (
-#         '{"type":"record","name":"myrecord","fields":['
-#         '{"name":"f1","type":"string"},'
-#         '{"name":"f2","type":"long"},'
-#         '{"name":"f3","type":["null","string"],"default":null}'
-#         "]}"
-#     )
-#     dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
-#     # remove kafka framing
-#     dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
-#     # deserialize avro
-#     dataset = dataset.map(
-#         lambda e: tfio.experimental.serialization.decode_avro(e, schema=schema)
-#     )
-#     entries = [(e["f1"], e["f2"], e["f3"]) for e in dataset]
-#     np.all(entries == [("value1", 1, ""), ("value2", 2, ""), ("value3", 3, "")])
+    # Reading from `test_e(time)e` we should get the same result
+    dataset = tfio.kafka.KafkaDataset(topics=[topic], group="test", eof=True)
+    for entry, prediction in zip(dataset, predictions):
+        assert entry.numpy() == prediction.encode()
 
 
-# def test_avro_kafka_dataset_with_resource():
-#     """test_avro_kafka_dataset_with_resource"""
-#     schema = (
-#         '{"type":"record","name":"myrecord","fields":['
-#         '{"name":"f1","type":"string"},'
-#         '{"name":"f2","type":"long"},'
-#         '{"name":"f3","type":["null","string"],"default":null}'
-#         ']}"'
-#     )
-#     schema_resource = kafka_io.decode_avro_init(schema)
-#     dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
-#     # remove kafka framing
-#     dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
-#     # deserialize avro
-#     dataset = dataset.map(
-#         lambda e: kafka_io.decode_avro(
-#             e, schema=schema_resource, dtype=[tf.string, tf.int64, tf.string]
-#         )
-#     )
-#     entries = [(f1.numpy(), f2.numpy(), f3.numpy()) for (f1, f2, f3) in dataset]
-#     np.all(entries == [("value1", 1), ("value2", 2), ("value3", 3)])
+def test_avro_kafka_dataset():
+    """test_avro_kafka_dataset"""
+    schema = (
+        '{"type":"record","name":"myrecord","fields":['
+        '{"name":"f1","type":"string"},'
+        '{"name":"f2","type":"long"},'
+        '{"name":"f3","type":["null","string"],"default":null}'
+        "]}"
+    )
+    dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
+    # remove kafka framing
+    dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
+    # deserialize avro
+    dataset = dataset.map(
+        lambda e: tfio.experimental.serialization.decode_avro(e, schema=schema)
+    )
+    entries = [(e["f1"], e["f2"], e["f3"]) for e in dataset]
+    np.all(entries == [("value1", 1, ""), ("value2", 2, ""), ("value3", 3, "")])
 
 
-# def test_kafka_stream_dataset():
-#     dataset = tfio.IODataset.stream().from_kafka("test").batch(2)
-#     assert np.all(
-#         [k.numpy().tolist() for (k, _) in dataset]
-#         == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
-#     )
+def test_avro_kafka_dataset_with_resource():
+    """test_avro_kafka_dataset_with_resource"""
+    schema = (
+        '{"type":"record","name":"myrecord","fields":['
+        '{"name":"f1","type":"string"},'
+        '{"name":"f2","type":"long"},'
+        '{"name":"f3","type":["null","string"],"default":null}'
+        ']}"'
+    )
+    schema_resource = kafka_io.decode_avro_init(schema)
+    dataset = kafka_io.KafkaDataset(["avro-test:0"], group="avro-test", eof=True)
+    # remove kafka framing
+    dataset = dataset.map(lambda e: tf.strings.substr(e, 5, -1))
+    # deserialize avro
+    dataset = dataset.map(
+        lambda e: kafka_io.decode_avro(
+            e, schema=schema_resource, dtype=[tf.string, tf.int64, tf.string]
+        )
+    )
+    entries = [(f1.numpy(), f2.numpy(), f3.numpy()) for (f1, f2, f3) in dataset]
+    np.all(entries == [("value1", 1), ("value2", 2), ("value3", 3)])
 
 
-# def test_kafka_io_dataset():
-#     dataset = tfio.IODataset.from_kafka(
-#         "test", configuration=["fetch.min.bytes=2"]
-#     ).batch(2)
-#     # repeat multiple times will result in the same result
-#     for _ in range(5):
-#         assert np.all(
-#             [k.numpy().tolist() for (k, _) in dataset]
-#             == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
-#         )
+def test_kafka_stream_dataset():
+    dataset = tfio.IODataset.stream().from_kafka("test").batch(2)
+    assert np.all(
+        [k.numpy().tolist() for (k, _) in dataset]
+        == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
+    )
 
 
-# def test_avro_encode_decode():
-#     """test_avro_encode_decode"""
-#     schema = (
-#         '{"type":"record","name":"myrecord","fields":'
-#         '[{"name":"f1","type":"string"},{"name":"f2","type":"long"}]}'
-#     )
-#     value = [("value1", 1), ("value2", 2), ("value3", 3)]
-#     f1 = tf.cast([v[0] for v in value], tf.string)
-#     f2 = tf.cast([v[1] for v in value], tf.int64)
-#     message = tfio.experimental.serialization.encode_avro([f1, f2], schema=schema)
-#     entries = tfio.experimental.serialization.decode_avro(message, schema=schema)
-#     assert np.all(entries["f1"].numpy() == f1.numpy())
-#     assert np.all(entries["f2"].numpy() == f2.numpy())
+def test_kafka_io_dataset():
+    dataset = tfio.IODataset.from_kafka(
+        "test", configuration=["fetch.min.bytes=2"]
+    ).batch(2)
+    # repeat multiple times will result in the same result
+    for _ in range(5):
+        assert np.all(
+            [k.numpy().tolist() for (k, _) in dataset]
+            == np.asarray([("D" + str(i)).encode() for i in range(10)]).reshape((5, 2))
+        )
 
 
-# def test_kafka_group_io_dataset_primary_cg():
-#     """Test the functionality of the KafkaGroupIODataset when the consumer group
-#     is being newly created.
-
-#     NOTE: After the kafka cluster is setup during the testing phase, 10 messages
-#     are written to the 'key-partition-test' topic with 5 in each partition
-#     (topic created with 2 partitions, the messages are split based on the keys).
-#     And the same 10 messages are written into the 'key-test' topic (topic created
-#     with 1 partition, so no splitting of the messages based on the keys).
-
-#     K0:D0, K1:D1, K0:D2, K1:D3, K0:D4, K1:D5, K0:D6, K1:D7, K0:D8, K1:D9.
-
-#     Here, messages D0, D2, D4, D6 and D8 are written into partition 0 and the rest are written
-#     into partition 1.
-
-#     Also, since the messages are read from different partitions, the order of retrieval may not be
-#     the same as storage. Thus, we sort and compare.
-#     """
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-partition-test"],
-#         group_id="cgtestprimary",
-#         servers="localhost:9092",
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
-#     assert np.all(
-#         sorted([k.numpy() for (k, _) in dataset])
-#         == sorted([("D" + str(i)).encode() for i in range(10)])
-#     )
+def test_avro_encode_decode():
+    """test_avro_encode_decode"""
+    schema = (
+        '{"type":"record","name":"myrecord","fields":'
+        '[{"name":"f1","type":"string"},{"name":"f2","type":"long"}]}'
+    )
+    value = [("value1", 1), ("value2", 2), ("value3", 3)]
+    f1 = tf.cast([v[0] for v in value], tf.string)
+    f2 = tf.cast([v[1] for v in value], tf.int64)
+    message = tfio.experimental.serialization.encode_avro([f1, f2], schema=schema)
+    entries = tfio.experimental.serialization.decode_avro(message, schema=schema)
+    assert np.all(entries["f1"].numpy() == f1.numpy())
+    assert np.all(entries["f2"].numpy() == f2.numpy())
 
 
-# def test_kafka_group_io_dataset_primary_cg_no_lag():
-#     """Test the functionality of the KafkaGroupIODataset when the
-#     consumer group has read all the messages and committed the offsets.
-#     """
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-partition-test"],
-#         group_id="cgtestprimary",
-#         servers="localhost:9092",
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
-#     assert np.all(sorted([k.numpy() for (k, _) in dataset]) == [])
+def test_kafka_group_io_dataset_primary_cg():
+    """Test the functionality of the KafkaGroupIODataset when the consumer group
+    is being newly created.
+
+    NOTE: After the kafka cluster is setup during the testing phase, 10 messages
+    are written to the 'key-partition-test' topic with 5 in each partition
+    (topic created with 2 partitions, the messages are split based on the keys).
+    And the same 10 messages are written into the 'key-test' topic (topic created
+    with 1 partition, so no splitting of the messages based on the keys).
+
+    K0:D0, K1:D1, K0:D2, K1:D3, K0:D4, K1:D5, K0:D6, K1:D7, K0:D8, K1:D9.
+
+    Here, messages D0, D2, D4, D6 and D8 are written into partition 0 and the rest are written
+    into partition 1.
+
+    Also, since the messages are read from different partitions, the order of retrieval may not be
+    the same as storage. Thus, we sort and compare.
+    """
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtestprimary",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(10)])
+    )
 
 
-# def test_kafka_group_io_dataset_primary_cg_new_topic():
-#     """Test the functionality of the KafkaGroupIODataset when the existing
-#     consumer group reads data from a new topic.
-#     """
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-test"],
-#         group_id="cgtestprimary",
-#         servers="localhost:9092",
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
-#     assert np.all(
-#         sorted([k.numpy() for (k, _) in dataset])
-#         == sorted([("D" + str(i)).encode() for i in range(10)])
-#     )
+def test_kafka_group_io_dataset_primary_cg_no_lag():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer group has read all the messages and committed the offsets.
+    """
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtestprimary",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(sorted([k.numpy() for (k, _) in dataset]) == [])
 
 
-# def test_kafka_group_io_dataset_resume_primary_cg():
-#     """Test the functionality of the KafkaGroupIODataset when the
-#     consumer group is yet to catch up with the newly added messages only
-#     (Instead of reading from the beginning).
-#     """
-
-#     # Write new messages to the topic
-#     for i in range(10, 100):
-#         message = "D{}".format(i)
-#         kafka_io.write_kafka(message=message, topic="key-partition-test")
-
-#     # Read only the newly sent 100 messages
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-partition-test"],
-#         group_id="cgtestprimary",
-#         servers="localhost:9092",
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
-#     assert np.all(
-#         sorted([k.numpy() for (k, _) in dataset])
-#         == sorted([("D" + str(i)).encode() for i in range(10, 100)])
-#     )
+def test_kafka_group_io_dataset_primary_cg_new_topic():
+    """Test the functionality of the KafkaGroupIODataset when the existing
+    consumer group reads data from a new topic.
+    """
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-test"],
+        group_id="cgtestprimary",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(10)])
+    )
 
 
-# def test_kafka_group_io_dataset_resume_primary_cg_new_topic():
-#     """Test the functionality of the KafkaGroupIODataset when the
-#     consumer group is yet to catch up with the newly added messages only
-#     (Instead of reading from the beginning) from the new topic.
-#     """
+def test_kafka_group_io_dataset_resume_primary_cg():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer group is yet to catch up with the newly added messages only
+    (Instead of reading from the beginning).
+    """
 
-#     # Write new messages to the topic
-#     for i in range(10, 100):
-#         message = "D{}".format(i)
-#         kafka_io.write_kafka(message=message, topic="key-test")
+    # Write new messages to the topic
+    for i in range(10, 100):
+        message = "D{}".format(i)
+        kafka_io.write_kafka(message=message, topic="key-partition-test")
 
-#     # Read only the newly sent 100 messages
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-test"],
-#         group_id="cgtestprimary",
-#         servers="localhost:9092",
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
-#     assert np.all(
-#         sorted([k.numpy() for (k, _) in dataset])
-#         == sorted([("D" + str(i)).encode() for i in range(10, 100)])
-#     )
-
-
-# def test_kafka_group_io_dataset_secondary_cg():
-#     """Test the functionality of the KafkaGroupIODataset when a
-#     secondary consumer group is created and is yet to catch up all the messages,
-#     from the beginning.
-#     """
-
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-partition-test"],
-#         group_id="cgtestsecondary",
-#         servers="localhost:9092",
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
-#     assert np.all(
-#         sorted([k.numpy() for (k, _) in dataset])
-#         == sorted([("D" + str(i)).encode() for i in range(100)])
-#     )
+    # Read only the newly sent 100 messages
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtestprimary",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(10, 100)])
+    )
 
 
-# def test_kafka_group_io_dataset_tertiary_cg_multiple_topics():
-#     """Test the functionality of the KafkaGroupIODataset when a new
-#     consumer group reads data from multiple topics from the beginning.
-#     """
+def test_kafka_group_io_dataset_resume_primary_cg_new_topic():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer group is yet to catch up with the newly added messages only
+    (Instead of reading from the beginning) from the new topic.
+    """
 
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-partition-test", "key-test"],
-#         group_id="cgtesttertiary",
-#         servers="localhost:9092",
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
-#     assert np.all(
-#         sorted([k.numpy() for (k, _) in dataset])
-#         == sorted([("D" + str(i)).encode() for i in range(100)] * 2)
-#     )
+    # Write new messages to the topic
+    for i in range(10, 100):
+        message = "D{}".format(i)
+        kafka_io.write_kafka(message=message, topic="key-test")
 
-
-# def test_kafka_group_io_dataset_invalid_stream_timeout():
-#     """Test the functionality of the KafkaGroupIODataset when the
-#     consumer is configured to have an invalid stream_timeout value which is
-#     less than the message_timeout value.
-#     NOTE: The default value for message_timeout=5000
-#     """
-
-#     try:
-#         tfio.experimental.streaming.KafkaGroupIODataset(
-#             topics=["key-partition-test", "key-test"],
-#             group_id="cgteststreaminvalid",
-#             servers="localhost:9092",
-#             stream_timeout=1000,
-#             configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#         )
-#     except ValueError as e:
-#         assert str(e) == "stream_timeout 1000 is less than the message_timeout 5000"
+    # Read only the newly sent 100 messages
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-test"],
+        group_id="cgtestprimary",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(10, 100)])
+    )
 
 
-# def test_kafka_group_io_dataset_stream_timeout_check():
-#     """Test the functionality of the KafkaGroupIODataset when the
-#     consumer is configured to have a valid stream_timeout value and thus waits
-#     for the new messages from kafka.
-#     NOTE: The default value for message_timeout=5000
-#     """
+def test_kafka_group_io_dataset_secondary_cg():
+    """Test the functionality of the KafkaGroupIODataset when a
+    secondary consumer group is created and is yet to catch up all the messages,
+    from the beginning.
+    """
 
-#     def write_messages_background():
-#         # Write new messages to the topic in a background thread
-#         time.sleep(6)
-#         for i in range(100, 200):
-#             message = "D{}".format(i)
-#             kafka_io.write_kafka(message=message, topic="key-partition-test")
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtestsecondary",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(100)])
+    )
 
-#     dataset = tfio.experimental.streaming.KafkaGroupIODataset(
-#         topics=["key-partition-test"],
-#         group_id="cgteststreamvalid",
-#         servers="localhost:9092",
-#         stream_timeout=10000,
-#         configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
-#     )
 
-#     # start writing the new messages to kafka using the background job.
-#     # the job sleep's for some time (< stream_timeout) and then writes the
-#     # messages into the topic.
-#     thread = threading.Thread(target=write_messages_background, args=())
-#     thread.daemon = True
-#     thread.start()
+def test_kafka_group_io_dataset_tertiary_cg_multiple_topics():
+    """Test the functionality of the KafkaGroupIODataset when a new
+    consumer group reads data from multiple topics from the beginning.
+    """
 
-#     # At the end, after the timeout has occurred, we must have the old 100 messages
-#     # along with the new 100 messages
-#     assert np.all(
-#         sorted([k.numpy() for (k, _) in dataset])
-#         == sorted([("D" + str(i)).encode() for i in range(200)])
-#     )
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test", "key-test"],
+        group_id="cgtesttertiary",
+        servers="localhost:9092",
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(100)] * 2)
+    )
+
+
+def test_kafka_group_io_dataset_invalid_stream_timeout():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer is configured to have an invalid stream_timeout value which is
+    less than the message_timeout value.
+    NOTE: The default value for message_timeout=5000
+    """
+
+    try:
+        tfio.experimental.streaming.KafkaGroupIODataset(
+            topics=["key-partition-test", "key-test"],
+            group_id="cgteststreaminvalid",
+            servers="localhost:9092",
+            stream_timeout=1000,
+            configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        )
+    except ValueError as e:
+        assert str(e) == "stream_timeout 1000 is less than the message_timeout 5000"
+
+
+def test_kafka_group_io_dataset_stream_timeout_check():
+    """Test the functionality of the KafkaGroupIODataset when the
+    consumer is configured to have a valid stream_timeout value and thus waits
+    for the new messages from kafka.
+    NOTE: The default value for message_timeout=5000
+    """
+
+    def write_messages_background():
+        # Write new messages to the topic in a background thread
+        time.sleep(6)
+        for i in range(100, 200):
+            message = "D{}".format(i)
+            kafka_io.write_kafka(message=message, topic="key-partition-test")
+
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgteststreamvalid",
+        servers="localhost:9092",
+        stream_timeout=10000,
+        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+    )
+
+    # start writing the new messages to kafka using the background job.
+    # the job sleep's for some time (< stream_timeout) and then writes the
+    # messages into the topic.
+    thread = threading.Thread(target=write_messages_background, args=())
+    thread.daemon = True
+    thread.start()
+
+    # At the end, after the timeout has occurred, we must have the old 100 messages
+    # along with the new 100 messages
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(200)])
+    )
 
 
 def test_kafka_batch_io_dataset():


### PR DESCRIPTION
This PR addresses the issues: https://github.com/tensorflow/io/issues/1076, https://github.com/tensorflow/io/issues/449 by adding experimental support for online learning using the `tf.experimental.streaming.KafkaBatchIODataset`. 

**Description:**

A dataset of type `KakfaBatchIODataset` is created to fetch messages from Kafka in a mini-dataset(or mini-batch) fashion, i.e each element of the iterable is a `tf.data.Dataset` in itself. This enables the user to directly pass this so-called mini-dataset to a tf model and train it. This training loop continues as long as the data keeps on flowing from Kafka into the `KakfaBatchIODataset`.

**Example:**

```python

import tensorflow_io as tfio
import tensorflow as tf

# initialize the dataset
dataset = tfio.experimental.streaming.KafkaBatchIODataset(
    topics=["mini-batch-test"],
    group_id="cgminibatch",
    servers=None,
    stream_timeout=10000,
    configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
)

# build the model
NUM_COLUMNS = 1
model = tf.keras.Sequential(
    [
        tf.keras.layers.Input(shape=(NUM_COLUMNS,)),
        tf.keras.layers.Dense(4, activation="relu"),
        tf.keras.layers.Dropout(0.1),
        tf.keras.layers.Dense(1, activation="sigmoid"),
    ]
)

# compile the model
model.compile(
    optimizer="adam",
    loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),
    metrics=["accuracy"],
)

# fit the model on a continuous stream of data without waiting for the entire dataset to be fetched
for mini_d in dataset:

   # mini_d is of type `tf.data.Dataset`, thus all the relevant functionality applies
    mini_d = mini_d.map(
        lambda m, k: (
            tf.strings.to_number(m, out_type=tf.float32),
            tf.strings.to_number(k, out_type=tf.float32),
        )
    ).batch(2)

    # Fits the model as long as the data keeps on streaming into `dataset`
    model.fit(mini_d, epochs=5)
```

**Output:**

```console
2020-08-11 23:41:36.879136: I tensorflow/compiler/xla/service/service.cc:176]   StreamExecutor device (0): Host, Default Version
2020-08-11 23:41:36.885718: I tensorflow_io/core/kernels/kafka_kernels.cc:853] Kafka configuration: session.timeout.ms=7000
2020-08-11 23:41:36.885742: I tensorflow_io/core/kernels/kafka_kernels.cc:853] Kafka configuration: max.poll.interval.ms=8000
2020-08-11 23:41:36.885751: I tensorflow_io/core/kernels/kafka_kernels.cc:853] Kafka configuration: group.id=cgminibatch
2020-08-11 23:41:36.885777: I tensorflow_io/core/kernels/kafka_kernels.cc:901] cpp: Creating the kafka consumer
2020-08-11 23:41:36.888352: I tensorflow_io/core/kernels/kafka_kernels.cc:908] cpp: Subscribing to the kafka topic: mini-batch-test
2020-08-11 23:41:39.904706: E tensorflow_io/core/kernels/kafka_kernels.cc:774] REBALANCE: Local: Assign partitions
2020-08-11 23:41:39.906375: E tensorflow_io/core/kernels/kafka_kernels.cc:775] Retrieved committed offsets with status code: 0
2020-08-11 23:41:39.906416: I tensorflow_io/core/kernels/kafka_kernels.cc:784] REBALANCE: mini-batch-test[0], 5 0
2020-08-11 23:41:39.906425: I tensorflow_io/core/kernels/kafka_kernels.cc:784] REBALANCE: mini-batch-test[1], 5 0
2020-08-11 23:41:39.906430: I tensorflow_io/core/kernels/kafka_kernels.cc:790] REBALANCE: Assigning partitions
2020-08-11 23:41:40.010261: I tensorflow_io/core/kernels/kafka_kernels.cc:955] %% EOF reached for all 2 partition(s)
2020-08-11 23:41:40.010289: I tensorflow_io/core/kernels/kafka_kernels.cc:958] Waiting for the next message
2020-08-11 23:41:50.015499: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
2020-08-11 23:41:50.015523: I tensorflow_io/core/kernels/kafka_kernels.cc:971] Waiting for the next message
2020-08-11 23:42:00.023622: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
Epoch 1/5
5/5 [==============================] - 0s 701us/step - loss: 0.7340 - accuracy: 0.4000
Epoch 2/5
5/5 [==============================] - 0s 527us/step - loss: 0.6807 - accuracy: 0.5000
Epoch 3/5
5/5 [==============================] - 0s 543us/step - loss: 0.7131 - accuracy: 0.4000
Epoch 4/5
5/5 [==============================] - 0s 600us/step - loss: 0.7131 - accuracy: 0.4000
Epoch 5/5
5/5 [==============================] - 0s 565us/step - loss: 0.7633 - accuracy: 0.4000
2020-08-11 23:42:05.462964: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
2020-08-11 23:42:05.463017: I tensorflow_io/core/kernels/kafka_kernels.cc:971] Waiting for the next message
2020-08-11 23:42:19.638937: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
2020-08-11 23:42:19.638991: I tensorflow_io/core/kernels/kafka_kernels.cc:971] Waiting for the next message
2020-08-11 23:42:29.640826: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
Epoch 1/5
15/15 [==============================] - 0s 602us/step - loss: 0.6921 - accuracy: 0.5333
Epoch 2/5
15/15 [==============================] - 0s 568us/step - loss: 0.7197 - accuracy: 0.5000
Epoch 3/5
15/15 [==============================] - 0s 592us/step - loss: 0.7114 - accuracy: 0.5333
Epoch 4/5
15/15 [==============================] - 0s 577us/step - loss: 0.6926 - accuracy: 0.5667
Epoch 5/5
15/15 [==============================] - 0s 704us/step - loss: 0.7093 - accuracy: 0.5000
2020-08-11 23:42:34.739468: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
2020-08-11 23:42:34.739496: I tensorflow_io/core/kernels/kafka_kernels.cc:971] Waiting for the next message
2020-08-11 23:42:44.740613: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
2020-08-11 23:42:44.740638: I tensorflow_io/core/kernels/kafka_kernels.cc:971] Waiting for the next message
2020-08-11 23:42:54.745028: E tensorflow_io/core/kernels/kafka_kernels.cc:969] Error: Local: Timed out
```

**Explanation:**

During the first training loop (with 5 batches and 5 epochs), the Kafka consumer read the already present data and trained the model. Next, it kept on waiting for a maximum of `stream_timeout` milliseconds and when it found the new messages that were written to Kafka, it fetched the new 15 batches of data and the model training resumed. 

**Dataset:**

The sample data which was repeatedly sent to Kafka for demo purposes is as follows:

```python
Key: Message
0:0
1:1
0:2
1:3
0:4
1:5
0:6
1:7
0:8
1:9

```