### PR TITLE
Bug fix in github actions while pushing docker images to registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,81 +415,81 @@ jobs:
   #         (python -m pytest -s -v test_dicom_eager.py)
   #         (python -m pytest -s -v test_dicom.py)
 
-  release:
-    name: Release
-    if: github.event_name == 'push'
-    needs: [lint, linux-test, macos-test, windows-test]
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.5-wheel
-          path: macOS-3.5-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.6-wheel
-          path: macOS-3.6-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.7-wheel
-          path: macOS-3.7-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.8-wheel
-          path: macOS-3.8-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.5-wheel
-          path: Linux-3.5-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.6-wheel
-          path: Linux-3.6-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.7-wheel
-          path: Linux-3.7-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.8-wheel
-          path: Linux-3.8-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.5-wheel
-          path: Windows-3.5-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.6-wheel
-          path: Windows-3.6-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.7-wheel
-          path: Windows-3.7-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.8-wheel
-          path: Windows-3.8-wheel
-      - run: |
-          set -e -x
-          mkdir -p wheelhouse
-          cp macOS-3.5-wheel/*.whl wheelhouse/
-          cp macOS-3.6-wheel/*.whl wheelhouse/
-          cp macOS-3.7-wheel/*.whl wheelhouse/
-          cp macOS-3.8-wheel/*.whl wheelhouse/
-          cp Linux-3.5-wheel/*.whl wheelhouse/
-          cp Linux-3.6-wheel/*.whl wheelhouse/
-          cp Linux-3.7-wheel/*.whl wheelhouse/
-          cp Linux-3.8-wheel/*.whl wheelhouse/
-          cp Windows-3.5-wheel/*.whl wheelhouse/
-          cp Windows-3.6-wheel/*.whl wheelhouse/
-          cp Windows-3.7-wheel/*.whl wheelhouse/
-          cp Windows-3.8-wheel/*.whl wheelhouse/
-          ls -la wheelhouse/
-          sha256sum wheelhouse/*.whl
-      - uses: actions/upload-artifact@v1
-        with:
-          name: tensorflow-io-release
-          path: wheelhouse
+  # release:
+  #   name: Release
+  #   if: github.event_name == 'push'
+  #   needs: [lint, linux-test, macos-test, windows-test]
+  #   runs-on: ubuntu-18.04
+  #   steps:
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.5-wheel
+  #         path: macOS-3.5-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.6-wheel
+  #         path: macOS-3.6-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.7-wheel
+  #         path: macOS-3.7-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.8-wheel
+  #         path: macOS-3.8-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.5-wheel
+  #         path: Linux-3.5-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.6-wheel
+  #         path: Linux-3.6-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.7-wheel
+  #         path: Linux-3.7-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.8-wheel
+  #         path: Linux-3.8-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.5-wheel
+  #         path: Windows-3.5-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.6-wheel
+  #         path: Windows-3.6-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.7-wheel
+  #         path: Windows-3.7-wheel
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.8-wheel
+  #         path: Windows-3.8-wheel
+  #     - run: |
+  #         set -e -x
+  #         mkdir -p wheelhouse
+  #         cp macOS-3.5-wheel/*.whl wheelhouse/
+  #         cp macOS-3.6-wheel/*.whl wheelhouse/
+  #         cp macOS-3.7-wheel/*.whl wheelhouse/
+  #         cp macOS-3.8-wheel/*.whl wheelhouse/
+  #         cp Linux-3.5-wheel/*.whl wheelhouse/
+  #         cp Linux-3.6-wheel/*.whl wheelhouse/
+  #         cp Linux-3.7-wheel/*.whl wheelhouse/
+  #         cp Linux-3.8-wheel/*.whl wheelhouse/
+  #         cp Windows-3.5-wheel/*.whl wheelhouse/
+  #         cp Windows-3.6-wheel/*.whl wheelhouse/
+  #         cp Windows-3.7-wheel/*.whl wheelhouse/
+  #         cp Windows-3.8-wheel/*.whl wheelhouse/
+  #         ls -la wheelhouse/
+  #         sha256sum wheelhouse/*.whl
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: tensorflow-io-release
+  #         path: wheelhouse
 
   docker-release:
     name: Docker Release
@@ -520,204 +520,204 @@ jobs:
           name: BUILD_NUMBER
           path: BUILD_NUMBER
 
-  macos-nightly:
-    name: Nightly ${{ matrix.python }} macOS
-    if: github.event_name == 'push'
-    needs: [build-number, release]
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: BUILD_NUMBER
-      - uses: einaregilsson/build-number@v2
-      - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Wheel ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python -m pip install -U wheel setuptools
-          python --version
-          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64 --nightly $BUILD_NUMBER
-      - name: Auditwheel ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python -m pip install twine delocate
-          delocate-wheel --version
-          ls dist/*
-          for f in dist/*.whl; do
-            delocate-wheel -w wheelhouse  $f
-          done
-          ls wheelhouse/*
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-nightly
-          path: wheelhouse
+  # macos-nightly:
+  #   name: Nightly ${{ matrix.python }} macOS
+  #   if: github.event_name == 'push'
+  #   needs: [build-number, release]
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       python: ['3.5', '3.6', '3.7', '3.8']
+  #   steps:
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: BUILD_NUMBER
+  #     - uses: einaregilsson/build-number@v2
+  #     - run: echo "Build number is $BUILD_NUMBER"
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Wheel ${{ matrix.python }} macOS
+  #       run: |
+  #         set -x -e
+  #         python -m pip install -U wheel setuptools
+  #         python --version
+  #         python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64 --nightly $BUILD_NUMBER
+  #     - name: Auditwheel ${{ matrix.python }} macOS
+  #       run: |
+  #         set -x -e
+  #         python -m pip install twine delocate
+  #         delocate-wheel --version
+  #         ls dist/*
+  #         for f in dist/*.whl; do
+  #           delocate-wheel -w wheelhouse  $f
+  #         done
+  #         ls wheelhouse/*
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-nightly
+  #         path: wheelhouse
 
-  linux-nightly:
-    name: Nightly ${{ matrix.python }} Linux
-    if: github.event_name == 'push'
-    needs: [build-number, release]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
-        python: ['3.5', '3.6', '3.7', '3.8']
-        exclude:
-          - os: ubuntu-16.04
-            python: '3.6'
-          - os: ubuntu-16.04
-            python: '3.7'
-          - os: ubuntu-16.04
-            python: '3.8'
-          - os: ubuntu-18.04
-            python: '3.5'
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: BUILD_NUMBER
-      - uses: einaregilsson/build-number@v2
-      - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
-      - name: Wheel ${{ matrix.python }} Linux
-        run: |
-          set -x -e
-          mv bazel-bin/tensorflow_io/.bazelrc .
-          docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
-      - name: Auditwheel ${{ matrix.python }} Linux
-        run: |
-          set -x -e
-          ls dist/*
-          for f in dist/*.whl; do
-            docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
-          done
-          sudo chown -R $(id -nu):$(id -ng) .
-          ls wheelhouse/*
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-nightly
-          path: wheelhouse
+  # linux-nightly:
+  #   name: Nightly ${{ matrix.python }} Linux
+  #   if: github.event_name == 'push'
+  #   needs: [build-number, release]
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-16.04, ubuntu-18.04]
+  #       python: ['3.5', '3.6', '3.7', '3.8']
+  #       exclude:
+  #         - os: ubuntu-16.04
+  #           python: '3.6'
+  #         - os: ubuntu-16.04
+  #           python: '3.7'
+  #         - os: ubuntu-16.04
+  #           python: '3.8'
+  #         - os: ubuntu-18.04
+  #           python: '3.5'
+  #   steps:
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: BUILD_NUMBER
+  #     - uses: einaregilsson/build-number@v2
+  #     - run: echo "Build number is $BUILD_NUMBER"
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
+  #     - name: Wheel ${{ matrix.python }} Linux
+  #       run: |
+  #         set -x -e
+  #         mv bazel-bin/tensorflow_io/.bazelrc .
+  #         docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
+  #     - name: Auditwheel ${{ matrix.python }} Linux
+  #       run: |
+  #         set -x -e
+  #         ls dist/*
+  #         for f in dist/*.whl; do
+  #           docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
+  #         done
+  #         sudo chown -R $(id -nu):$(id -ng) .
+  #         ls wheelhouse/*
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-nightly
+  #         path: wheelhouse
 
-  windows-nightly:
-    name: Nightly ${{ matrix.python }} Windows
-    if: github.event_name == 'push'
-    needs: [build-number, release]
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python: ['3.5', '3.6', '3.7', 3.8]
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: BUILD_NUMBER
-      - uses: einaregilsson/build-number@v2
-      - run: echo "Build number is $BUILD_NUMBER"
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Wheel ${{ matrix.python }} Windows
-        shell: cmd
-        run: |
-          @echo on
-          python --version
-          python -m pip install -U wheel setuptools
-          python setup.py --data bazel-bin -q bdist_wheel --nightly %BUILD_NUMBER%
-          ls -la dist
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-nightly
-          path: dist
+  # windows-nightly:
+  #   name: Nightly ${{ matrix.python }} Windows
+  #   if: github.event_name == 'push'
+  #   needs: [build-number, release]
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       python: ['3.5', '3.6', '3.7', 3.8]
+  #   steps:
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: BUILD_NUMBER
+  #     - uses: einaregilsson/build-number@v2
+  #     - run: echo "Build number is $BUILD_NUMBER"
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Wheel ${{ matrix.python }} Windows
+  #       shell: cmd
+  #       run: |
+  #         @echo on
+  #         python --version
+  #         python -m pip install -U wheel setuptools
+  #         python setup.py --data bazel-bin -q bdist_wheel --nightly %BUILD_NUMBER%
+  #         ls -la dist
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-nightly
+  #         path: dist
 
-  nightly:
-    name: Nightly
-    if: github.event_name == 'push'
-    needs: [linux-nightly, macos-nightly, windows-nightly]
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.5-nightly
-          path: macOS-3.5-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.6-nightly
-          path: macOS-3.6-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.7-nightly
-          path: macOS-3.7-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: macOS-3.8-nightly
-          path: macOS-3.8-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.5-nightly
-          path: Linux-3.5-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.6-nightly
-          path: Linux-3.6-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.7-nightly
-          path: Linux-3.7-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Linux-3.8-nightly
-          path: Linux-3.8-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.5-nightly
-          path: Windows-3.5-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.6-nightly
-          path: Windows-3.6-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.7-nightly
-          path: Windows-3.7-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.8-nightly
-          path: Windows-3.8-nightly
-      - run: |
-          set -e -x
-          mkdir -p dist
-          cp macOS-3.5-nightly/*.whl dist/
-          cp macOS-3.6-nightly/*.whl dist/
-          cp macOS-3.7-nightly/*.whl dist/
-          cp macOS-3.8-nightly/*.whl dist/
-          cp Linux-3.5-nightly/*.whl dist/
-          cp Linux-3.6-nightly/*.whl dist/
-          cp Linux-3.7-nightly/*.whl dist/
-          cp Linux-3.8-nightly/*.whl dist/
-          cp Windows-3.5-nightly/*.whl dist/
-          cp Windows-3.6-nightly/*.whl dist/
-          cp Windows-3.7-nightly/*.whl dist/
-          cp Windows-3.8-nightly/*.whl dist/
-          ls -la dist/
-          sha256sum dist/*.whl
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.github_tensorflow_io_nightly }}
+  # nightly:
+  #   name: Nightly
+  #   if: github.event_name == 'push'
+  #   needs: [linux-nightly, macos-nightly, windows-nightly]
+  #   runs-on: ubuntu-18.04
+  #   steps:
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.5-nightly
+  #         path: macOS-3.5-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.6-nightly
+  #         path: macOS-3.6-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.7-nightly
+  #         path: macOS-3.7-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: macOS-3.8-nightly
+  #         path: macOS-3.8-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.5-nightly
+  #         path: Linux-3.5-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.6-nightly
+  #         path: Linux-3.6-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.7-nightly
+  #         path: Linux-3.7-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Linux-3.8-nightly
+  #         path: Linux-3.8-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.5-nightly
+  #         path: Windows-3.5-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.6-nightly
+  #         path: Windows-3.6-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.7-nightly
+  #         path: Windows-3.7-nightly
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: Windows-3.8-nightly
+  #         path: Windows-3.8-nightly
+  #     - run: |
+  #         set -e -x
+  #         mkdir -p dist
+  #         cp macOS-3.5-nightly/*.whl dist/
+  #         cp macOS-3.6-nightly/*.whl dist/
+  #         cp macOS-3.7-nightly/*.whl dist/
+  #         cp macOS-3.8-nightly/*.whl dist/
+  #         cp Linux-3.5-nightly/*.whl dist/
+  #         cp Linux-3.6-nightly/*.whl dist/
+  #         cp Linux-3.7-nightly/*.whl dist/
+  #         cp Linux-3.8-nightly/*.whl dist/
+  #         cp Windows-3.5-nightly/*.whl dist/
+  #         cp Windows-3.6-nightly/*.whl dist/
+  #         cp Windows-3.7-nightly/*.whl dist/
+  #         cp Windows-3.8-nightly/*.whl dist/
+  #         ls -la dist/
+  #         sha256sum dist/*.whl
+  #     - uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.github_tensorflow_io_nightly }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,379 +41,379 @@ jobs:
           git status --untracked-files=no --porcelain
           [ -z "$(git status --untracked-files=no --porcelain)" ] || exit 1
 
-  macos:
-    name: macOS
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -x -e
-          echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
-          export PATH=/usr/bin:$PATH
-          echo $PATH
-          echo "Note the following is to fix a bug in Apple's python 3.7.3"
-          sudo sed -i.bak 's/sys.modules.values()/list(sys.modules.values())/g' /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/linecache.py
-          python3 --version
-          python3 -c 'import site; print(site.getsitepackages())'
-          python3 .github/workflows/build.instruction.py --sudo=true README.md "#### macOS" > source.sh
-          bash -x -e source.sh
-          python3 -c 'import tensorflow as tf; print(tf.version.VERSION)'
+  # macos:
+  #   name: macOS
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: |
+  #         set -x -e
+  #         echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
+  #         export PATH=/usr/bin:$PATH
+  #         echo $PATH
+  #         echo "Note the following is to fix a bug in Apple's python 3.7.3"
+  #         sudo sed -i.bak 's/sys.modules.values()/list(sys.modules.values())/g' /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/linecache.py
+  #         python3 --version
+  #         python3 -c 'import site; print(site.getsitepackages())'
+  #         python3 .github/workflows/build.instruction.py --sudo=true README.md "#### macOS" > source.sh
+  #         bash -x -e source.sh
+  #         python3 -c 'import tensorflow as tf; print(tf.version.VERSION)'
 
-  ubuntu-1804:
-    name: Ubuntu 18.04
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
-          cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
-            bash -x -e source.sh
+  # ubuntu-1804:
+  #   name: Ubuntu 18.04
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: |
+  #         set -x -e
+  #         bash -x -e .github/workflows/build.space.sh
+  #         python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
+  #         cat source.sh
+  #         docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
+  #           bash -x -e source.sh
 
-  ubuntu-2004:
-    name: Ubuntu 20.04
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
-          cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:20.04 \
-            bash -x -e source.sh
+  # ubuntu-2004:
+  #   name: Ubuntu 20.04
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: |
+  #         set -x -e
+  #         bash -x -e .github/workflows/build.space.sh
+  #         python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
+  #         cat source.sh
+  #         docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:20.04 \
+  #           bash -x -e source.sh
 
-  centos-8:
-    name: CentOS 8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py README.md "##### CentOS 8" > source.sh
-          cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host centos:8 \
-            bash -x -e source.sh
+  # centos-8:
+  #   name: CentOS 8
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: |
+  #         set -x -e
+  #         bash -x -e .github/workflows/build.space.sh
+  #         python3 .github/workflows/build.instruction.py README.md "##### CentOS 8" > source.sh
+  #         cat source.sh
+  #         docker run -i --rm -v $PWD:/v -w /v --net=host centos:8 \
+  #           bash -x -e source.sh
 
-  centos-7:
-    name: CentOS 7
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py README.md "##### CentOS 7" > source.sh
-          cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host centos:7 \
-            bash -x -e source.sh
+  # centos-7:
+  #   name: CentOS 7
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: |
+  #         set -x -e
+  #         bash -x -e .github/workflows/build.space.sh
+  #         python3 .github/workflows/build.instruction.py README.md "##### CentOS 7" > source.sh
+  #         cat source.sh
+  #         docker run -i --rm -v $PWD:/v -w /v --net=host centos:7 \
+  #           bash -x -e source.sh
 
-  macos-bazel:
-    name: Bazel macOS
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Bazel on macOS
-        run: |
-          set -x -e
-          BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-          BAZEL_VERSION=$(cat .bazelversion)
-          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          sudo python3 -m pip install $(python3 setup.py --package-version)
-          python3 tools/build/configure.py
-          bazel build \
-            ${BAZEL_OPTIMIZATION} \
-            --copt -Wunguarded-availability \
-            --copt -mmacosx-version-min=10.13 \
-            --linkopt -mmacosx-version-min=10.13 \
-            --noshow_progress \
-            --noshow_loading_progress \
-            --verbose_failures \
-            --test_output=errors \
-            //tensorflow_io/...
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
+  # macos-bazel:
+  #   name: Bazel macOS
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Bazel on macOS
+  #       run: |
+  #         set -x -e
+  #         BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
+  #         BAZEL_VERSION=$(cat .bazelversion)
+  #         curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+  #         sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+  #         sudo python3 -m pip install $(python3 setup.py --package-version)
+  #         python3 tools/build/configure.py
+  #         bazel build \
+  #           ${BAZEL_OPTIMIZATION} \
+  #           --copt -Wunguarded-availability \
+  #           --copt -mmacosx-version-min=10.13 \
+  #           --linkopt -mmacosx-version-min=10.13 \
+  #           --noshow_progress \
+  #           --noshow_loading_progress \
+  #           --verbose_failures \
+  #           --test_output=errors \
+  #           //tensorflow_io/...
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
 
-  macos-wheel:
-    name: Wheel ${{ matrix.python }} macOS
-    needs: macos-bazel
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Wheel ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python -m pip install -U wheel setuptools
-          python --version
-          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64
-      - name: Auditwheel ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python -m pip install twine delocate
-          delocate-wheel --version
-          ls dist/*
-          for f in dist/*.whl; do
-            delocate-wheel -w wheelhouse  $f
-          done
-          ls wheelhouse/*
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-wheel
-          path: wheelhouse
+  # macos-wheel:
+  #   name: Wheel ${{ matrix.python }} macOS
+  #   needs: macos-bazel
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       python: ['3.5', '3.6', '3.7', '3.8']
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Wheel ${{ matrix.python }} macOS
+  #       run: |
+  #         set -x -e
+  #         python -m pip install -U wheel setuptools
+  #         python --version
+  #         python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64
+  #     - name: Auditwheel ${{ matrix.python }} macOS
+  #       run: |
+  #         set -x -e
+  #         python -m pip install twine delocate
+  #         delocate-wheel --version
+  #         ls dist/*
+  #         for f in dist/*.whl; do
+  #           delocate-wheel -w wheelhouse  $f
+  #         done
+  #         ls wheelhouse/*
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
+  #         path: wheelhouse
 
-  macos-test:
-    name: Test ${{ matrix.python }} macOS
-    needs: macos-wheel
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python: ['3.6', '3.7']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-wheel
-          path: wheelhouse
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python }}
-      - run: |
-          set -x -e
-          python -m pip install -U wheel setuptools
-          python --version
-      - name: Setup ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          bash -x -e tests/test_kafka/kafka_test.sh
-          bash -x -e tests/test_azure/start_azure.sh
-          bash -x -e tests/test_pubsub/pubsub_test.sh
-      - name: Install ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python --version
-          df -h
-          (cd wheelhouse && python -m pip install *.whl)
-      - name: Test ${{ matrix.python }} macOS
-        run: |
-          set -x -e
-          python --version
-          bash -x -e .github/workflows/build.wheel.sh python
+  # macos-test:
+  #   name: Test ${{ matrix.python }} macOS
+  #   needs: macos-wheel
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       python: ['3.6', '3.7']
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
+  #         path: wheelhouse
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - run: |
+  #         set -x -e
+  #         python -m pip install -U wheel setuptools
+  #         python --version
+  #     - name: Setup ${{ matrix.python }} macOS
+  #       run: |
+  #         set -x -e
+  #         bash -x -e tests/test_kafka/kafka_test.sh
+  #         bash -x -e tests/test_azure/start_azure.sh
+  #         bash -x -e tests/test_pubsub/pubsub_test.sh
+  #     - name: Install ${{ matrix.python }} macOS
+  #       run: |
+  #         set -x -e
+  #         python --version
+  #         df -h
+  #         (cd wheelhouse && python -m pip install *.whl)
+  #     - name: Test ${{ matrix.python }} macOS
+  #       run: |
+  #         set -x -e
+  #         python --version
+  #         bash -x -e .github/workflows/build.wheel.sh python
 
-  linux-bazel:
-    name: Bazel Linux
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Bazel on Linux
-        run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-          BAZEL_VERSION=$(cat .bazelversion)
-          docker run -i --rm -v $PWD:/v -w /v --net=host \
-            -e BAZEL_VERSION=${BAZEL_VERSION} \
-            -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
-            gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.github/workflows/build.bazel.sh
-          sudo chown -R $(id -nu):$(id -ng) .
-          sudo find build/tensorflow_io -name '*runfiles*' | sudo xargs rm -rf
-          sudo cp .bazelrc build/tensorflow_io/
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: build/tensorflow_io
+  # linux-bazel:
+  #   name: Bazel Linux
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Bazel on Linux
+  #       run: |
+  #         set -x -e
+  #         bash -x -e .github/workflows/build.space.sh
+  #         BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
+  #         BAZEL_VERSION=$(cat .bazelversion)
+  #         docker run -i --rm -v $PWD:/v -w /v --net=host \
+  #           -e BAZEL_VERSION=${BAZEL_VERSION} \
+  #           -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
+  #           gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.github/workflows/build.bazel.sh
+  #         sudo chown -R $(id -nu):$(id -ng) .
+  #         sudo find build/tensorflow_io -name '*runfiles*' | sudo xargs rm -rf
+  #         sudo cp .bazelrc build/tensorflow_io/
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: build/tensorflow_io
 
-  linux-wheel:
-    name: Wheel ${{ matrix.python }} Linux
-    needs: linux-bazel
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
-      - name: Wheel ${{ matrix.python }} Linux
-        run: |
-          set -x -e
-          mv bazel-bin/tensorflow_io/.bazelrc .
-          docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel
-      - name: Auditwheel ${{ matrix.python }} Linux
-        run: |
-          set -x -e
-          ls dist/*
-          for f in dist/*.whl; do
-            docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
-          done
-          sudo chown -R $(id -nu):$(id -ng) .
-          ls wheelhouse/*
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-wheel
-          path: wheelhouse
+  # linux-wheel:
+  #   name: Wheel ${{ matrix.python }} Linux
+  #   needs: linux-bazel
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python: ['3.5', '3.6', '3.7', '3.8']
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
+  #     - name: Wheel ${{ matrix.python }} Linux
+  #       run: |
+  #         set -x -e
+  #         mv bazel-bin/tensorflow_io/.bazelrc .
+  #         docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel
+  #     - name: Auditwheel ${{ matrix.python }} Linux
+  #       run: |
+  #         set -x -e
+  #         ls dist/*
+  #         for f in dist/*.whl; do
+  #           docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
+  #         done
+  #         sudo chown -R $(id -nu):$(id -ng) .
+  #         ls wheelhouse/*
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
+  #         path: wheelhouse
 
-  linux-test:
-    name: Test ${{ matrix.python }} Linux
-    needs: linux-wheel
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
-        python: ['3.6', '3.7']
-        exclude:
-          - os: ubuntu-20.04
-            python: '3.6'
-          - os: ubuntu-20.04
-            python: '3.7'
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-wheel
-          path: wheelhouse
-      - name: Setup Linux
-        run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          bash -x -e tests/test_kafka/kafka_test.sh
-          bash -x -e tests/test_kinesis/kinesis_test.sh
-          bash -x -e tests/test_pubsub/pubsub_test.sh
-          bash -x -e tests/test_prometheus/prometheus_test.sh start
-          bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
-          bash -x -e tests/test_azure/start_azure.sh
-          bash -x -e tests/test_sql/sql_test.sh
-      - name: Test Linux
-        run: |
-          set -x -e
-          df -h
-          docker run -i --rm -v $PWD:/v -w /v --net=host \
-            buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
-            bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
+  # linux-test:
+  #   name: Test ${{ matrix.python }} Linux
+  #   needs: linux-wheel
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-18.04, ubuntu-20.04]
+  #       python: ['3.6', '3.7']
+  #       exclude:
+  #         - os: ubuntu-20.04
+  #           python: '3.6'
+  #         - os: ubuntu-20.04
+  #           python: '3.7'
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
+  #         path: wheelhouse
+  #     - name: Setup Linux
+  #       run: |
+  #         set -x -e
+  #         bash -x -e .github/workflows/build.space.sh
+  #         bash -x -e tests/test_kafka/kafka_test.sh
+  #         bash -x -e tests/test_kinesis/kinesis_test.sh
+  #         bash -x -e tests/test_pubsub/pubsub_test.sh
+  #         bash -x -e tests/test_prometheus/prometheus_test.sh start
+  #         bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
+  #         bash -x -e tests/test_azure/start_azure.sh
+  #         bash -x -e tests/test_sql/sql_test.sh
+  #     - name: Test Linux
+  #       run: |
+  #         set -x -e
+  #         df -h
+  #         docker run -i --rm -v $PWD:/v -w /v --net=host \
+  #           buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
+  #           bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
 
-  windows-bazel:
-    name: Bazel Windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.8.5
-      - name: Bazel on Windows
-        env:
-          PYTHON_VERSION: 3.8.5
-          BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
-        shell: cmd
-        run: |
-          @echo on
-          set /P BAZEL_VERSION=< .bazelversion
-          BAZEL_VERSION=$(cat .bazelversion)
-          curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
-          bazel version
-          cp /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python3
-          python3 --version
-          python3 -m pip install wheel setuptools
-          python3 -m pip --version
-          python3 setup.py --package-version | xargs python3 -m pip install
-          python3 tools/build/configure.py
-          cat .bazelrc
-          bazel build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
+  # windows-bazel:
+  #   name: Bazel Windows
+  #   runs-on: windows-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: 3.8.5
+  #     - name: Bazel on Windows
+  #       env:
+  #         PYTHON_VERSION: 3.8.5
+  #         BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
+  #       shell: cmd
+  #       run: |
+  #         @echo on
+  #         set /P BAZEL_VERSION=< .bazelversion
+  #         BAZEL_VERSION=$(cat .bazelversion)
+  #         curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
+  #         bazel version
+  #         cp /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python3
+  #         python3 --version
+  #         python3 -m pip install wheel setuptools
+  #         python3 -m pip --version
+  #         python3 setup.py --package-version | xargs python3 -m pip install
+  #         python3 tools/build/configure.py
+  #         cat .bazelrc
+  #         bazel build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
 
-  windows-wheel:
-    name: Wheel ${{ matrix.python }} Windows
-    needs: windows-bazel
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-bazel-bin
-          path: bazel-bin/tensorflow_io
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Wheel ${{ matrix.python }} Windows
-        shell: cmd
-        run: |
-          @echo on
-          python --version
-          python -m pip install -U wheel setuptools
-          python setup.py --data bazel-bin -q bdist_wheel
-          ls -la dist
-      - uses: actions/upload-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-wheel
-          path: dist
+  # windows-wheel:
+  #   name: Wheel ${{ matrix.python }} Windows
+  #   needs: windows-bazel
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       python: ['3.5', '3.6', '3.7', '3.8']
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-bazel-bin
+  #         path: bazel-bin/tensorflow_io
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - name: Wheel ${{ matrix.python }} Windows
+  #       shell: cmd
+  #       run: |
+  #         @echo on
+  #         python --version
+  #         python -m pip install -U wheel setuptools
+  #         python setup.py --data bazel-bin -q bdist_wheel
+  #         ls -la dist
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
+  #         path: dist
 
-  windows-test:
-    name: Test ${{ matrix.python }} Windows
-    needs: windows-wheel
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python: ['3.6', '3.7']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v1
-        with:
-          name: ${{ runner.os }}-${{ matrix.python }}-wheel
-          path: wheel
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '8.x'
-      - name: Setup ${{ matrix.python }} Windows
-        shell: cmd
-        run: |
-          @echo on
-          bash -x -e tests/test_azure/start_azure.sh
-      - name: Install ${{ matrix.python }} Windows
-        shell: cmd
-        run: |
-          @echo on
-          python --version
-          (cd wheel && ls *.whl | xargs python -m pip install)
-      - name: Test ${{ matrix.python }} Windows
-        shell: cmd
-        run: |
-          @echo on
-          python --version
-          python -m pip install -U pytest-benchmark
-          rm -rf tensorflow_io
-          (cd tests && python -m pytest -s -v test_lmdb_eager.py)
-          (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr or openexr or tiff or avif")
-          (python -m pytest -s -v test_serialization_eager.py)
-          (python -m pytest -s -v test_io_dataset_eager.py -k "numpy or hdf5 or audio or to_file")
-          python -m pip install google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
-          (python -m pytest -s -v test_bigquery_eager.py)
-          (python -m pytest -s -v test_dicom_eager.py)
-          (python -m pytest -s -v test_dicom.py)
+  # windows-test:
+  #   name: Test ${{ matrix.python }} Windows
+  #   needs: windows-wheel
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       python: ['3.6', '3.7']
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
+  #         path: wheel
+  #     - uses: actions/setup-python@v1
+  #       with:
+  #         python-version: ${{ matrix.python }}
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: '8.x'
+  #     - name: Setup ${{ matrix.python }} Windows
+  #       shell: cmd
+  #       run: |
+  #         @echo on
+  #         bash -x -e tests/test_azure/start_azure.sh
+  #     - name: Install ${{ matrix.python }} Windows
+  #       shell: cmd
+  #       run: |
+  #         @echo on
+  #         python --version
+  #         (cd wheel && ls *.whl | xargs python -m pip install)
+  #     - name: Test ${{ matrix.python }} Windows
+  #       shell: cmd
+  #       run: |
+  #         @echo on
+  #         python --version
+  #         python -m pip install -U pytest-benchmark
+  #         rm -rf tensorflow_io
+  #         (cd tests && python -m pytest -s -v test_lmdb_eager.py)
+  #         (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr or openexr or tiff or avif")
+  #         (python -m pytest -s -v test_serialization_eager.py)
+  #         (python -m pytest -s -v test_io_dataset_eager.py -k "numpy or hdf5 or audio or to_file")
+  #         python -m pip install google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
+  #         (python -m pytest -s -v test_bigquery_eager.py)
+  #         (python -m pytest -s -v test_dicom_eager.py)
+  #         (python -m pytest -s -v test_dicom.py)
 
   release:
     name: Release
@@ -493,10 +493,11 @@ jobs:
 
   docker-release:
     name: Docker Release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [lint, linux-test, macos-test, windows-test]
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    # needs: [lint, linux-test, macos-test, windows-test]
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v2
       - run: |
           set -e -x
           docker login --username tfsigio --password ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,460 +41,460 @@ jobs:
           git status --untracked-files=no --porcelain
           [ -z "$(git status --untracked-files=no --porcelain)" ] || exit 1
 
-  # macos:
-  #   name: macOS
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: |
-  #         set -x -e
-  #         echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
-  #         export PATH=/usr/bin:$PATH
-  #         echo $PATH
-  #         echo "Note the following is to fix a bug in Apple's python 3.7.3"
-  #         sudo sed -i.bak 's/sys.modules.values()/list(sys.modules.values())/g' /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/linecache.py
-  #         python3 --version
-  #         python3 -c 'import site; print(site.getsitepackages())'
-  #         python3 .github/workflows/build.instruction.py --sudo=true README.md "#### macOS" > source.sh
-  #         bash -x -e source.sh
-  #         python3 -c 'import tensorflow as tf; print(tf.version.VERSION)'
+  macos:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          set -x -e
+          echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
+          export PATH=/usr/bin:$PATH
+          echo $PATH
+          echo "Note the following is to fix a bug in Apple's python 3.7.3"
+          sudo sed -i.bak 's/sys.modules.values()/list(sys.modules.values())/g' /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/linecache.py
+          python3 --version
+          python3 -c 'import site; print(site.getsitepackages())'
+          python3 .github/workflows/build.instruction.py --sudo=true README.md "#### macOS" > source.sh
+          bash -x -e source.sh
+          python3 -c 'import tensorflow as tf; print(tf.version.VERSION)'
 
-  # ubuntu-1804:
-  #   name: Ubuntu 18.04
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: |
-  #         set -x -e
-  #         bash -x -e .github/workflows/build.space.sh
-  #         python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
-  #         cat source.sh
-  #         docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
-  #           bash -x -e source.sh
+  ubuntu-1804:
+    name: Ubuntu 18.04
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          set -x -e
+          bash -x -e .github/workflows/build.space.sh
+          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
+          cat source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
+            bash -x -e source.sh
 
-  # ubuntu-2004:
-  #   name: Ubuntu 20.04
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: |
-  #         set -x -e
-  #         bash -x -e .github/workflows/build.space.sh
-  #         python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
-  #         cat source.sh
-  #         docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:20.04 \
-  #           bash -x -e source.sh
+  ubuntu-2004:
+    name: Ubuntu 20.04
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          set -x -e
+          bash -x -e .github/workflows/build.space.sh
+          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
+          cat source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:20.04 \
+            bash -x -e source.sh
 
-  # centos-8:
-  #   name: CentOS 8
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: |
-  #         set -x -e
-  #         bash -x -e .github/workflows/build.space.sh
-  #         python3 .github/workflows/build.instruction.py README.md "##### CentOS 8" > source.sh
-  #         cat source.sh
-  #         docker run -i --rm -v $PWD:/v -w /v --net=host centos:8 \
-  #           bash -x -e source.sh
+  centos-8:
+    name: CentOS 8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          set -x -e
+          bash -x -e .github/workflows/build.space.sh
+          python3 .github/workflows/build.instruction.py README.md "##### CentOS 8" > source.sh
+          cat source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host centos:8 \
+            bash -x -e source.sh
 
-  # centos-7:
-  #   name: CentOS 7
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: |
-  #         set -x -e
-  #         bash -x -e .github/workflows/build.space.sh
-  #         python3 .github/workflows/build.instruction.py README.md "##### CentOS 7" > source.sh
-  #         cat source.sh
-  #         docker run -i --rm -v $PWD:/v -w /v --net=host centos:7 \
-  #           bash -x -e source.sh
+  centos-7:
+    name: CentOS 7
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          set -x -e
+          bash -x -e .github/workflows/build.space.sh
+          python3 .github/workflows/build.instruction.py README.md "##### CentOS 7" > source.sh
+          cat source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host centos:7 \
+            bash -x -e source.sh
 
-  # macos-bazel:
-  #   name: Bazel macOS
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Bazel on macOS
-  #       run: |
-  #         set -x -e
-  #         BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-  #         BAZEL_VERSION=$(cat .bazelversion)
-  #         curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-  #         sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-  #         sudo python3 -m pip install $(python3 setup.py --package-version)
-  #         python3 tools/build/configure.py
-  #         bazel build \
-  #           ${BAZEL_OPTIMIZATION} \
-  #           --copt -Wunguarded-availability \
-  #           --copt -mmacosx-version-min=10.13 \
-  #           --linkopt -mmacosx-version-min=10.13 \
-  #           --noshow_progress \
-  #           --noshow_loading_progress \
-  #           --verbose_failures \
-  #           --test_output=errors \
-  #           //tensorflow_io/...
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
+  macos-bazel:
+    name: Bazel macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bazel on macOS
+        run: |
+          set -x -e
+          BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
+          BAZEL_VERSION=$(cat .bazelversion)
+          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+          sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+          sudo python3 -m pip install $(python3 setup.py --package-version)
+          python3 tools/build/configure.py
+          bazel build \
+            ${BAZEL_OPTIMIZATION} \
+            --copt -Wunguarded-availability \
+            --copt -mmacosx-version-min=10.13 \
+            --linkopt -mmacosx-version-min=10.13 \
+            --noshow_progress \
+            --noshow_loading_progress \
+            --verbose_failures \
+            --test_output=errors \
+            //tensorflow_io/...
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
 
-  # macos-wheel:
-  #   name: Wheel ${{ matrix.python }} macOS
-  #   needs: macos-bazel
-  #   runs-on: macos-latest
-  #   strategy:
-  #     matrix:
-  #       python: ['3.5', '3.6', '3.7', '3.8']
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: ${{ matrix.python }}
-  #     - name: Wheel ${{ matrix.python }} macOS
-  #       run: |
-  #         set -x -e
-  #         python -m pip install -U wheel setuptools
-  #         python --version
-  #         python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64
-  #     - name: Auditwheel ${{ matrix.python }} macOS
-  #       run: |
-  #         set -x -e
-  #         python -m pip install twine delocate
-  #         delocate-wheel --version
-  #         ls dist/*
-  #         for f in dist/*.whl; do
-  #           delocate-wheel -w wheelhouse  $f
-  #         done
-  #         ls wheelhouse/*
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
-  #         path: wheelhouse
+  macos-wheel:
+    name: Wheel ${{ matrix.python }} macOS
+    needs: macos-bazel
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', '3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Wheel ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python -m pip install -U wheel setuptools
+          python --version
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64
+      - name: Auditwheel ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python -m pip install twine delocate
+          delocate-wheel --version
+          ls dist/*
+          for f in dist/*.whl; do
+            delocate-wheel -w wheelhouse  $f
+          done
+          ls wheelhouse/*
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-wheel
+          path: wheelhouse
 
-  # macos-test:
-  #   name: Test ${{ matrix.python }} macOS
-  #   needs: macos-wheel
-  #   runs-on: macos-latest
-  #   strategy:
-  #     matrix:
-  #       python: ['3.6', '3.7']
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
-  #         path: wheelhouse
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: ${{ matrix.python }}
-  #     - run: |
-  #         set -x -e
-  #         python -m pip install -U wheel setuptools
-  #         python --version
-  #     - name: Setup ${{ matrix.python }} macOS
-  #       run: |
-  #         set -x -e
-  #         bash -x -e tests/test_kafka/kafka_test.sh
-  #         bash -x -e tests/test_azure/start_azure.sh
-  #         bash -x -e tests/test_pubsub/pubsub_test.sh
-  #     - name: Install ${{ matrix.python }} macOS
-  #       run: |
-  #         set -x -e
-  #         python --version
-  #         df -h
-  #         (cd wheelhouse && python -m pip install *.whl)
-  #     - name: Test ${{ matrix.python }} macOS
-  #       run: |
-  #         set -x -e
-  #         python --version
-  #         bash -x -e .github/workflows/build.wheel.sh python
+  macos-test:
+    name: Test ${{ matrix.python }} macOS
+    needs: macos-wheel
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python: ['3.6', '3.7']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-wheel
+          path: wheelhouse
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - run: |
+          set -x -e
+          python -m pip install -U wheel setuptools
+          python --version
+      - name: Setup ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          bash -x -e tests/test_kafka/kafka_test.sh
+          bash -x -e tests/test_azure/start_azure.sh
+          bash -x -e tests/test_pubsub/pubsub_test.sh
+      - name: Install ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python --version
+          df -h
+          (cd wheelhouse && python -m pip install *.whl)
+      - name: Test ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python --version
+          bash -x -e .github/workflows/build.wheel.sh python
 
-  # linux-bazel:
-  #   name: Bazel Linux
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Bazel on Linux
-  #       run: |
-  #         set -x -e
-  #         bash -x -e .github/workflows/build.space.sh
-  #         BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-  #         BAZEL_VERSION=$(cat .bazelversion)
-  #         docker run -i --rm -v $PWD:/v -w /v --net=host \
-  #           -e BAZEL_VERSION=${BAZEL_VERSION} \
-  #           -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
-  #           gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.github/workflows/build.bazel.sh
-  #         sudo chown -R $(id -nu):$(id -ng) .
-  #         sudo find build/tensorflow_io -name '*runfiles*' | sudo xargs rm -rf
-  #         sudo cp .bazelrc build/tensorflow_io/
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: build/tensorflow_io
+  linux-bazel:
+    name: Bazel Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bazel on Linux
+        run: |
+          set -x -e
+          bash -x -e .github/workflows/build.space.sh
+          BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
+          BAZEL_VERSION=$(cat .bazelversion)
+          docker run -i --rm -v $PWD:/v -w /v --net=host \
+            -e BAZEL_VERSION=${BAZEL_VERSION} \
+            -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
+            gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.github/workflows/build.bazel.sh
+          sudo chown -R $(id -nu):$(id -ng) .
+          sudo find build/tensorflow_io -name '*runfiles*' | sudo xargs rm -rf
+          sudo cp .bazelrc build/tensorflow_io/
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: build/tensorflow_io
 
-  # linux-wheel:
-  #   name: Wheel ${{ matrix.python }} Linux
-  #   needs: linux-bazel
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python: ['3.5', '3.6', '3.7', '3.8']
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
-  #     - name: Wheel ${{ matrix.python }} Linux
-  #       run: |
-  #         set -x -e
-  #         mv bazel-bin/tensorflow_io/.bazelrc .
-  #         docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel
-  #     - name: Auditwheel ${{ matrix.python }} Linux
-  #       run: |
-  #         set -x -e
-  #         ls dist/*
-  #         for f in dist/*.whl; do
-  #           docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
-  #         done
-  #         sudo chown -R $(id -nu):$(id -ng) .
-  #         ls wheelhouse/*
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
-  #         path: wheelhouse
+  linux-wheel:
+    name: Wheel ${{ matrix.python }} Linux
+    needs: linux-bazel
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', '3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - name: Wheel ${{ matrix.python }} Linux
+        run: |
+          set -x -e
+          mv bazel-bin/tensorflow_io/.bazelrc .
+          docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel
+      - name: Auditwheel ${{ matrix.python }} Linux
+        run: |
+          set -x -e
+          ls dist/*
+          for f in dist/*.whl; do
+            docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
+          done
+          sudo chown -R $(id -nu):$(id -ng) .
+          ls wheelhouse/*
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-wheel
+          path: wheelhouse
 
-  # linux-test:
-  #   name: Test ${{ matrix.python }} Linux
-  #   needs: linux-wheel
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-18.04, ubuntu-20.04]
-  #       python: ['3.6', '3.7']
-  #       exclude:
-  #         - os: ubuntu-20.04
-  #           python: '3.6'
-  #         - os: ubuntu-20.04
-  #           python: '3.7'
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
-  #         path: wheelhouse
-  #     - name: Setup Linux
-  #       run: |
-  #         set -x -e
-  #         bash -x -e .github/workflows/build.space.sh
-  #         bash -x -e tests/test_kafka/kafka_test.sh
-  #         bash -x -e tests/test_kinesis/kinesis_test.sh
-  #         bash -x -e tests/test_pubsub/pubsub_test.sh
-  #         bash -x -e tests/test_prometheus/prometheus_test.sh start
-  #         bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
-  #         bash -x -e tests/test_azure/start_azure.sh
-  #         bash -x -e tests/test_sql/sql_test.sh
-  #     - name: Test Linux
-  #       run: |
-  #         set -x -e
-  #         df -h
-  #         docker run -i --rm -v $PWD:/v -w /v --net=host \
-  #           buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
-  #           bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
+  linux-test:
+    name: Test ${{ matrix.python }} Linux
+    needs: linux-wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        python: ['3.6', '3.7']
+        exclude:
+          - os: ubuntu-20.04
+            python: '3.6'
+          - os: ubuntu-20.04
+            python: '3.7'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-wheel
+          path: wheelhouse
+      - name: Setup Linux
+        run: |
+          set -x -e
+          bash -x -e .github/workflows/build.space.sh
+          bash -x -e tests/test_kafka/kafka_test.sh
+          bash -x -e tests/test_kinesis/kinesis_test.sh
+          bash -x -e tests/test_pubsub/pubsub_test.sh
+          bash -x -e tests/test_prometheus/prometheus_test.sh start
+          bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
+          bash -x -e tests/test_azure/start_azure.sh
+          bash -x -e tests/test_sql/sql_test.sh
+      - name: Test Linux
+        run: |
+          set -x -e
+          df -h
+          docker run -i --rm -v $PWD:/v -w /v --net=host \
+            buildpack-deps:$(echo ${{ matrix.os }} | awk -F- '{print $2}') \
+            bash -x -e .github/workflows/build.wheel.sh python${{ matrix.python }}
 
-  # windows-bazel:
-  #   name: Bazel Windows
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: 3.8.5
-  #     - name: Bazel on Windows
-  #       env:
-  #         PYTHON_VERSION: 3.8.5
-  #         BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
-  #       shell: cmd
-  #       run: |
-  #         @echo on
-  #         set /P BAZEL_VERSION=< .bazelversion
-  #         BAZEL_VERSION=$(cat .bazelversion)
-  #         curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
-  #         bazel version
-  #         cp /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python3
-  #         python3 --version
-  #         python3 -m pip install wheel setuptools
-  #         python3 -m pip --version
-  #         python3 setup.py --package-version | xargs python3 -m pip install
-  #         python3 tools/build/configure.py
-  #         cat .bazelrc
-  #         bazel build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
+  windows-bazel:
+    name: Bazel Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8.5
+      - name: Bazel on Windows
+        env:
+          PYTHON_VERSION: 3.8.5
+          BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
+        shell: cmd
+        run: |
+          @echo on
+          set /P BAZEL_VERSION=< .bazelversion
+          BAZEL_VERSION=$(cat .bazelversion)
+          curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
+          bazel version
+          cp /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python /c/hostedtoolcache/windows/Python/%PYTHON_VERSION%/x64/python3
+          python3 --version
+          python3 -m pip install wheel setuptools
+          python3 -m pip --version
+          python3 setup.py --package-version | xargs python3 -m pip install
+          python3 tools/build/configure.py
+          cat .bazelrc
+          bazel build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
 
-  # windows-wheel:
-  #   name: Wheel ${{ matrix.python }} Windows
-  #   needs: windows-bazel
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       python: ['3.5', '3.6', '3.7', '3.8']
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: ${{ matrix.python }}
-  #     - name: Wheel ${{ matrix.python }} Windows
-  #       shell: cmd
-  #       run: |
-  #         @echo on
-  #         python --version
-  #         python -m pip install -U wheel setuptools
-  #         python setup.py --data bazel-bin -q bdist_wheel
-  #         ls -la dist
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
-  #         path: dist
+  windows-wheel:
+    name: Wheel ${{ matrix.python }} Windows
+    needs: windows-bazel
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', '3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Wheel ${{ matrix.python }} Windows
+        shell: cmd
+        run: |
+          @echo on
+          python --version
+          python -m pip install -U wheel setuptools
+          python setup.py --data bazel-bin -q bdist_wheel
+          ls -la dist
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-wheel
+          path: dist
 
-  # windows-test:
-  #   name: Test ${{ matrix.python }} Windows
-  #   needs: windows-wheel
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       python: ['3.6', '3.7']
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-wheel
-  #         path: wheel
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: ${{ matrix.python }}
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: '8.x'
-  #     - name: Setup ${{ matrix.python }} Windows
-  #       shell: cmd
-  #       run: |
-  #         @echo on
-  #         bash -x -e tests/test_azure/start_azure.sh
-  #     - name: Install ${{ matrix.python }} Windows
-  #       shell: cmd
-  #       run: |
-  #         @echo on
-  #         python --version
-  #         (cd wheel && ls *.whl | xargs python -m pip install)
-  #     - name: Test ${{ matrix.python }} Windows
-  #       shell: cmd
-  #       run: |
-  #         @echo on
-  #         python --version
-  #         python -m pip install -U pytest-benchmark
-  #         rm -rf tensorflow_io
-  #         (cd tests && python -m pytest -s -v test_lmdb_eager.py)
-  #         (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr or openexr or tiff or avif")
-  #         (python -m pytest -s -v test_serialization_eager.py)
-  #         (python -m pytest -s -v test_io_dataset_eager.py -k "numpy or hdf5 or audio or to_file")
-  #         python -m pip install google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
-  #         (python -m pytest -s -v test_bigquery_eager.py)
-  #         (python -m pytest -s -v test_dicom_eager.py)
-  #         (python -m pytest -s -v test_dicom.py)
+  windows-test:
+    name: Test ${{ matrix.python }} Windows
+    needs: windows-wheel
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python: ['3.6', '3.7']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-wheel
+          path: wheel
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '8.x'
+      - name: Setup ${{ matrix.python }} Windows
+        shell: cmd
+        run: |
+          @echo on
+          bash -x -e tests/test_azure/start_azure.sh
+      - name: Install ${{ matrix.python }} Windows
+        shell: cmd
+        run: |
+          @echo on
+          python --version
+          (cd wheel && ls *.whl | xargs python -m pip install)
+      - name: Test ${{ matrix.python }} Windows
+        shell: cmd
+        run: |
+          @echo on
+          python --version
+          python -m pip install -U pytest-benchmark
+          rm -rf tensorflow_io
+          (cd tests && python -m pytest -s -v test_lmdb_eager.py)
+          (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr or openexr or tiff or avif")
+          (python -m pytest -s -v test_serialization_eager.py)
+          (python -m pytest -s -v test_io_dataset_eager.py -k "numpy or hdf5 or audio or to_file")
+          python -m pip install google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
+          (python -m pytest -s -v test_bigquery_eager.py)
+          (python -m pytest -s -v test_dicom_eager.py)
+          (python -m pytest -s -v test_dicom.py)
 
-  # release:
-  #   name: Release
-  #   if: github.event_name == 'push'
-  #   needs: [lint, linux-test, macos-test, windows-test]
-  #   runs-on: ubuntu-18.04
-  #   steps:
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.5-wheel
-  #         path: macOS-3.5-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.6-wheel
-  #         path: macOS-3.6-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.7-wheel
-  #         path: macOS-3.7-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.8-wheel
-  #         path: macOS-3.8-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.5-wheel
-  #         path: Linux-3.5-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.6-wheel
-  #         path: Linux-3.6-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.7-wheel
-  #         path: Linux-3.7-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.8-wheel
-  #         path: Linux-3.8-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.5-wheel
-  #         path: Windows-3.5-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.6-wheel
-  #         path: Windows-3.6-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.7-wheel
-  #         path: Windows-3.7-wheel
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.8-wheel
-  #         path: Windows-3.8-wheel
-  #     - run: |
-  #         set -e -x
-  #         mkdir -p wheelhouse
-  #         cp macOS-3.5-wheel/*.whl wheelhouse/
-  #         cp macOS-3.6-wheel/*.whl wheelhouse/
-  #         cp macOS-3.7-wheel/*.whl wheelhouse/
-  #         cp macOS-3.8-wheel/*.whl wheelhouse/
-  #         cp Linux-3.5-wheel/*.whl wheelhouse/
-  #         cp Linux-3.6-wheel/*.whl wheelhouse/
-  #         cp Linux-3.7-wheel/*.whl wheelhouse/
-  #         cp Linux-3.8-wheel/*.whl wheelhouse/
-  #         cp Windows-3.5-wheel/*.whl wheelhouse/
-  #         cp Windows-3.6-wheel/*.whl wheelhouse/
-  #         cp Windows-3.7-wheel/*.whl wheelhouse/
-  #         cp Windows-3.8-wheel/*.whl wheelhouse/
-  #         ls -la wheelhouse/
-  #         sha256sum wheelhouse/*.whl
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: tensorflow-io-release
-  #         path: wheelhouse
+  release:
+    name: Release
+    if: github.event_name == 'push'
+    needs: [lint, linux-test, macos-test, windows-test]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.5-wheel
+          path: macOS-3.5-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.6-wheel
+          path: macOS-3.6-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.7-wheel
+          path: macOS-3.7-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.8-wheel
+          path: macOS-3.8-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.5-wheel
+          path: Linux-3.5-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.6-wheel
+          path: Linux-3.6-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.7-wheel
+          path: Linux-3.7-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.8-wheel
+          path: Linux-3.8-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.5-wheel
+          path: Windows-3.5-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.6-wheel
+          path: Windows-3.6-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.7-wheel
+          path: Windows-3.7-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.8-wheel
+          path: Windows-3.8-wheel
+      - run: |
+          set -e -x
+          mkdir -p wheelhouse
+          cp macOS-3.5-wheel/*.whl wheelhouse/
+          cp macOS-3.6-wheel/*.whl wheelhouse/
+          cp macOS-3.7-wheel/*.whl wheelhouse/
+          cp macOS-3.8-wheel/*.whl wheelhouse/
+          cp Linux-3.5-wheel/*.whl wheelhouse/
+          cp Linux-3.6-wheel/*.whl wheelhouse/
+          cp Linux-3.7-wheel/*.whl wheelhouse/
+          cp Linux-3.8-wheel/*.whl wheelhouse/
+          cp Windows-3.5-wheel/*.whl wheelhouse/
+          cp Windows-3.6-wheel/*.whl wheelhouse/
+          cp Windows-3.7-wheel/*.whl wheelhouse/
+          cp Windows-3.8-wheel/*.whl wheelhouse/
+          ls -la wheelhouse/
+          sha256sum wheelhouse/*.whl
+      - uses: actions/upload-artifact@v1
+        with:
+          name: tensorflow-io-release
+          path: wheelhouse
 
   docker-release:
     name: Docker Release
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    # needs: [lint, linux-test, macos-test, windows-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [lint, linux-test, macos-test, windows-test]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -520,204 +520,204 @@ jobs:
           name: BUILD_NUMBER
           path: BUILD_NUMBER
 
-  # macos-nightly:
-  #   name: Nightly ${{ matrix.python }} macOS
-  #   if: github.event_name == 'push'
-  #   needs: [build-number, release]
-  #   runs-on: macos-latest
-  #   strategy:
-  #     matrix:
-  #       python: ['3.5', '3.6', '3.7', '3.8']
-  #   steps:
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: BUILD_NUMBER
-  #     - uses: einaregilsson/build-number@v2
-  #     - run: echo "Build number is $BUILD_NUMBER"
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: ${{ matrix.python }}
-  #     - name: Wheel ${{ matrix.python }} macOS
-  #       run: |
-  #         set -x -e
-  #         python -m pip install -U wheel setuptools
-  #         python --version
-  #         python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64 --nightly $BUILD_NUMBER
-  #     - name: Auditwheel ${{ matrix.python }} macOS
-  #       run: |
-  #         set -x -e
-  #         python -m pip install twine delocate
-  #         delocate-wheel --version
-  #         ls dist/*
-  #         for f in dist/*.whl; do
-  #           delocate-wheel -w wheelhouse  $f
-  #         done
-  #         ls wheelhouse/*
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-nightly
-  #         path: wheelhouse
+  macos-nightly:
+    name: Nightly ${{ matrix.python }} macOS
+    if: github.event_name == 'push'
+    needs: [build-number, release]
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', '3.8']
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: BUILD_NUMBER
+      - uses: einaregilsson/build-number@v2
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Wheel ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python -m pip install -U wheel setuptools
+          python --version
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64 --nightly $BUILD_NUMBER
+      - name: Auditwheel ${{ matrix.python }} macOS
+        run: |
+          set -x -e
+          python -m pip install twine delocate
+          delocate-wheel --version
+          ls dist/*
+          for f in dist/*.whl; do
+            delocate-wheel -w wheelhouse  $f
+          done
+          ls wheelhouse/*
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-nightly
+          path: wheelhouse
 
-  # linux-nightly:
-  #   name: Nightly ${{ matrix.python }} Linux
-  #   if: github.event_name == 'push'
-  #   needs: [build-number, release]
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-16.04, ubuntu-18.04]
-  #       python: ['3.5', '3.6', '3.7', '3.8']
-  #       exclude:
-  #         - os: ubuntu-16.04
-  #           python: '3.6'
-  #         - os: ubuntu-16.04
-  #           python: '3.7'
-  #         - os: ubuntu-16.04
-  #           python: '3.8'
-  #         - os: ubuntu-18.04
-  #           python: '3.5'
-  #   steps:
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: BUILD_NUMBER
-  #     - uses: einaregilsson/build-number@v2
-  #     - run: echo "Build number is $BUILD_NUMBER"
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
-  #     - name: Wheel ${{ matrix.python }} Linux
-  #       run: |
-  #         set -x -e
-  #         mv bazel-bin/tensorflow_io/.bazelrc .
-  #         docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
-  #     - name: Auditwheel ${{ matrix.python }} Linux
-  #       run: |
-  #         set -x -e
-  #         ls dist/*
-  #         for f in dist/*.whl; do
-  #           docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
-  #         done
-  #         sudo chown -R $(id -nu):$(id -ng) .
-  #         ls wheelhouse/*
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-nightly
-  #         path: wheelhouse
+  linux-nightly:
+    name: Nightly ${{ matrix.python }} Linux
+    if: github.event_name == 'push'
+    needs: [build-number, release]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04]
+        python: ['3.5', '3.6', '3.7', '3.8']
+        exclude:
+          - os: ubuntu-16.04
+            python: '3.6'
+          - os: ubuntu-16.04
+            python: '3.7'
+          - os: ubuntu-16.04
+            python: '3.8'
+          - os: ubuntu-18.04
+            python: '3.5'
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: BUILD_NUMBER
+      - uses: einaregilsson/build-number@v2
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - name: Wheel ${{ matrix.python }} Linux
+        run: |
+          set -x -e
+          mv bazel-bin/tensorflow_io/.bazelrc .
+          docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
+      - name: Auditwheel ${{ matrix.python }} Linux
+        run: |
+          set -x -e
+          ls dist/*
+          for f in dist/*.whl; do
+            docker run -i --rm -v $PWD:/v -w /v --net=host quay.io/pypa/manylinux2010_x86_64 bash -x -e /v/tools/build/auditwheel repair --plat manylinux2010_x86_64 $f
+          done
+          sudo chown -R $(id -nu):$(id -ng) .
+          ls wheelhouse/*
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-nightly
+          path: wheelhouse
 
-  # windows-nightly:
-  #   name: Nightly ${{ matrix.python }} Windows
-  #   if: github.event_name == 'push'
-  #   needs: [build-number, release]
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       python: ['3.5', '3.6', '3.7', 3.8]
-  #   steps:
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: BUILD_NUMBER
-  #     - uses: einaregilsson/build-number@v2
-  #     - run: echo "Build number is $BUILD_NUMBER"
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-bazel-bin
-  #         path: bazel-bin/tensorflow_io
-  #     - uses: actions/setup-python@v1
-  #       with:
-  #         python-version: ${{ matrix.python }}
-  #     - name: Wheel ${{ matrix.python }} Windows
-  #       shell: cmd
-  #       run: |
-  #         @echo on
-  #         python --version
-  #         python -m pip install -U wheel setuptools
-  #         python setup.py --data bazel-bin -q bdist_wheel --nightly %BUILD_NUMBER%
-  #         ls -la dist
-  #     - uses: actions/upload-artifact@v1
-  #       with:
-  #         name: ${{ runner.os }}-${{ matrix.python }}-nightly
-  #         path: dist
+  windows-nightly:
+    name: Nightly ${{ matrix.python }} Windows
+    if: github.event_name == 'push'
+    needs: [build-number, release]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python: ['3.5', '3.6', '3.7', 3.8]
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: BUILD_NUMBER
+      - uses: einaregilsson/build-number@v2
+      - run: echo "Build number is $BUILD_NUMBER"
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: ${{ runner.os }}-bazel-bin
+          path: bazel-bin/tensorflow_io
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Wheel ${{ matrix.python }} Windows
+        shell: cmd
+        run: |
+          @echo on
+          python --version
+          python -m pip install -U wheel setuptools
+          python setup.py --data bazel-bin -q bdist_wheel --nightly %BUILD_NUMBER%
+          ls -la dist
+      - uses: actions/upload-artifact@v1
+        with:
+          name: ${{ runner.os }}-${{ matrix.python }}-nightly
+          path: dist
 
-  # nightly:
-  #   name: Nightly
-  #   if: github.event_name == 'push'
-  #   needs: [linux-nightly, macos-nightly, windows-nightly]
-  #   runs-on: ubuntu-18.04
-  #   steps:
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.5-nightly
-  #         path: macOS-3.5-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.6-nightly
-  #         path: macOS-3.6-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.7-nightly
-  #         path: macOS-3.7-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: macOS-3.8-nightly
-  #         path: macOS-3.8-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.5-nightly
-  #         path: Linux-3.5-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.6-nightly
-  #         path: Linux-3.6-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.7-nightly
-  #         path: Linux-3.7-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Linux-3.8-nightly
-  #         path: Linux-3.8-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.5-nightly
-  #         path: Windows-3.5-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.6-nightly
-  #         path: Windows-3.6-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.7-nightly
-  #         path: Windows-3.7-nightly
-  #     - uses: actions/download-artifact@v1
-  #       with:
-  #         name: Windows-3.8-nightly
-  #         path: Windows-3.8-nightly
-  #     - run: |
-  #         set -e -x
-  #         mkdir -p dist
-  #         cp macOS-3.5-nightly/*.whl dist/
-  #         cp macOS-3.6-nightly/*.whl dist/
-  #         cp macOS-3.7-nightly/*.whl dist/
-  #         cp macOS-3.8-nightly/*.whl dist/
-  #         cp Linux-3.5-nightly/*.whl dist/
-  #         cp Linux-3.6-nightly/*.whl dist/
-  #         cp Linux-3.7-nightly/*.whl dist/
-  #         cp Linux-3.8-nightly/*.whl dist/
-  #         cp Windows-3.5-nightly/*.whl dist/
-  #         cp Windows-3.6-nightly/*.whl dist/
-  #         cp Windows-3.7-nightly/*.whl dist/
-  #         cp Windows-3.8-nightly/*.whl dist/
-  #         ls -la dist/
-  #         sha256sum dist/*.whl
-  #     - uses: pypa/gh-action-pypi-publish@master
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.github_tensorflow_io_nightly }}
+  nightly:
+    name: Nightly
+    if: github.event_name == 'push'
+    needs: [linux-nightly, macos-nightly, windows-nightly]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.5-nightly
+          path: macOS-3.5-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.6-nightly
+          path: macOS-3.6-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.7-nightly
+          path: macOS-3.7-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: macOS-3.8-nightly
+          path: macOS-3.8-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.5-nightly
+          path: Linux-3.5-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.6-nightly
+          path: Linux-3.6-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.7-nightly
+          path: Linux-3.7-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Linux-3.8-nightly
+          path: Linux-3.8-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.5-nightly
+          path: Windows-3.5-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.6-nightly
+          path: Windows-3.6-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.7-nightly
+          path: Windows-3.7-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.8-nightly
+          path: Windows-3.8-nightly
+      - run: |
+          set -e -x
+          mkdir -p dist
+          cp macOS-3.5-nightly/*.whl dist/
+          cp macOS-3.6-nightly/*.whl dist/
+          cp macOS-3.7-nightly/*.whl dist/
+          cp macOS-3.8-nightly/*.whl dist/
+          cp Linux-3.5-nightly/*.whl dist/
+          cp Linux-3.6-nightly/*.whl dist/
+          cp Linux-3.7-nightly/*.whl dist/
+          cp Linux-3.8-nightly/*.whl dist/
+          cp Windows-3.5-nightly/*.whl dist/
+          cp Windows-3.6-nightly/*.whl dist/
+          cp Windows-3.7-nightly/*.whl dist/
+          cp Windows-3.8-nightly/*.whl dist/
+          ls -la dist/
+          sha256sum dist/*.whl
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.github_tensorflow_io_nightly }}


### PR DESCRIPTION
The current github action job `docker-release` is unable to find the script for building and testing the docker image. This PR fixes that issue.