### PR TITLE
BigQuery reader optimizations

### DIFF
--- a/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
+++ b/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
@@ -66,24 +66,7 @@ class BigQueryClientOp : public OpKernel {
               cinfo_.container(), cinfo_.name(), &resource,
               [this, ctx](BigQueryClientResource** ret)
                   TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-                    std::string server_name =
-                        "dns:///bigquerystorage.googleapis.com";
-                    auto creds = ::grpc::GoogleDefaultCredentials();
-                    grpc::ChannelArguments args;
-                    args.SetMaxReceiveMessageSize(kMaxReceiveMessageSize);
-                    args.SetUserAgentPrefix(
-                        strings::StrCat("tensorflow-", TF_VERSION_STRING));
-                    args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 0);
-                    args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 60 * 1000);
-                    auto channel =
-                        ::grpc::CreateCustomChannel(server_name, creds, args);
-                    VLOG(3) << "Creating GRPC channel";
-                    auto stub =
-                        absl::make_unique<apiv1beta1::BigQueryStorage::Stub>(
-                            channel);
-                    VLOG(3) << "Done creating GRPC channel";
-
-                    *ret = new BigQueryClientResource(std::move(stub));
+                    *ret = new BigQueryClientResource();
                     return Status::OK();
                   }));
       core::ScopedUnref resource_cleanup(resource);
