### PR TITLE
Enable parsing arrays of arbitrary dimensions from json files

### DIFF
--- a/tensorflow_io/core/kernels/serialization_kernels.cc
+++ b/tensorflow_io/core/kernels/serialization_kernels.cc
@@ -33,7 +33,6 @@ class DecodeJSONOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    // TODO: support batch (1-D) input
     const Tensor* input_tensor;
     OP_REQUIRES_OK(context, context->input("input", &input_tensor));
     const string& input = input_tensor->scalar<tstring>()();
@@ -58,134 +57,35 @@ class DecodeJSONOp : public OpKernel {
                                           names_tensor->flat<tstring>()(i)));
 
       Tensor* value_tensor;
-      if (entry->IsArray()) {
-        if (entry->Size() > 0 && (*entry)[0].IsArray()) {
-          int64 dim0 = entry->Size();
-          int64 dim1 = 0;
-          for (int64 j = 0; j < entry->Size(); j++) {
-            if (dim1 < (*entry)[j].Size()) {
-              dim1 = (*entry)[j].Size();
-            }
-          }
-          OP_REQUIRES_OK(context,
-                         context->allocate_output(i, TensorShape({dim0, dim1}),
-                                                  &value_tensor));
-
-          switch (value_tensor->dtype()) {
-            case DT_INT32:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                for (int64 k = 0; k < (*entry)[j].Size(); k++) {
-                  value_tensor->tensor<int32, 2>()(j, k) =
-                      (*entry)[j][k].GetInt();
-                }
-              }
-              break;
-            case DT_INT64:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                for (int64 k = 0; k < (*entry)[j].Size(); k++) {
-                  value_tensor->tensor<int64, 2>()(j, k) =
-                      (*entry)[j][k].GetInt64();
-                }
-              }
-              break;
-            case DT_FLOAT:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                for (int64 k = 0; k < (*entry)[j].Size(); k++) {
-                  value_tensor->tensor<float, 2>()(j, k) =
-                      (*entry)[j][k].GetDouble();
-                }
-              }
-              break;
-            case DT_DOUBLE:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                for (int64 k = 0; k < (*entry)[j].Size(); k++) {
-                  value_tensor->tensor<double, 2>()(j, k) =
-                      (*entry)[j][k].GetDouble();
-                }
-              }
-              break;
-            case DT_STRING:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                for (int64 k = 0; k < (*entry)[j].Size(); k++) {
-                  value_tensor->tensor<tstring, 2>()(j, k) =
-                      (*entry)[j][k].GetString();
-                }
-              }
-              break;
-            default:
-              OP_REQUIRES(context, false,
-                          errors::InvalidArgument(
-                              "data type not supported: ",
-                              DataTypeString(value_tensor->dtype())));
-              break;
-          }
-
-        } else {
-          OP_REQUIRES_OK(
-              context, context->allocate_output(i, TensorShape({entry->Size()}),
-                                                &value_tensor));
-
-          switch (value_tensor->dtype()) {
-            case DT_INT32:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                value_tensor->flat<int32>()(j) = (*entry)[j].GetInt();
-              }
-              break;
-            case DT_INT64:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                value_tensor->flat<int64>()(j) = (*entry)[j].GetInt64();
-              }
-              break;
-            case DT_FLOAT:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                value_tensor->flat<float>()(j) = (*entry)[j].GetDouble();
-              }
-              break;
-            case DT_DOUBLE:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                value_tensor->flat<double>()(j) = (*entry)[j].GetDouble();
-              }
-              break;
-            case DT_STRING:
-              for (int64 j = 0; j < entry->Size(); j++) {
-                value_tensor->flat<tstring>()(j) = (*entry)[j].GetString();
-              }
-              break;
-            default:
-              OP_REQUIRES(context, false,
-                          errors::InvalidArgument(
-                              "data type not supported: ",
-                              DataTypeString(value_tensor->dtype())));
-              break;
-          }
-        }
-
-      } else {
-        OP_REQUIRES_OK(context, context->allocate_output(i, TensorShape({1}),
-                                                         &value_tensor));
-        switch (value_tensor->dtype()) {
-          case DT_INT32:
-            value_tensor->flat<int32>()(0) = entry->GetInt();
-            break;
-          case DT_INT64:
-            value_tensor->flat<int64>()(0) = entry->GetInt64();
-            break;
-          case DT_FLOAT:
-            value_tensor->flat<float>()(0) = entry->GetDouble();
-            break;
-          case DT_DOUBLE:
-            value_tensor->flat<double>()(0) = entry->GetDouble();
-            break;
-          case DT_STRING:
-            value_tensor->flat<tstring>()(0) = entry->GetString();
-            break;
-          default:
-            OP_REQUIRES(
-                context, false,
-                errors::InvalidArgument("data type not supported: ",
-                                        DataTypeString(value_tensor->dtype())));
-            break;
-        }
+      std::vector <int64> tensor_shape_vector;
+      getTensorShape(entry, tensor_shape_vector);
+      OP_REQUIRES_OK(context,
+                     context->allocate_output(i, TensorShape(tensor_shape_vector),
+                                              &value_tensor));
+      int64 flat_index;
+      flat_index = 0;
+      switch (value_tensor->dtype()) {
+        case DT_INT32:
+          writeToTensor(entry, value_tensor, flat_index, writeInt32);
+          break;
+        case DT_INT64:
+          writeToTensor(entry, value_tensor, flat_index, writeInt64);
+          break;
+        case DT_FLOAT:
+          writeToTensor(entry, value_tensor, flat_index, writeFloat);
+          break;
+        case DT_DOUBLE:
+          writeToTensor(entry, value_tensor, flat_index, writeDouble);
+          break;
+        case DT_STRING:
+          writeToTensor(entry, value_tensor, flat_index, writeString);
+          break;
+        default:
+          OP_REQUIRES(context, false,
+                      errors::InvalidArgument(
+                          "data type not supported: ",
+                          DataTypeString(value_tensor->dtype())));
+          break;
       }
     }
   }
