### PR TITLE
github action to push docker images to registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,11 +307,6 @@ jobs:
           docker run -i --rm -v $PWD:/v -w /v --net=host \
             buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
             bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
-      - name: Test docker images on Linux
-        run: |
-          set -x -e
-          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
-          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
 
   windows-bazel:
     name: Bazel Windows
@@ -495,6 +490,20 @@ jobs:
         with:
           name: tensorflow-io-release
           path: wheelhouse
+
+  docker-release:
+    name: Docker Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [lint, linux-test, macos-test, windows-test]
+    runs-on: ubuntu-18.04
+    steps:
+      - run: |
+          set -e -x
+          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+          bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
+          docker push tfsigio/tfio:latest
+          bash -x -e tools/docker/tests/dockerfile_devel_test.sh
+          docker push tfsigio/tfio:latest-devel
 
   build-number:
     name: Build Number

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,7 +499,7 @@ jobs:
     steps:
       - run: |
           set -e -x
-          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+          docker login --username tfsigio --password ${{ secrets.DOCKER_PASSWORD }}
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           docker push tfsigio/tfio:latest
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh

--- a/tools/docker/tests/dockerfile_cpu_test.sh
+++ b/tools/docker/tests/dockerfile_cpu_test.sh
@@ -14,11 +14,12 @@
 # limitations under the License.
 # ==============================================================================
 
-IMAGE_NAME="tfio-cpu"
-export PYTHON_BIN_PATH=$(which python3.7)
+IMAGE_NAME="tfsigio/tfio"
+IMAGE_TAG="latest"
+export PYTHON_BIN_PATH=$(which python3)
 
 echo "Build the docker image ..."
-docker build -f tools/docker/cpu.Dockerfile -t ${IMAGE_NAME} .
+docker build -f tools/docker/cpu.Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
 
-echo "Starting the docker container from image: ${IMAGE_NAME} and validating import ..."
-docker run -t --rm ${IMAGE_NAME} python -c "import tensorflow_io as tfio; print(tfio.__version__)"
+echo "Starting the docker container from image: ${IMAGE_NAME}:${IMAGE_TAG} and validating import ..."
+docker run -t --rm ${IMAGE_NAME}:${IMAGE_TAG} python -c "import tensorflow_io as tfio; print(tfio.__version__)"

--- a/tools/docker/tests/dockerfile_devel_test.sh
+++ b/tools/docker/tests/dockerfile_devel_test.sh
@@ -14,11 +14,12 @@
 # limitations under the License.
 # ==============================================================================
 
-IMAGE_NAME="tfio-dev"
+IMAGE_NAME="tfsigio/tfio"
+IMAGE_TAG="latest-devel"
 export PYTHON_BIN_PATH=$(which python3)
 
 echo "Build the docker image ..."
-docker build -f tools/docker/devel.Dockerfile -t ${IMAGE_NAME} .
+docker build -f tools/docker/devel.Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
 
-echo "Starting the docker container from image: ${IMAGE_NAME} and building the package ..."
-docker run -t --rm --net=host -v ${PWD}:/v -w /v tfio-dev bash tools/docker/tests/bazel_build.sh
+echo "Starting the docker container from image: ${IMAGE_NAME}:${IMAGE_TAG} and building the package ..."
+docker run -t --rm --net=host -v ${PWD}:/v -w /v ${IMAGE_NAME}:${IMAGE_TAG} bash tools/docker/tests/bazel_build.sh


### PR DESCRIPTION
This PR addresses the issue: https://github.com/tensorflow/io/issues/1087 by adding a GitHub action to test and push the docker images to the registry.

The docker image testing step has been migrated from the `linux-test` job to the new `docker-release` job.