### PR TITLE
Consolidate bazel version specification to always take from .bazelversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ xcodebuild -version
 # macOS's default python3 is 3.7.3
 python3 --version
 
-# Install bazel 3.1.0:
-curl -OL https://github.com/bazelbuild/bazel/releases/download/3.1.0/bazel-3.1.0-installer-darwin-x86_64.sh
-sudo bash -x -e bazel-3.1.0-installer-darwin-x86_64.sh
+# Install Bazel version specified in .bazelversion
+curl -OL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-darwin-x86_64.sh
+sudo bash -x -e bazel-$(cat .bazelversion)-installer-darwin-x86_64.sh
 
 # Install tensorflow and configure bazel
 sudo ./configure.sh
@@ -234,9 +234,9 @@ the shared libraries on Ubuntu 18.04/20.04:
 sudo apt-get -y -qq update
 sudo apt-get -y -qq install gcc g++ git unzip curl python3-pip
 
-# Install Bazel 3.1.0
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/3.1.0/bazel-3.1.0-installer-linux-x86_64.sh
-sudo bash -x -e bazel-3.1.0-installer-linux-x86_64.sh
+# Install Bazel version specified in .bazelversion
+curl -sSOL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
+sudo bash -x -e bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
 
 # Upgrade pip
 sudo python3 -m pip install -U pip
@@ -264,9 +264,9 @@ the shared libraries on CentOS 8:
 # Install gcc/g++, git, unzip/which (for bazel), and python3
 sudo yum install -y python3 python3-devel gcc gcc-c++ git unzip which
 
-# Install Bazel 3.1.0
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/3.1.0/bazel-3.1.0-installer-linux-x86_64.sh
-sudo bash -x -e bazel-3.1.0-installer-linux-x86_64.sh
+# Install Bazel version specified in .bazelversion
+curl -sSOL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
+sudo bash -x -e bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
 
 # Upgrade pip
 sudo python3 -m pip install -U pip
@@ -299,9 +299,9 @@ The following will install bazel, devtoolset-9, rh-python36, and build the share
 sudo yum install -y centos-release-scl
 sudo yum install -y devtoolset-9 git rh-python36
 
-# Install Bazel 3.1.0
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/3.1.0/bazel-3.1.0-installer-linux-x86_64.sh
-sudo bash -x -e bazel-3.1.0-installer-linux-x86_64.sh
+# Install Bazel version specified in .bazelversion
+curl -sSOL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
+sudo bash -x -e bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
 
 # Upgrade pip
 scl enable rh-python36 devtoolset-9 \


### PR DESCRIPTION
This PR consolidate bazel version specification to always take from .bazelversion,
in order to avoid out-of-sync in case of updates.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>