@@ -172,7 +155,7 @@ class BigQueryReadSessionOp : public OpKernel {
     std::shared_ptr<apiv1beta1::ReadSession> readSessionResponse =
         std::make_shared<apiv1beta1::ReadSession>();
     VLOG(3) << "calling readSession";
-    ::grpc::Status status = client_resource->get_stub()->CreateReadSession(
+    ::grpc::Status status = client_resource->GetStub("")->CreateReadSession(
         &context, createReadSessionRequest, readSessionResponse.get());
     if (!status.ok()) {
       VLOG(3) << "readSession status:" << GrpcStatusToString(status);

--- a/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
+++ b/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
@@ -60,15 +60,13 @@ class BigQueryClientOp : public OpKernel {
       ResourceMgr* mgr = ctx->resource_manager();
       OP_REQUIRES_OK(ctx, cinfo_.Init(mgr, def()));
       BigQueryClientResource* resource;
-      OP_REQUIRES_OK(
-          ctx,
-          mgr->LookupOrCreate<BigQueryClientResource>(
-              cinfo_.container(), cinfo_.name(), &resource,
-              [this, ctx](BigQueryClientResource** ret)
-                  TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-                    *ret = new BigQueryClientResource();
-                    return Status::OK();
-                  }));
+      OP_REQUIRES_OK(ctx, mgr->LookupOrCreate<BigQueryClientResource>(
+                              cinfo_.container(), cinfo_.name(), &resource,
+                              [this, ctx](BigQueryClientResource** ret)
+                                  TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+                                    *ret = new BigQueryClientResource();
+                                    return Status::OK();
+                                  }));
       core::ScopedUnref resource_cleanup(resource);
       initialized_ = true;
     }

--- a/tensorflow_io/bigquery/kernels/bigquery_lib.h
+++ b/tensorflow_io/bigquery/kernels/bigquery_lib.h
@@ -36,11 +36,13 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/public/version.h"
 #include "tensorflow_io/arrow/kernels/arrow_util.h"
 
 namespace tensorflow {
 
 namespace apiv1beta1 = ::google::cloud::bigquery::storage::v1beta1;
+static constexpr int kMaxReceiveMessageSize = 1 << 24;  // 16 MBytes
 
 Status GrpcStatusToTfStatus(const ::grpc::Status &status);
 string GrpcStatusToString(const ::grpc::Status &status);
@@ -50,17 +52,43 @@ Status GetDataFormat(string data_format_str,
 class BigQueryClientResource : public ResourceBase {
  public:
   explicit BigQueryClientResource(
-      std::shared_ptr<apiv1beta1::BigQueryStorage::Stub> stub)
-      : stub_(std::move(stub)) {}
+      std::function<std::unique_ptr<apiv1beta1::BigQueryStorage::Stub>()> stub_factory)
+      : stub_factory_(stub_factory) {
+  }
 
-  std::shared_ptr<apiv1beta1::BigQueryStorage::Stub> get_stub() {
-    return stub_;
+  explicit BigQueryClientResource() : BigQueryClientResource([]()
+  {
+      string server_name =
+          "dns:///bigquerystorage.googleapis.com";
+      auto creds = ::grpc::GoogleDefaultCredentials();
+      grpc::ChannelArguments args;
+      args.SetMaxReceiveMessageSize(kMaxReceiveMessageSize);
+      args.SetUserAgentPrefix(
+          strings::StrCat("tensorflow-", TF_VERSION_STRING));
+      args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 0);
+      args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 60 * 1000);
+      auto channel =
+          ::grpc::CreateCustomChannel(server_name, creds, args);
+      VLOG(3) << "Creating GRPC channel";
+      return absl::make_unique<apiv1beta1::BigQueryStorage::Stub>(channel);
+  }) {}
+
+  apiv1beta1::BigQueryStorage::Stub* GetStub(const string& read_stream)
+    TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    if (stubs_.find(read_stream) == stubs_.end()) {
+      auto stub = stub_factory_();
+      stubs_.emplace(read_stream, std::move(stub));
+    }
+    return stubs_[read_stream].get();
   }
 
   string DebugString() const override { return "BigQueryClientResource"; }
 
- private:
-  std::shared_ptr<apiv1beta1::BigQueryStorage::Stub> stub_;
+private:
+  std::function<std::unique_ptr<apiv1beta1::BigQueryStorage::Stub>()> stub_factory_;
+  mutex mu_;
+  std::unordered_map<string, std::unique_ptr<apiv1beta1::BigQueryStorage::Stub>> stubs_
+    TF_GUARDED_BY(mu_);
 };
 
 namespace data {
@@ -129,7 +157,7 @@ class BigQueryReaderDatasetIteratorBase : public DatasetIterator<Dataset> {
 
     VLOG(3) << "getting reader, stream: "
             << readRowsRequest.read_position().stream().DebugString();
-    reader_ = this->dataset()->client_resource()->get_stub()->ReadRows(
+    reader_ = this->dataset()->client_resource()->GetStub(readRowsRequest.read_position().stream().name())->ReadRows(
         read_rows_context_.get(), readRowsRequest);
 
     return Status::OK();
@@ -262,6 +290,7 @@ class BigQueryReaderAvroDatasetIterator
             &this->response_->avro_rows().serialized_binary_rows()[0]),
         this->response_->avro_rows().serialized_binary_rows().size());
     this->decoder_->init(*memory_input_stream_);
+    this->datum_ = absl::make_unique<avro::GenericDatum>(*this->dataset()->avro_schema());
     return Status::OK();
   }
 
