### PR TITLE
added 'import' tests and github actions for docker images

### DIFF
--- a/.github/workflows/build.space.sh
+++ b/.github/workflows/build.space.sh
@@ -1,9 +1,9 @@
 # Free disk space on Linux
-        #sudo swapoff /swapfile
-        #sudo rm -rf /swapfile
-        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-        sudo apt-get remove php* ruby-* subversion mongodb-org -yq >/dev/null 2>&1
-        sudo apt-get autoremove -y >/dev/null 2>&1
-        sudo apt-get autoclean -y >/dev/null 2>&1
-        sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
-        docker rmi $(docker image ls -aq) >/dev/null 2>&1
+#sudo swapoff /swapfile
+#sudo rm -rf /swapfile
+sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+sudo apt-get remove php* ruby-* subversion mongodb-org -yq >/dev/null 2>&1
+sudo apt-get autoremove -y >/dev/null 2>&1
+sudo apt-get autoclean -y >/dev/null 2>&1
+sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
+docker rmi $(docker image ls -aq) >/dev/null 2>&1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,17 @@ jobs:
           set -x -e
           python --version
           bash -x -e .github/workflows/build.wheel.sh python
+      - name: Test docker images on macOS
+        run: |
+          set -x -e
+          mkdir -p ~/.docker/machine/cache
+          curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+          brew install docker docker-machine
+          docker-machine create --driver virtualbox default
+          docker-machine env default
+          eval "$(docker-machine env default)"
+          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
+          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
   linux-bazel:
     name: Bazel Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,11 @@ jobs:
           set -x -e
           python --version
           bash -x -e .github/workflows/build.wheel.sh python
+      - name: Test docker images on macOS
+        run: |
+          set -x -e
+          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
+          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
   linux-bazel:
     name: Bazel Linux
@@ -304,6 +309,11 @@ jobs:
           docker run -i --rm -v $PWD:/v -w /v --net=host \
             buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
             bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
+      - name: Test docker images on Linux
+        run: |
+          set -x -e
+          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
+          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
   windows-bazel:
     name: Bazel Windows
@@ -409,6 +419,13 @@ jobs:
           (python -m pytest -s -v test_bigquery_eager.py)
           (python -m pytest -s -v test_dicom_eager.py)
           (python -m pytest -s -v test_dicom.py)
+      - name: Test docker images on Windows
+        shell: cmd
+        run: |
+          @echo on
+          set -x -e
+          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
+          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
   release:
     name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Test docker images on macOS
         run: |
           set -x -e
-          brew install docker
+          brew cask install docker
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
@@ -420,12 +420,6 @@ jobs:
           (python -m pytest -s -v test_bigquery_eager.py)
           (python -m pytest -s -v test_dicom_eager.py)
           (python -m pytest -s -v test_dicom.py)
-      - name: Test docker images on Windows
-        shell: cmd
-        run: |
-          @echo on
-          set -x -e
-          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
 
   release:
     name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,7 @@ jobs:
       - name: Test docker images on macOS
         run: |
           set -x -e
+          brew install docker
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
@@ -425,7 +426,6 @@ jobs:
           @echo on
           set -x -e
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
-          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
   release:
     name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,9 +216,14 @@ jobs:
       - name: Test docker images on macOS
         run: |
           set -x -e
-          brew cask install docker
+          brew install docker docker-machine
+          brew cask install virtualbox
+          docker-machine create --driver virtualbox default
+          docker-machine env default
+          eval "$(docker-machine env default)"
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh
+          docker-machine stop default
 
   linux-bazel:
     name: Bazel Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,6 @@ jobs:
           docker-machine env default
           eval "$(docker-machine env default)"
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
-          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
   linux-bazel:
     name: Bazel Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,17 +213,6 @@ jobs:
           set -x -e
           python --version
           bash -x -e .github/workflows/build.wheel.sh python
