### PR TITLE
Add support of multiple dimension tensor for tfio.experimental.serialization.decode_json

### DIFF
--- a/tests/test_serialization_eager.py
+++ b/tests/test_serialization_eager.py
@@ -200,3 +200,21 @@ def test_json_partial_shape():
 
     v = parse_json(r)
     assert np.array_equal(v, [1, 2, 3, 4, 5])
+
+
+def test_json_multiple_dimension_tensor():
+
+    # Test case is to resolve the issue where multiple dimension tensor
+    # was not supported for decode_json.
+    # The issue was initially raised in:
+    # https://github.com/tensorflow/io/pull/695#issuecomment-683270751
+    r = '{"x": [[1.0]]}'
+
+    @tf.function(autograph=False)
+    def parse_json(json_text):
+        specs = {"x": tf.TensorSpec(tf.TensorShape([1, 1]), tf.float32)}
+        parsed = tfio.experimental.serialization.decode_json(json_text, specs)
+        return parsed["x"]
+
+    v = parse_json(r)
+    assert np.array_equal(v, [[1.0]])


### PR DESCRIPTION
This PR tries to address the issue raised in https://github.com/tensorflow/io/pull/695#issuecomment-683270751 where
it was not possible to use tfio.experimental.serialization.decode_json
for entries of multi dimensional tensor, e.g. `'{"x":[[1.0]]}'`.

Supporting unlimited dimensional tensor could be a challange so this PR
takes a first step of support 2D tensor first.

A follow up PR will be created for higher dimension tensors.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>