@@ -269,92 +298,96 @@ class BigQueryReaderAvroDatasetIterator
                     const std::vector<string> &columns,
                     const std::vector<DataType> &output_types)
       TF_EXCLUSIVE_LOCKS_REQUIRED(this->mu_) override {
-    avro::GenericDatum datum =
-        avro::GenericDatum(*this->dataset()->avro_schema());
-    avro::decode(*this->decoder_, datum);
-    if (datum.type() != avro::AVRO_RECORD) {
+    avro::decode(*this->decoder_, *this->datum_);
+    if (this->datum_->type() != avro::AVRO_RECORD) {
       return errors::Unknown("record is not of AVRO_RECORD type");
     }
-    const avro::GenericRecord &record = datum.value<avro::GenericRecord>();
-    out_tensors->clear();
-    // Let's allocate enough space for Tensor, if more than read then slice.
-    std::vector<DataType> expected_output_types;
-    expected_output_types.reserve(output_types.size());
-    for (size_t i = 0; i < columns.size(); i++) {
-      const string &column = columns[i];
-      const avro::GenericDatum &field = record.field(column);
-      DataType dtype;
-      switch (field.type()) {
-        case avro::AVRO_BOOL:
-          dtype = DT_BOOL;
-          break;
-        case avro::AVRO_INT:
-          dtype = DT_INT32;
-          break;
-        case avro::AVRO_LONG:
-          dtype = DT_INT64;
-          break;
-        case avro::AVRO_FLOAT:
-          dtype = DT_FLOAT;
-          break;
-        case avro::AVRO_DOUBLE:
-          dtype = DT_DOUBLE;
-          break;
-        case avro::AVRO_STRING:
-          dtype = DT_STRING;
-          break;
-        case avro::AVRO_BYTES:
-          dtype = DT_STRING;
-          break;
-        case avro::AVRO_FIXED:
-          dtype = DT_STRING;
-          break;
-        case avro::AVRO_ENUM:
-          dtype = DT_STRING;
-          break;
-        case avro::AVRO_ARRAY: {
-          auto values_vector = field.value<avro::GenericArray>().value();
-          if (values_vector.empty())
+    const avro::GenericRecord &record = this->datum_->value<avro::GenericRecord>();
+
+    if (this->column_indices_.size() == 0) {
+      this->column_indices_.reserve(columns.size());
+      std::vector<DataType> expected_output_types;
+      expected_output_types.reserve(output_types.size());
+      for (size_t i = 0; i < columns.size(); i++) {
+        const string &column = columns[i];
+        size_t column_index = record.fieldIndex(column);
+        this->column_indices_.emplace_back(column_index);
+
+        const avro::GenericDatum &field = record.fieldAt(column_index);
+        DataType dtype;
+        switch (field.type()) {
+          case avro::AVRO_BOOL:
+            dtype = DT_BOOL;
+            break;
+          case avro::AVRO_INT:
+            dtype = DT_INT32;
+            break;
+          case avro::AVRO_LONG:
+            dtype = DT_INT64;
+            break;
+          case avro::AVRO_FLOAT:
+            dtype = DT_FLOAT;
+            break;
+          case avro::AVRO_DOUBLE:
+            dtype = DT_DOUBLE;
+            break;
+          case avro::AVRO_STRING:
+            dtype = DT_STRING;
+            break;
+          case avro::AVRO_BYTES:
+            dtype = DT_STRING;
+            break;
+          case avro::AVRO_FIXED:
+            dtype = DT_STRING;
+            break;
+          case avro::AVRO_ENUM:
+            dtype = DT_STRING;
+            break;
+          case avro::AVRO_ARRAY: {
+            auto values_vector = field.value<avro::GenericArray>().value();
+            if (values_vector.empty())
+              dtype = output_types[i];
+            else {
+              auto value_type = values_vector[0].type();
+              if (value_type == avro::AVRO_BOOL)
+                dtype = DT_BOOL;
+              else if (value_type == avro::AVRO_INT)
+                dtype = DT_INT32;
+              else if (value_type == avro::AVRO_LONG)
+                dtype = DT_INT64;
+              else if (value_type == avro::AVRO_FLOAT)
+                dtype = DT_FLOAT;
+              else if (value_type == avro::AVRO_DOUBLE)
+                dtype = DT_DOUBLE;
+              else if (value_type == avro::AVRO_STRING)
+                dtype = DT_STRING;
+              else
+                return errors::InvalidArgument(
+                    "unsupported data type within AVRO_ARRAY ", value_type);
+            }
+          } break;
+          case avro::AVRO_NULL:
             dtype = output_types[i];
-          else {
-            auto value_type = values_vector[0].type();
-            if (value_type == avro::AVRO_BOOL)
-              dtype = DT_BOOL;
-            else if (value_type == avro::AVRO_INT)
-              dtype = DT_INT32;
-            else if (value_type == avro::AVRO_LONG)
-              dtype = DT_INT64;
-            else if (value_type == avro::AVRO_FLOAT)
-              dtype = DT_FLOAT;
-            else if (value_type == avro::AVRO_DOUBLE)
-              dtype = DT_DOUBLE;
-            else if (value_type == avro::AVRO_STRING)
-              dtype = DT_STRING;
-            else
-              return errors::InvalidArgument(
-                  "unsupported data type within AVRO_ARRAY ", value_type);
-          }
-        } break;
-        case avro::AVRO_NULL:
-          dtype = output_types[i];
-          break;
-        default:
-          return errors::InvalidArgument("unsupported data type: ",
-                                         field.type());
+            break;
+          default:
+            return errors::InvalidArgument("unsupported data type: ",
+                                          field.type());
+        }
+        if (dtype != output_types[i]) {
+          return errors::InvalidArgument(
+              "output type mismatch for column: ", columns[i],
+              " expected type: ", DataType_Name(dtype),
+              " actual type: ", DataType_Name(output_types[i]));
+        }
+        expected_output_types.emplace_back(dtype);
       }
-      if (dtype != output_types[i]) {
-        return errors::InvalidArgument(
-            "output type mismatch for column: ", columns[i],
-            " expected type: ", DataType_Name(dtype),
-            " actual type: ", DataType_Name(output_types[i]));
-      }
-      expected_output_types.emplace_back(dtype);
+    }
+
+    out_tensors->clear();
+    for (size_t i = 0; i < columns.size(); i++) {
       Tensor tensor(ctx->allocator({}), output_types[i], {});
       out_tensors->emplace_back(std::move(tensor));
-    }
-    for (size_t i = 0; i < columns.size(); i++) {
-      const string &column = columns[i];
-      const avro::GenericDatum &field = record.field(column);
+      const avro::GenericDatum &field = record.fieldAt(this->column_indices_[i]);
       switch (field.type()) {
         case avro::AVRO_BOOL:
           ((*out_tensors)[i]).scalar<bool>()() = field.value<bool>();
@@ -478,7 +511,9 @@ class BigQueryReaderAvroDatasetIterator
  private:
   std::unique_ptr<avro::InputStream> memory_input_stream_
       TF_GUARDED_BY(this->mu_);
+  std::unique_ptr<avro::GenericDatum> datum_ TF_GUARDED_BY(this->mu_);
   avro::DecoderPtr decoder_ TF_GUARDED_BY(this->mu_);
+  std::vector<size_t> column_indices_ TF_GUARDED_BY(this->mu_);
 };
 
 }  // namespace data

--- a/tensorflow_io/bigquery/kernels/bigquery_lib.h
+++ b/tensorflow_io/bigquery/kernels/bigquery_lib.h
@@ -305,7 +305,7 @@ class BigQueryReaderAvroDatasetIterator
       return errors::Unknown("record is not of AVRO_RECORD type");
     }
     const avro::GenericRecord &record =
-        this->datum_->value<avro::GenericRecord>();
+        this->datum_->template value<avro::GenericRecord>();
 
     if (this->column_indices_.size() == 0) {
       this->column_indices_.reserve(columns.size());

--- a/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
+++ b/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
@@ -70,7 +70,8 @@ class BigQueryTestClientOp : public OpKernel {
               cinfo_.container(), cinfo_.name(), &resource,
               [this](BigQueryClientResource** ret) TF_EXCLUSIVE_LOCKS_REQUIRED(
                   mu_) {
-                *ret = new BigQueryClientResource([this]() {
+                *ret = new BigQueryClientResource([this](const string&
+                                                             read_stream) {
                   LOG(INFO) << "Connecting BigQueryTestClientOp Fake client to:"
                             << fake_server_address_;
                   std::shared_ptr<grpc::Channel> channel =

--- a/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
+++ b/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
@@ -70,18 +70,20 @@ class BigQueryTestClientOp : public OpKernel {
               cinfo_.container(), cinfo_.name(), &resource,
               [this](BigQueryClientResource** ret) TF_EXCLUSIVE_LOCKS_REQUIRED(
                   mu_) {
-                  *ret = new BigQueryClientResource([this](){
+                *ret = new BigQueryClientResource([this]() {
                   LOG(INFO) << "Connecting BigQueryTestClientOp Fake client to:"
                             << fake_server_address_;
-                  std::shared_ptr<grpc::Channel> channel = ::grpc::CreateChannel(
-                      this->fake_server_address_, grpc::InsecureChannelCredentials());
+                  std::shared_ptr<grpc::Channel> channel =
+                      ::grpc::CreateChannel(this->fake_server_address_,
+                                            grpc::InsecureChannelCredentials());
                   auto stub = apiv1beta1::BigQueryStorage::NewStub(channel);
                   LOG(INFO) << "BigQueryTestClientOp waiting for connections";
                   channel->WaitForConnected(
                       gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
-                                  gpr_time_from_seconds(15, GPR_TIMESPAN)));
+                                   gpr_time_from_seconds(15, GPR_TIMESPAN)));
                   LOG(INFO) << "Done creating BigQueryTestClientOp Fake client";
-                  return absl::make_unique<apiv1beta1::BigQueryStorage::Stub>(channel);
+                  return absl::make_unique<apiv1beta1::BigQueryStorage::Stub>(
+                      channel);
                 });
                 return Status::OK();
               }));

--- a/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
+++ b/tensorflow_io/bigquery/kernels/test_kernels/bigquery_test_client_op.cc
@@ -70,17 +70,19 @@ class BigQueryTestClientOp : public OpKernel {
               cinfo_.container(), cinfo_.name(), &resource,
               [this](BigQueryClientResource** ret) TF_EXCLUSIVE_LOCKS_REQUIRED(
                   mu_) {
-                LOG(INFO) << "Connecting BigQueryTestClientOp Fake client to:"
-                          << fake_server_address_;
-                std::shared_ptr<grpc::Channel> channel = ::grpc::CreateChannel(
-                    fake_server_address_, grpc::InsecureChannelCredentials());
-                auto stub = apiv1beta1::BigQueryStorage::NewStub(channel);
-                LOG(INFO) << "BigQueryTestClientOp waiting for connections";
-                channel->WaitForConnected(
-                    gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
-                                 gpr_time_from_seconds(15, GPR_TIMESPAN)));
-                LOG(INFO) << "Done creating BigQueryTestClientOp Fake client";
-                *ret = new BigQueryClientResource(std::move(stub));
+                  *ret = new BigQueryClientResource([this](){
+                  LOG(INFO) << "Connecting BigQueryTestClientOp Fake client to:"
+                            << fake_server_address_;
+                  std::shared_ptr<grpc::Channel> channel = ::grpc::CreateChannel(
+                      this->fake_server_address_, grpc::InsecureChannelCredentials());
+                  auto stub = apiv1beta1::BigQueryStorage::NewStub(channel);
+                  LOG(INFO) << "BigQueryTestClientOp waiting for connections";
+                  channel->WaitForConnected(
+                      gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                                  gpr_time_from_seconds(15, GPR_TIMESPAN)));
+                  LOG(INFO) << "Done creating BigQueryTestClientOp Fake client";
+                  return absl::make_unique<apiv1beta1::BigQueryStorage::Stub>(channel);
+                });
                 return Status::OK();
               }));
 


### PR DESCRIPTION
- Doing field type validations only for first row since types won't change
- Initializing avro::GenericDatum only once
- Using separate gRPC connections per reader stream