### PR TITLE
Remove docker build test on macOS (Linux is kept)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,16 +213,6 @@ jobs:
           set -x -e
           python --version
           bash -x -e .github/workflows/build.wheel.sh python
-      - name: Test docker images on macOS
-        run: |
-          set -x -e
-          mkdir -p ~/.docker/machine/cache
-          curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
-          brew install docker docker-machine
-          docker-machine create --driver virtualbox default
-          docker-machine env default
-          eval "$(docker-machine env default)"
-          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
 
   linux-bazel:
     name: Bazel Linux


### PR DESCRIPTION
This PR removes docker build test on macOS as
docker install on GitHub Actions macOS is not very stable
and often breaks (See e.g., https://github.com/tensorflow/io/runs/1024230016).

We are still covered with Linux for docker build test.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>