@@ -193,6 +93,53 @@ class DecodeJSONOp : public OpKernel {
  private:
   mutable mutex mu_;
   Env* env_ TF_GUARDED_BY(mu_);
+
+  // Tensor Shape
+
+  static void getTensorShape(rapidjson::Value *entry, std::vector <int64> &tensor_shape_vector) {
+    if (entry->IsArray()) {
+      tensor_shape_vector.push_back(entry->Size());
+      getTensorShape(&(*entry)[0], tensor_shape_vector);
+    }
+  }
+
+  // Single Entry Tensor Writes
+
+  static void writeInt32(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+    value_tensor->flat<int32>()(flat_index) = (*entry).GetInt();
+  }
+
+  static void writeInt64(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+    value_tensor->flat<int64>()(flat_index) = (*entry).GetInt64();
+  }
+
+  static void writeFloat(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+    value_tensor->flat<float>()(flat_index) = (*entry).GetDouble();
+  }
+
+  static void writeDouble(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+    value_tensor->flat<double>()(flat_index) = (*entry).GetDouble();
+  }
+
+  static void writeString(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+    value_tensor->flat<tstring>()(flat_index) = (*entry).GetString();
+  }
+
+  // Full Tensor Write
+
+  template<class T>
+  static void
+  writeToTensor(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index, T write_func) {
+    if (entry->IsArray()) {
+      for (int64 i = 0; i < entry->Size(); i++) {
+        writeToTensor(&(*entry)[i], value_tensor, flat_index, write_func);
+      }
+    } else {
+      write_func(entry, value_tensor, flat_index);
+      flat_index++;
+    }
+  }
+
 };
 
 class DecodeAvroOp : public OpKernel {
@@ -560,3 +507,4 @@ REGISTER_KERNEL_BUILDER(Name("IO>EncodeAvro").Device(DEVICE_CPU), EncodeAvroOp);
 }  // namespace
 }  // namespace data
 }  // namespace tensorflow
+

