### PR TITLE
Update namespace to allow the source code build on both tf-nightly and tensorflow 2.3.0

### DIFF
--- a/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset.cc
+++ b/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow_io/core/kernels/ignite/dataset/ignite_dataset_iterator.h"
 
 namespace tensorflow {
+namespace data {
 
 IgniteDataset::IgniteDataset(OpKernelContext* ctx, string cache_name,
                              string host, int32 port, bool local, int32 part,
@@ -78,4 +79,5 @@ Status IgniteDataset::AsGraphDefInternal(SerializationContext* ctx,
       "IgniteDataset does not support 'AsGraphDefInternal'");
 }
 
+}  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset.h
+++ b/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/core/framework/dataset.h"
 
 namespace tensorflow {
+namespace data {
 
 class IgniteDataset : public DatasetBase {
  public:
@@ -59,6 +60,7 @@ class IgniteDataset : public DatasetBase {
   const std::vector<PartialTensorShape> shapes_;
 };
 
+}  // namespace data
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CONTRIB_IGNITE_KERNELS_DATASET_IGNITE_DATASET_H_

--- a/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset_iterator.cc
+++ b/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset_iterator.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow_io/core/kernels/ignite/client/ignite_ssl_wrapper.h"
 
 namespace tensorflow {
+namespace data {
 
 IgniteDatasetIterator::IgniteDatasetIterator(
     const Params& params, string host, int32 port, string cache_name,
@@ -420,4 +421,5 @@ int32_t IgniteDatasetIterator::JavaHashCode(string str) const {
   return h;
 }
 
+}  // namespace data
 }  // namespace tensorflow

--- a/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset_iterator.h
+++ b/tensorflow_io/core/kernels/ignite/dataset/ignite_dataset_iterator.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow_io/core/kernels/ignite/dataset/ignite_dataset.h"
 
 namespace tensorflow {
+namespace data {
 
 class IgniteDatasetIterator : public DatasetIterator<IgniteDataset> {
  public:
@@ -95,6 +96,7 @@ constexpr int32_t kCloseConnectionReqLength = 18;
 constexpr int32_t kHandshakeReqDefaultLength = 8;
 constexpr int32_t kMinResLength = 12;
 
+}  // namespace data
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CONTRIB_IGNITE_KERNELS_DATASET_IGNITE_DATASET_ITERATOR_H_

--- a/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tensorflow_io/core/kernels/sequence_ops.h"
 
 namespace tensorflow {
+namespace data {
 
 class KafkaDatasetOp : public DatasetOpKernel {
  public:
@@ -750,8 +751,6 @@ class KafkaOutputSequenceOp : public OutputSequenceOp<KafkaOutputSequence> {
                    resource_->Initialize(topic_str, partition, metadata));
   }
 };
-
-namespace data {
 
 class KafkaEventCb : public RdKafka::EventCb {
  public:


### PR DESCRIPTION
There were some recent changes in TF code base. As such some adjustment in tensorflow-io
is needed in order to allow building against tf-nightly (tf master) and tensorflow 2.3.0

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>