-      - name: Test docker images on macOS
-        run: |
-          set -x -e
-          brew install docker docker-machine
-          brew cask install virtualbox
-          docker-machine create --driver virtualbox default
-          docker-machine env default
-          eval "$(docker-machine env default)"
-          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
-          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
-          docker-machine stop default
 
   linux-bazel:
     name: Bazel Linux

--- a/tools/docker/tests/bazel_build.sh
+++ b/tools/docker/tests/bazel_build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+echo "Configuring the environment for build ..."
+./configure.sh
+
+echo "Cleaning up existing bazel build files ..."
+rm -rf bazel-*
+
+echo "Building the tensorflow-io package ..."
+bazel build -j 8 --copt=-msse4.2 --copt=-mavx --compilation_mode=opt --verbose_failures --test_output=errors --crosstool_top=//third_party/toolchains/gcc7_manylinux2010:toolchain //tensorflow_io/...
+
+echo "Validating import ..."
+python -c "import tensorflow_io as tfio; print(tfio.__version__)"

--- a/tools/docker/tests/dockerfile_cpu_test.sh
+++ b/tools/docker/tests/dockerfile_cpu_test.sh
@@ -21,4 +21,4 @@ echo "Build the docker image ..."
 docker build -f tools/docker/cpu.Dockerfile -t ${IMAGE_NAME} .
 
 echo "Starting the docker container from image: ${IMAGE_NAME} and validating import ..."
-docker run -it --rm ${IMAGE_NAME} python -c "import tensorflow_io as tfio; print(tfio.__version__)"
+docker run -t --rm ${IMAGE_NAME} python -c "import tensorflow_io as tfio; print(tfio.__version__)"

--- a/tools/docker/tests/dockerfile_cpu_test.sh
+++ b/tools/docker/tests/dockerfile_cpu_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+IMAGE_NAME="tfio-cpu"
+export PYTHON_BIN_PATH=$(which python3.7)
+
+echo "Build the docker image ..."
+docker build -f tools/docker/cpu.Dockerfile -t ${IMAGE_NAME} .
+
+echo "Starting the docker container from image: ${IMAGE_NAME} and validating import ..."
+docker run -it --rm ${IMAGE_NAME} python -c "import tensorflow_io as tfio; print(tfio.__version__)"

--- a/tools/docker/tests/dockerfile_devel_test.sh
+++ b/tools/docker/tests/dockerfile_devel_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+IMAGE_NAME="tfio-dev"
+export PYTHON_BIN_PATH=$(which python3)
+
+echo "Build the docker image ..."
+docker build -f tools/docker/devel.Dockerfile -t ${IMAGE_NAME} .
+
+echo "Starting the docker container from image: ${IMAGE_NAME} and building the package ..."
+docker run -it --rm --net=host -v ${PWD}:/v -w /v tfio-dev bash tools/docker/tests/bazel_build.sh

--- a/tools/docker/tests/dockerfile_devel_test.sh
+++ b/tools/docker/tests/dockerfile_devel_test.sh
@@ -21,4 +21,4 @@ echo "Build the docker image ..."
 docker build -f tools/docker/devel.Dockerfile -t ${IMAGE_NAME} .
 
 echo "Starting the docker container from image: ${IMAGE_NAME} and building the package ..."
-docker run -it --rm --net=host -v ${PWD}:/v -w /v tfio-dev bash tools/docker/tests/bazel_build.sh
+docker run -t --rm --net=host -v ${PWD}:/v -w /v tfio-dev bash tools/docker/tests/bazel_build.sh


### PR DESCRIPTION
This PR addresses the issue: https://github.com/tensorflow/io/issues/1087 and is a follow up of PR: https://github.com/tensorflow/io/pull/1089

Github actions have been added to test the docker build and package import functionality on the Linux and MacOS platforms.

The tests include the following:

- Build `tfio-cpu` image using `cpu.Dockerfile` and validate the tfio import in python.
- Build `tfio-dev` image using `devel.Dockerfile`, build tfio from source using bazel and validate it's import in python.