--- a/tensorflow_io/core/kernels/serialization_kernels.cc
+++ b/tensorflow_io/core/kernels/serialization_kernels.cc
@@ -58,7 +58,11 @@ class DecodeJSONOp : public OpKernel {
 
       Tensor* value_tensor;
       std::vector<int64> tensor_shape_vector;
-      getTensorShape(entry, tensor_shape_vector);
+      if (entry->IsArray()) {
+        getTensorShape(entry, tensor_shape_vector);
+      } else {
+        tensor_shape_vector.push_back(1);
+      }
       OP_REQUIRES_OK(
           context, context->allocate_output(i, TensorShape(tensor_shape_vector),
                                             &value_tensor));

--- a/tensorflow_io/core/kernels/serialization_kernels.cc
+++ b/tensorflow_io/core/kernels/serialization_kernels.cc
@@ -57,11 +57,11 @@ class DecodeJSONOp : public OpKernel {
                                           names_tensor->flat<tstring>()(i)));
 
       Tensor* value_tensor;
-      std::vector <int64> tensor_shape_vector;
+      std::vector<int64> tensor_shape_vector;
       getTensorShape(entry, tensor_shape_vector);
-      OP_REQUIRES_OK(context,
-                     context->allocate_output(i, TensorShape(tensor_shape_vector),
-                                              &value_tensor));
+      OP_REQUIRES_OK(
+          context, context->allocate_output(i, TensorShape(tensor_shape_vector),
+                                            &value_tensor));
       int64 flat_index;
       flat_index = 0;
       switch (value_tensor->dtype()) {
@@ -81,10 +81,10 @@ class DecodeJSONOp : public OpKernel {
           writeToTensor(entry, value_tensor, flat_index, writeString);
           break;
         default:
-          OP_REQUIRES(context, false,
-                      errors::InvalidArgument(
-                          "data type not supported: ",
-                          DataTypeString(value_tensor->dtype())));
+          OP_REQUIRES(
+              context, false,
+              errors::InvalidArgument("data type not supported: ",
+                                      DataTypeString(value_tensor->dtype())));
           break;
       }
     }
