### PR TITLE
Update bigquery_lib.h

### DIFF
--- a/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
+++ b/tensorflow_io/bigquery/kernels/bigquery_kernels.cc
@@ -37,7 +37,6 @@ namespace tensorflow {
 namespace {
 
 namespace apiv1beta1 = ::google::cloud::bigquery::storage::v1beta1;
-static constexpr int kMaxReceiveMessageSize = 1 << 24;  // 16 MBytes
 
 class BigQueryClientOp : public OpKernel {
  public:

--- a/tensorflow_io/bigquery/kernels/bigquery_lib.h
+++ b/tensorflow_io/bigquery/kernels/bigquery_lib.h
@@ -42,7 +42,7 @@ limitations under the License.
 namespace tensorflow {
 
 namespace apiv1beta1 = ::google::cloud::bigquery::storage::v1beta1;
-static constexpr int kMaxReceiveMessageSize = 1 << 24;  // 16 MBytes
+static constexpr int kMaxReceiveMessageSize = -1;  // Disabled
 
 Status GrpcStatusToTfStatus(const ::grpc::Status &status);
 string GrpcStatusToString(const ::grpc::Status &status);


### PR DESCRIPTION
Disable max message size checks for the BQ read API.  this seems to be consistent with the python client: https://github.com/googleapis/python-bigquery-storage/blob/645e65d3533cb445b542a54f4552e3c05a5b1382/google/cloud/bigquery_storage_v1beta2/gapic/transports/big_query_read_grpc_transport.py