### PR TITLE
Elasticsearch: decoupling io and parsing ops

### DIFF
--- a/tensorflow_io/core/ops/elasticsearch_ops.cc
+++ b/tensorflow_io/core/ops/elasticsearch_ops.cc
@@ -40,12 +40,9 @@ REGISTER_OP("IO>ElasticsearchReadableNext")
     .Input("resource: resource")
     .Input("request_url: string")
     .Input("scroll_request_url: string")
-    .Output("column_values: dtypes")
-    .Attr("dtypes: list(type)")
+    .Output("items: string")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
-      for (size_t i = 0; i < c->num_outputs(); ++i) {
-        c->set_output(static_cast<int64>(i), c->MakeShape({c->UnknownDim()}));
-      }
+      c->set_output(0, c->MakeShape({c->UnknownDim()}));
       return Status::OK();
     });
 

--- a/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
@@ -14,9 +14,11 @@
 # ==============================================================================
 """ElasticsearchIODatasets"""
 
+import multiprocessing
 from urllib.parse import urlparse
 import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops
+from tensorflow_io.core.python.experimental import serialization_ops
 
 
 class _ElasticsearchHandler:
@@ -99,7 +101,7 @@ class _ElasticsearchHandler:
                         dtypes.append(tf.double)
                     elif dtype == "DT_STRING":
                         dtypes.append(tf.string)
-                return resource, columns, dtypes, request_url
+                return resource, columns.numpy(), dtypes, request_url
             except Exception:
                 print("Skipping host: {}".format(healthcheck_url))
                 continue
@@ -108,7 +110,7 @@ class _ElasticsearchHandler:
                 "No healthy node available for this index, check the cluster status and index"
             )
 
-    def prepare_next_batch(self, resource, columns, dtypes, request_url):
+    def get_next_batch(self, resource, request_url):
         """Prepares the next batch of data based on the request url and
         the counter index.
 
@@ -118,7 +120,7 @@ class _ElasticsearchHandler:
             dtypes: tf.dtypes of the columns.
             request_url: The request url to fetch the data
         Returns:
-            Structured data which columns as keys and the corresponding tensors as values.
+            A Tensor containing serialized JSON records.
         """
 
         url_obj = urlparse(request_url)
@@ -130,12 +132,25 @@ class _ElasticsearchHandler:
             resource=resource,
             request_url=request_url,
             scroll_request_url=scroll_request_url,
-            dtypes=dtypes,
         )
-        data = {}
-        for i, column in enumerate(columns.numpy()):
-            data[column.decode("utf-8")] = values[i]
-        return data
+        return values
+
+    def parse_json(self, raw_item, columns, dtypes):
+        """Prepares the next batch of data based on the request url and
+        the counter index.
+
+        Args:
+            raw_value: A serialized JSON record in tf.string format.
+            columns: list of columns to prepare the structured data.
+            dtypes: tf.dtypes of the columns.
+        Returns:
+            Structured data with columns as keys and the corresponding tensors as values.
+        """
+        specs = {}
+        for column, dtype in zip(columns, dtypes):
+            specs[column.decode("utf-8")] = tf.TensorSpec(tf.TensorShape([]), dtype)
+        parsed_item = serialization_ops.decode_json(data=raw_item, specs=specs)
+        return parsed_item
 
 
 class ElasticsearchIODataset(tf.compat.v2.data.Dataset):
