### PR TITLE
Elasticsearch init ops and kernel

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -190,6 +190,7 @@ cc_library(
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
         "@rapidjson",
+        "@curl",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -169,6 +169,33 @@ cc_library(
     alwayslink = 1,
 )
 
+
+cc_library(
+    name = "elasticsearch_ops",
+    srcs = [
+        "kernels/elasticsearch_kernels.cc",
+        "ops/elasticsearch_ops.cc",
+    ],
+    copts = tf_io_copts(),
+    linkstatic = True,
+    deps = [
+        "@rapidjson",
+        "//tensorflow_io/core:dataset_ops",
+        "//tensorflow_io/core:sequence_ops",
+        "@com_google_absl//absl/algorithm",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
+        "@com_google_absl//absl/types:variant",
+        "@local_config_tf//:libtensorflow_framework",
+        "@local_config_tf//:tf_header_lib",
+    ],
+    alwayslink = 1,
+)
+
+
 cc_library(
     name = "pcap_ops",
     srcs = [
@@ -657,6 +684,7 @@ cc_binary(
         "//tensorflow_io/core:avro_ops",
         "//tensorflow_io/core:azfs_ops",
         "//tensorflow_io/core:cpuinfo",
+        "//tensorflow_io/core:elasticsearch_ops",
         "//tensorflow_io/core:file_ops",
         "//tensorflow_io/core:grpc_ops",
         "//tensorflow_io/core:hdf5_ops",

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -683,7 +683,6 @@ cc_binary(
         "//tensorflow_io/core:avro_ops",
         "//tensorflow_io/core:azfs_ops",
         "//tensorflow_io/core:cpuinfo",
-        "//tensorflow_io/core:elasticsearch_ops",
         "//tensorflow_io/core:file_ops",
         "//tensorflow_io/core:grpc_ops",
         "//tensorflow_io/core:hdf5_ops",
@@ -707,6 +706,7 @@ cc_binary(
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [
             "//tensorflow_io/core:core_ops",
+            "//tensorflow_io/core:elasticsearch_ops",
             "//tensorflow_io/core:genome_ops",
             "//tensorflow_io/core:optimization",
             "//tensorflow_io/core:oss_ops",

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -187,10 +187,10 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
+        "@curl",
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
         "@rapidjson",
-        "@curl",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -169,7 +169,6 @@ cc_library(
     alwayslink = 1,
 )
 
-
 cc_library(
     name = "elasticsearch_ops",
     srcs = [
@@ -179,7 +178,6 @@ cc_library(
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [
-        "@rapidjson",
         "//tensorflow_io/core:dataset_ops",
         "//tensorflow_io/core:sequence_ops",
         "@com_google_absl//absl/algorithm",
@@ -191,10 +189,10 @@ cc_library(
         "@com_google_absl//absl/types:variant",
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
+        "@rapidjson",
     ],
     alwayslink = 1,
 )
-
 
 cc_library(
     name = "pcap_ops",

--- a/tensorflow_io/core/kernels/elasticsearch_kernels.cc
+++ b/tensorflow_io/core/kernels/elasticsearch_kernels.cc
@@ -1,0 +1,123 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "rapidjson/document.h"
+#include "rapidjson/error/en.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/resource_op_kernel.h"
+#include "tensorflow/core/platform/cloud/curl_http_request.h"
+
+namespace tensorflow {
+namespace io {
+namespace {
+
+class ElasticsearchReadableResource : public ResourceBase {
+ public:
+  ElasticsearchReadableResource(Env* env) : env_(env) {}
+  ~ElasticsearchReadableResource() {}
+
+  Status Init(const std::string& url, const std::string& healthcheck_field) {
+    HttpRequest* request = http_request_factory_.Create();
+    // LOG(INFO) << "Setting the url";
+    request->SetUri(url);
+
+    // LOG(INFO) << "Setting the response buffer";
+    std::vector<char> response;
+    request->SetResultBuffer(&response);
+
+    // LOG(INFO) << "Sending the request";
+    TF_RETURN_IF_ERROR(request->Send());
+
+    // LOG(INFO) << "Getting the length of content";
+    string length_string = request->GetResponseHeader("content-length");
+
+    // LOG(INFO) << "response length: " << length_string;
+    std::string response_str(response.begin(), response.end());
+
+    // LOG(INFO) << "response: " << response_str;
+    rapidjson::Document response_json;
+
+    if (response_json.Parse(response_str.c_str()).HasParseError()) {
+      LOG(ERROR) << "Error while parsing json at offset: "
+                 << response_json.GetErrorOffset() << " : "
+                 << GetParseError_En(response_json.GetParseError());
+      return errors::InvalidArgument(
+          "Unable to convert the response body to JSON");
+    }
+
+    if (response_json.HasMember(healthcheck_field.c_str())) {
+      LOG(INFO) << "cluster health: "
+                << response_json[healthcheck_field.c_str()].GetString();
+    } else
+      return errors::FailedPrecondition("healthcheck failed");
+
+    return Status::OK();
+  }
+
+  Status Read() {
+    // TODO (kvignesh1420)
+  }
+
+  string DebugString() const override { return "ElasticsearchBaseResource"; }
+
+ protected:
+  mutable mutex mu_;
+  Env* env_ TF_GUARDED_BY(mu_);
+  string url_;
+  CurlHttpRequest::Factory http_request_factory_ = CurlHttpRequest::Factory();
+};
+
+class ElasticsearchReadableInitOp
+    : public ResourceOpKernel<ElasticsearchReadableResource> {
+ public:
+  explicit ElasticsearchReadableInitOp(OpKernelConstruction* context)
+      : ResourceOpKernel<ElasticsearchReadableResource>(context) {
+    env_ = context->env();
+  }
+
+ private:
+  void Compute(OpKernelContext* context) override {
+    ResourceOpKernel<ElasticsearchReadableResource>::Compute(context);
+
+    const Tensor* url_tensor;
+    OP_REQUIRES_OK(context, context->input("url", &url_tensor));
+    const string& url = url_tensor->scalar<tstring>()();
+
+    const Tensor* healthcheck_field_tensor;
+    OP_REQUIRES_OK(context, context->input("healthcheck_field",
+                                           &healthcheck_field_tensor));
+    const string& healthcheck_field =
+        healthcheck_field_tensor->scalar<tstring>()();
+
+    OP_REQUIRES_OK(context, resource_->Init(url, healthcheck_field));
+  }
+
+  Status CreateResource(ElasticsearchReadableResource** resource)
+      TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+    *resource = new ElasticsearchReadableResource(env_);
+    return Status::OK();
+  }
+
+ private:
+  mutable mutex mu_;
+  Env* env_ TF_GUARDED_BY(mu_);
+};
+
+REGISTER_KERNEL_BUILDER(Name("IO>ElasticsearchReadableInit").Device(DEVICE_CPU),
+                        ElasticsearchReadableInitOp);
+
+}  // namespace
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/ops/elasticsearch_ops.cc
+++ b/tensorflow_io/core/ops/elasticsearch_ops.cc
@@ -1,0 +1,37 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+namespace io {
+namespace {
+
+REGISTER_OP("IO>ElasticsearchReadableInit")
+    .Input("url: string")
+    .Input("healthcheck_field: string")
+    .Output("resource: resource")
+    .Attr("container: string = ''")
+    .Attr("shared_name: string = ''")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Scalar());
+      return Status::OK();
+    });
+
+}  // namespace
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/python/api/experimental/__init__.py
+++ b/tensorflow_io/core/python/api/experimental/__init__.py
@@ -27,3 +27,4 @@ from tensorflow_io.core.python.api.experimental import color
 from tensorflow_io.core.python.api.experimental import audio
 from tensorflow_io.core.python.api.experimental import streaming
 from tensorflow_io.core.python.api.experimental import filter
+from tensorflow_io.core.python.api.experimental import elasticsearch

--- a/tensorflow_io/core/python/api/experimental/elasticsearch.py
+++ b/tensorflow_io/core/python/api/experimental/elasticsearch.py
@@ -1,0 +1,19 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""tensorflow_io.experimental.elasticsearch"""
+
+from tensorflow_io.core.python.experimental.elasticsearch_dataset_ops import (  # pylint: disable=unused-import
+    ElasticsearchIODataset,
+)

--- a/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
@@ -1,0 +1,90 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""ElasticsearchIODatasets"""
+
+from urllib.parse import urlparse
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
+
+
+class ElasticsearchIODataset(tf.data.Dataset):
+    """Represents an elasticsearch based tf.data.Dataset"""
+
+    def __init__(self, hosts=None, protocol="http", internal=True):
+        with tf.name_scope("ElasticsearchIODataset"):
+            assert internal
+
+            base_urls = prepare_base_urls(hosts=hosts, protocol=protocol)
+            healthcheck_urls = prepare_healthcheck_urls(base_urls=base_urls)
+            resource = get_healthy_resource(healthcheck_urls=healthcheck_urls)
+
+            # TODO (kvignesh1420): Read data from the cluster
+
+    def _inputs(self):
+        return []
+
+    @property
+    def element_spec(self):
+        return self._dataset.element_spec
+
+
+def prepare_base_urls(hosts, protocol):
+    """Prepares the base url for establish connection with the elasticsearch master
+    
+    Args:
+        hosts: A list of tf.strings in the host:port format.
+        protocol: The protocol to be used to connect to the elasticsearch cluster.
+    Returns:
+        A list of base_url's, each of type tf.string for establishing the connection pool
+    """
+
+    if hosts is None:
+        hosts = ["localhost:9200"]
+
+    elif isinstance(hosts, str):
+        hosts = [hosts]
+
+    base_urls = []
+    for host in hosts:
+        if "//" in host:
+            raise ValueError("Please provide the list of hosts in 'host:port' format.")
+
+        base_url = "{}://{}".format(protocol, host)
+        base_urls.append(base_url)
+
+    return base_urls
+
+
+def prepare_healthcheck_urls(base_urls):
+    """Appends the healthcheck path to all the base_urls"""
+
+    return ["{}/_cluster/health".format(base_url) for base_url in base_urls]
+
+
+def get_healthy_resource(healthcheck_urls):
+    """Retrieve the resource which is connected to a healthy node"""
+
+    for url in healthcheck_urls:
+        try:
+            resource = core_ops.io_elasticsearch_readable_init(
+                url=url, healthcheck_field="status"
+            )
+            print("Connection successful:{}".format(url))
+            return resource
+        except:
+            print("Skipping host:{}".format(url))
+            continue
+    else:
+        raise Exception("No healthy node available, please check your cluster status")


### PR DESCRIPTION
This PR addresses the issue https://github.com/tensorflow/io/issues/1093 by adding implementations for the following:

- `IO>ElasticsearchReadableInit` Op.
- `ElasticsearchReadableInitOp` Kernel.
- `tfio.experimental.elasticsearch.ElasticsearchIODataset` template implementation and few helper methods.

Also, modified the `BUILD` file for Bazel build of `elasticsearch_ops`.