@@ -96,7 +96,8 @@ class DecodeJSONOp : public OpKernel {
 
   // Tensor Shape
 
-  static void getTensorShape(rapidjson::Value *entry, std::vector <int64> &tensor_shape_vector) {
+  static void getTensorShape(rapidjson::Value* entry,
+                             std::vector<int64>& tensor_shape_vector) {
     if (entry->IsArray()) {
       tensor_shape_vector.push_back(entry->Size());
       getTensorShape(&(*entry)[0], tensor_shape_vector);
@@ -105,31 +106,36 @@ class DecodeJSONOp : public OpKernel {
 
   // Single Entry Tensor Writes
 
-  static void writeInt32(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+  static void writeInt32(rapidjson::Value* entry, Tensor* value_tensor,
+                         int64& flat_index) {
     value_tensor->flat<int32>()(flat_index) = (*entry).GetInt();
   }
 
-  static void writeInt64(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+  static void writeInt64(rapidjson::Value* entry, Tensor* value_tensor,
+                         int64& flat_index) {
     value_tensor->flat<int64>()(flat_index) = (*entry).GetInt64();
   }
 
-  static void writeFloat(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+  static void writeFloat(rapidjson::Value* entry, Tensor* value_tensor,
+                         int64& flat_index) {
     value_tensor->flat<float>()(flat_index) = (*entry).GetDouble();
   }
 
-  static void writeDouble(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+  static void writeDouble(rapidjson::Value* entry, Tensor* value_tensor,
+                          int64& flat_index) {
     value_tensor->flat<double>()(flat_index) = (*entry).GetDouble();
   }
 
-  static void writeString(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index) {
+  static void writeString(rapidjson::Value* entry, Tensor* value_tensor,
+                          int64& flat_index) {
     value_tensor->flat<tstring>()(flat_index) = (*entry).GetString();
   }
 
   // Full Tensor Write
 
-  template<class T>
-  static void
-  writeToTensor(rapidjson::Value *entry, Tensor *value_tensor, int64 &flat_index, T write_func) {
+  template <class T>
+  static void writeToTensor(rapidjson::Value* entry, Tensor* value_tensor,
+                            int64& flat_index, T write_func) {
     if (entry->IsArray()) {
       for (int64 i = 0; i < entry->Size(); i++) {
         writeToTensor(&(*entry)[i], value_tensor, flat_index, write_func);
@@ -139,7 +145,6 @@ class DecodeJSONOp : public OpKernel {
       flat_index++;
     }
   }
-
 };
 
 class DecodeAvroOp : public OpKernel {
@@ -507,4 +512,3 @@ REGISTER_KERNEL_BUILDER(Name("IO>EncodeAvro").Device(DEVICE_CPU), EncodeAvroOp);
 }  // namespace
 }  // namespace data
 }  // namespace tensorflow
-

--- a/tests/test_serialization_eager.py
+++ b/tests/test_serialization_eager.py
@@ -208,13 +208,19 @@ def test_json_multiple_dimension_tensor():
     # was not supported for decode_json.
     # The issue was initially raised in:
     # https://github.com/tensorflow/io/pull/695#issuecomment-683270751
-    r = '{"x": [[[1.0], [2.0]]]}'
+    r = '{"x": [[[1.0], [2.0]]], "y": ["index", "count"], "z": 0.5}'
 
     @tf.function(autograph=False)
     def parse_json(json_text):
-        specs = {"x": tf.TensorSpec(tf.TensorShape([1, 2, 1]), tf.float32)}
+        specs = {
+            "x": tf.TensorSpec(tf.TensorShape([1, 2, 1]), tf.float32),
+            "y": tf.TensorSpec(tf.TensorShape([2]), tf.string),
+            "z": tf.TensorSpec(tf.TensorShape([]), tf.float32),
+        }
         parsed = tfio.experimental.serialization.decode_json(json_text, specs)
-        return parsed["x"]
+        return parsed
 
     v = parse_json(r)
-    assert np.array_equal(v, [[[1.0], [2.0]]])
+    assert np.array_equal(v["x"], [[[1.0], [2.0]]])
+    assert np.array_equal(v["y"], [b"index", b"count"])
+    assert np.array_equal(v["z"], 0.5)

--- a/tests/test_serialization_eager.py
+++ b/tests/test_serialization_eager.py
@@ -218,4 +218,3 @@ def test_json_multiple_dimension_tensor():
 
     v = parse_json(r)
     assert np.array_equal(v, [[[1.0], [2.0]]])
-

--- a/tests/test_serialization_eager.py
+++ b/tests/test_serialization_eager.py
@@ -208,13 +208,14 @@ def test_json_multiple_dimension_tensor():
     # was not supported for decode_json.
     # The issue was initially raised in:
     # https://github.com/tensorflow/io/pull/695#issuecomment-683270751
-    r = '{"x": [[1.0]]}'
+    r = '{"x": [[[1.0], [2.0]]]}'
 
     @tf.function(autograph=False)
     def parse_json(json_text):
-        specs = {"x": tf.TensorSpec(tf.TensorShape([1, 1]), tf.float32)}
+        specs = {"x": tf.TensorSpec(tf.TensorShape([1, 2, 1]), tf.float32)}
         parsed = tfio.experimental.serialization.decode_json(json_text, specs)
         return parsed["x"]
 
     v = parse_json(r)
-    assert np.array_equal(v, [[1.0]])
+    assert np.array_equal(v, [[[1.0], [2.0]]])
+


### PR DESCRIPTION
Continues on from this [PR](https://github.com/tensorflow/io/pull/1101), where this [comment](https://github.com/tensorflow/io/pull/1101#issue-476359614) suggested to add higher dimensions at a later stage. This PR was originally made following this [comment](https://github.com/tensorflow/io/pull/695#issuecomment-683270751).

I'm not sure how much the recursive design will sacrifice speed with the extra function calls, but I think the readability and simplicity is improved, and I think it's safe to assume that json files are unlikely to contain very large arrays, as this would be an inefficient storage method for such data.