@@ -160,19 +175,17 @@ class ElasticsearchIODataset(tf.compat.v2.data.Dataset):
 
             dataset = tf.data.experimental.Counter()
             dataset = dataset.map(
-                lambda i: handler.prepare_next_batch(
-                    resource=resource,
-                    columns=columns,
-                    dtypes=dtypes,
-                    request_url=request_url,
+                lambda i: handler.get_next_batch(
+                    resource=resource, request_url=request_url
                 )
             )
             dataset = dataset.apply(
-                tf.data.experimental.take_while(
-                    lambda v: tf.greater(
-                        tf.shape(v[columns.numpy()[0].decode("utf-8")])[0], 0
-                    )
-                )
+                tf.data.experimental.take_while(lambda v: tf.greater(tf.shape(v)[0], 0))
+            )
+            dataset = dataset.unbatch()
+            dataset = dataset.map(
+                lambda v: handler.parse_json(v, columns=columns, dtypes=dtypes),
+                num_parallel_calls=multiprocessing.cpu_count(),
             )
             self._dataset = dataset
 

--- a/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
@@ -181,7 +181,7 @@ class ElasticsearchIODataset(tf.compat.v2.data.Dataset):
             dataset = dataset.apply(
                 tf.data.experimental.take_while(lambda v: tf.greater(tf.shape(v)[0], 0))
             )
-            dataset = dataset.unbatch()
+            dataset = dataset.flat_map(lambda x: tf.data.Dataset.from_tensor_slices(x))
             dataset = dataset.map(
                 lambda v: handler.parse_json(v, columns=columns, dtypes=dtypes),
                 num_parallel_calls=tf.data.experimental.AUTOTUNE,

--- a/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """ElasticsearchIODatasets"""
 
-import multiprocessing
 from urllib.parse import urlparse
 import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops
@@ -185,7 +184,7 @@ class ElasticsearchIODataset(tf.compat.v2.data.Dataset):
             dataset = dataset.unbatch()
             dataset = dataset.map(
                 lambda v: handler.parse_json(v, columns=columns, dtypes=dtypes),
-                num_parallel_calls=multiprocessing.cpu_count(),
+                num_parallel_calls=tf.data.experimental.AUTOTUNE,
             )
             self._dataset = dataset
 

--- a/tensorflow_io/core/python/experimental/serialization_ops.py
+++ b/tensorflow_io/core/python/experimental/serialization_ops.py
@@ -153,7 +153,7 @@ def decode_avro(data, schema, name=None):
 
 def encode_avro(data, schema, name=None):
     """
-    Encode Tendsors into Avro string.
+    Encode Tensors into Avro string.
 
     Args:
         data: A list of Tensors to encode.

--- a/tensorflow_io/core/python/experimental/serialization_ops.py
+++ b/tensorflow_io/core/python/experimental/serialization_ops.py
@@ -49,19 +49,18 @@ def named_spec(specs, name=""):
 
 def decode_json(data, specs, name=None):
     """
-  Decode JSON string into Tensors.
+    Decode JSON string into Tensors.
 
-  TODO: support batch (1-D) input
+    Args:
+        data: A String Tensor. The JSON strings to decode.
+        specs: A structured TensorSpecs describing the signature
+        of the JSON elements.
+        name: A name for the operation (optional).
 
-  Args:
-    data: A String Tensor. The JSON strings to decode.
-    specs: A structured TensorSpecs describing the signature
-      of the JSON elements.
-    name: A name for the operation (optional).
-
-  Returns:
-    A structured Tensors.
-  """
+    Returns:
+        A structured Tensors.
+    """
+    # TODO: support batch (1-D) input
     # Make a copy of specs to keep the original specs
     named = tf.nest.map_structure(lambda e: _NamedTensorSpec(e.shape, e.dtype), specs)
     named_spec(named)
@@ -128,16 +127,16 @@ def process_entry(data, name):
 
 def decode_avro(data, schema, name=None):
     """
-  Decode Avro string into Tensors.
+    Decode Avro string into Tensors.
 
-  Args:
-    data: A String Tensor. The Avro strings to decode.
-    schema: A string of the Avro schema.
-    name: A name for the operation (optional).
+    Args:
+        data: A String Tensor. The Avro strings to decode.
+        schema: A string of the Avro schema.
+        name: A name for the operation (optional).
 
-  Returns:
-    A structured Tensors.
-  """
+    Returns:
+        A structured Tensors.
+    """
     # TODO: Use resource to reuse schema initialization
     specs = process_entry(
         json.loads(schema.decode() if isinstance(schema, bytes) else schema), ""
@@ -154,16 +153,16 @@ def decode_avro(data, schema, name=None):
 
 def encode_avro(data, schema, name=None):
     """
-  Encode Tendsors into Avro string.
+    Encode Tendsors into Avro string.
 
-  Args:
-    data: A list of Tensors to encode.
-    schema: A string of the Avro schema.
-    name: A name for the operation (optional).
+    Args:
+        data: A list of Tensors to encode.
+        schema: A string of the Avro schema.
+        name: A name for the operation (optional).
 
-  Returns:
-    An Avro-encoded string Tensor.
-  """
+    Returns:
+        An Avro-encoded string Tensor.
+    """
     # TODO: Use resource to reuse schema initialization
     specs = process_entry(
         json.loads(schema.decode() if isinstance(schema, bytes) else schema), ""


### PR DESCRIPTION
This PR addresses the feature request: https://github.com/tensorflow/io/issues/1093 and is a follow up of https://github.com/tensorflow/io/pull/1099.  The following changes have been made:

- decoupled the IO and JSON parsing operations for the `ElasticsearchIODataset`.
- adjusted docstrings for serialization ops.

@yongtang The final `dataset.map` operation to parse JSON's can be moved out of the class in the future. However, I am currently keeping it as a part of the `ElasticsearchIODataset` so that users need not define the `specs` for parsing JSON's.