### PR TITLE
fix docstring indentations for arrow, bigquery and ignite python api's

### DIFF
--- a/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
+++ b/tensorflow_io/arrow/python/ops/arrow_dataset_ops.py
@@ -36,8 +36,8 @@ else:
 
 def arrow_to_tensor_type(pa_t):
     """Convert Arrow type to tuple of (Tensor dtype, shape dims).
-  This function requires pyarrow to be installed.
-  """
+    This function requires pyarrow to be installed.
+    """
     import pyarrow as pa  # pylint: disable=import-outside-toplevel
 
     shape_dims = []  # initialize shape as scalar
@@ -79,8 +79,8 @@ def arrow_to_tensor_type(pa_t):
 
 def arrow_schema_to_tensor_types(schema):
     """Convert an Arrow schema to tuple of (Tensor dtypes, TensorShapes).
-  This function requires pyarrow to be installed.
-  """
+    This function requires pyarrow to be installed.
+    """
     type_shape_list = [arrow_to_tensor_type(field.type) for field in schema]
     tensor_types, shape_dims = zip(*type_shape_list)
     tensor_shapes = tuple(tf.TensorShape(s) for s in shape_dims)
@@ -89,8 +89,8 @@ def arrow_schema_to_tensor_types(schema):
 
 class ArrowBaseDataset(dataset_ops.DatasetV2):
     """Base class for Arrow Datasets to provide columns used in record batches
-  and corresponding output tensor types, shapes and classes.
-  """
+    and corresponding output tensor types, shapes and classes.
+    """
 
     batch_modes_supported = ("keep_remainder", "drop_remainder", "auto")
 
@@ -158,8 +158,7 @@ class ArrowBaseDataset(dataset_ops.DatasetV2):
 
 
 class ArrowDataset(ArrowBaseDataset):
-    """An Arrow Dataset from record batches in memory, or a Pandas DataFrame.
-  """
+    """An Arrow Dataset from record batches in memory, or a Pandas DataFrame."""
 
     def __init__(
         self,
@@ -172,29 +171,29 @@ class ArrowDataset(ArrowBaseDataset):
         arrow_buffer=None,
     ):
         """Create an ArrowDataset from a Tensor of serialized batches.
-    This constructor requires pyarrow to be installed.
+        This constructor requires pyarrow to be installed.
 
-    Args:
-      serialized_batches: A string Tensor as a serialized buffer containing
-                          Arrow record batches in Arrow File format
-      columns: A list of column indices to be used in the Dataset
-      output_types: Tensor dtypes of the output tensors
-      output_shapes: TensorShapes of the output tensors or None to
-                     infer partial
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched Tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-      arrow_buffer: Optional Arrow Buffer containing Arrow record batches in
-                    Arrow File format. This will share the Arrow buffer with
-                    the C++ kernel by address for zero-copy. Only supported if
-                    the kernel process is local, with TensorFlow in eager mode.
-                    If this is used, set `serialized_batches` to `None`.
-    """
+        Args:
+            serialized_batches: A string Tensor as a serialized buffer containing
+                                Arrow record batches in Arrow File format
+            columns: A list of column indices to be used in the Dataset
+            output_types: Tensor dtypes of the output tensors
+            output_shapes: TensorShapes of the output tensors or None to
+                        infer partial
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched Tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+            arrow_buffer: Optional Arrow Buffer containing Arrow record batches in
+                        Arrow File format. This will share the Arrow buffer with
+                        the C++ kernel by address for zero-copy. Only supported if
+                        the kernel process is local, with TensorFlow in eager mode.
+                        If this is used, set `serialized_batches` to `None`.
+        """
         if serialized_batches is not None:
             make_variant_fn = partial(
                 core_ops.io_arrow_serialized_dataset, serialized_batches
@@ -239,23 +238,23 @@ class ArrowDataset(ArrowBaseDataset):
         batch_mode="keep_remainder",
     ):
         """Create an ArrowDataset directly from Arrow record batches.
-    This constructor requires pyarrow to be installed.
+        This constructor requires pyarrow to be installed.
 
-    Args:
-      record_batches: An Arrow record batch or sequence of record batches
-      output_types: Tensor dtypes of the output tensors
-      output_shapes: TensorShapes of the output tensors or None to
-                     infer partial
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-      columns: A list of column indices to be used in the Dataset
-    """
+        Args:
+            record_batches: An Arrow record batch or sequence of record batches
+            output_types: Tensor dtypes of the output tensors
+            output_shapes: TensorShapes of the output tensors or None to
+                            infer partial
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+            columns: A list of column indices to be used in the Dataset
+        """
         import pyarrow as pa  # pylint: disable=import-outside-toplevel
 
         if isinstance(record_batches, pa.RecordBatch):
@@ -301,23 +300,23 @@ class ArrowDataset(ArrowBaseDataset):
         batch_mode="keep_remainder",
     ):
         """Create an ArrowDataset from a given Pandas DataFrame. Output types
-    and shapes are inferred from the Arrow schema after DataFrame conversion.
-    If preserve_index is True, the DataFrame index will be the last column.
-    This method requires pyarrow to be installed.
+        and shapes are inferred from the Arrow schema after DataFrame conversion.
+        If preserve_index is True, the DataFrame index will be the last column.
+        This method requires pyarrow to be installed.
 
-    Args:
-      df: a Pandas DataFrame
-      columns: Optional column indices to use, if None all are used
-      preserve_index: Flag to include the DataFrame index as the last column
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-    """
+        Args:
+            df: a Pandas DataFrame
+            columns: Optional column indices to use, if None all are used
+            preserve_index: Flag to include the DataFrame index as the last column
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+        """
         import pyarrow as pa  # pylint: disable=import-outside-toplevel
 
         if columns is not None:
@@ -337,10 +336,10 @@ class ArrowDataset(ArrowBaseDataset):
 
 class ArrowFeatherDataset(ArrowBaseDataset):
     """An Arrow Dataset for reading record batches from Arrow feather files.
-  Feather is a light-weight columnar format ideal for simple writing of
-  Pandas DataFrames. Pyarrow can be used for reading/writing Feather files,
-  see https://arrow.apache.org/docs/python/ipc.html#feather-format
-  """
+    Feather is a light-weight columnar format ideal for simple writing of
+    Pandas DataFrames. Pyarrow can be used for reading/writing Feather files,
+    see https://arrow.apache.org/docs/python/ipc.html#feather-format
+    """
 
     def __init__(
         self,
@@ -353,22 +352,22 @@ class ArrowFeatherDataset(ArrowBaseDataset):
     ):
         """Create an ArrowDataset from one or more Feather file names.
 
-    Args:
-      filenames: A `tf.string` tensor, Python list or scalar containing files
-                 in Arrow Feather format
-      columns: A list of column indices to be used in the Dataset
-      output_types: Tensor dtypes of the output tensors
-      output_shapes: TensorShapes of the output tensors or None to
-                     infer partial
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-    """
+        Args:
+            filenames: A `tf.string` tensor, Python list or scalar containing files
+                        in Arrow Feather format
+            columns: A list of column indices to be used in the Dataset
+            output_types: Tensor dtypes of the output tensors
+            output_shapes: TensorShapes of the output tensors or None to
+                        infer partial
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+        """
         filenames = tf.convert_to_tensor(
             filenames, dtype=dtypes.string, name="filenames"
         )
@@ -391,23 +390,23 @@ class ArrowFeatherDataset(ArrowBaseDataset):
         batch_mode="keep_remainder",
     ):
         """Create an Arrow Dataset for reading record batches from Arrow feather
-    files, inferring output types and shapes from the given Arrow schema.
-    This method requires pyarrow to be installed.
+        files, inferring output types and shapes from the given Arrow schema.
+        This method requires pyarrow to be installed.
 
-    Args:
-      filenames: A `tf.string` tensor, Python list or scalar containing files
-                 in Arrow Feather format
-      schema: Arrow schema defining the record batch data in the stream
-      columns: A list of column indicies to use from the schema, None for all
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-    """
+        Args:
+            filenames: A `tf.string` tensor, Python list or scalar containing files
+                        in Arrow Feather format
+            schema: Arrow schema defining the record batch data in the stream
+            columns: A list of column indicies to use from the schema, None for all
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+        """
         if columns is None:
             columns = list(range(len(schema)))
         output_types, output_shapes = arrow_schema_to_tensor_types(schema)
@@ -418,8 +417,8 @@ class ArrowFeatherDataset(ArrowBaseDataset):
 
 class ArrowStreamDataset(ArrowBaseDataset):
     """An Arrow Dataset for reading record batches from an input stream.
-  Currently supported input streams are a socket client or stdin.
-  """
+    Currently supported input streams are a socket client or stdin.
+    """
 
     def __init__(
         self,
@@ -432,28 +431,28 @@ class ArrowStreamDataset(ArrowBaseDataset):
     ):
         """Create an ArrowDataset from an input stream.
 
-    Args:
-      endpoints: A `tf.string` tensor, Python list or scalar string defining the
-                 input stream.
-                 `endpoints` supports the following formats:
-                   - "host:port": IPv4 address (default)
-                   - "tcp://<host:port>": IPv4 address,
-                   - "unix://<path>": local path as unix socket address,
-                   - "fd://<number>": STDIN or file descriptor number. For
-                     STDIN, use "fd://0" or "fd://-".
-      columns: A list of column indices to be used in the Dataset
-      output_types: Tensor dtypes of the output tensors
-      output_shapes: TensorShapes of the output tensors or None to
-                     infer partial
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-    """
+        Args:
+            endpoints: A `tf.string` tensor, Python list or scalar string defining the
+                        input stream.
+                        `endpoints` supports the following formats:
+                        - "host:port": IPv4 address (default)
+                        - "tcp://<host:port>": IPv4 address,
+                        - "unix://<path>": local path as unix socket address,
+                        - "fd://<number>": STDIN or file descriptor number. For
+                            STDIN, use "fd://0" or "fd://-".
+            columns: A list of column indices to be used in the Dataset
+            output_types: Tensor dtypes of the output tensors
+            output_shapes: TensorShapes of the output tensors or None to
+                            infer partial
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+        """
         endpoints = tf.convert_to_tensor(
             endpoints, dtype=dtypes.string, name="endpoints"
         )
@@ -476,29 +475,29 @@ class ArrowStreamDataset(ArrowBaseDataset):
         batch_mode="keep_remainder",
     ):
         """Create an Arrow Dataset from an input stream, inferring output types
-    and shapes from the given Arrow schema.
-    This method requires pyarrow to be installed.
+        and shapes from the given Arrow schema.
+        This method requires pyarrow to be installed.
 
-    Args:
-      endpoints: A `tf.string` tensor, Python list or scalar string defining the
-                 input stream.
-                 `endpoints` supports the following formats:
-                   - "host:port": IPv4 address (default)
-                   - "tcp://<host:port>": IPv4 address,
-                   - "unix://<path>": local path as unix socket address,
-                   - "fd://<number>": STDIN or file descriptor number. For
-                     STDIN, use "fd://0" or "fd://-".
-      schema: Arrow schema defining the record batch data in the stream
-      columns: A list of column indicies to use from the schema, None for all
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-    """
+        Args:
+            endpoints: A `tf.string` tensor, Python list or scalar string defining the
+                        input stream.
+                        `endpoints` supports the following formats:
+                        - "host:port": IPv4 address (default)
+                        - "tcp://<host:port>": IPv4 address,
+                        - "unix://<path>": local path as unix socket address,
+                        - "fd://<number>": STDIN or file descriptor number. For
+                            STDIN, use "fd://0" or "fd://-".
+            schema: Arrow schema defining the record batch data in the stream
+            columns: A list of column indicies to use from the schema, None for all
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+        """
         if columns is None:
             columns = list(range(len(schema)))
         output_types, output_shapes = arrow_schema_to_tensor_types(schema)
@@ -518,26 +517,26 @@ class ArrowStreamDataset(ArrowBaseDataset):
         record_batch_iter_factory=None,
     ):
         """Create an ArrowStreamDataset by serving a sequence of Arrow record
-    batches in a background thread.
-    This constructor requires pyarrow to be installed.
+        batches in a background thread. This constructor requires pyarrow to
+        be installed.
 
-    Args:
-      record_batch_iter: A sequence or iterator of Arrow record batches
-      output_types: Tensor dtypes of the output tensors
-      output_shapes: TensorShapes of the output tensors or None to
-                     infer partial
-      columns: Optional list of column indices to be used, if None all are used
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: batch_size does not need to be set if batch_mode='auto'
-      batch_mode: Mode of batching, supported strings:
-                  "keep_remainder" (default, keeps partial batch data),
-                  "drop_remainder" (discard partial batch data),
-                  "auto" (size to number of records in Arrow record batch)
-      record_batch_iter_factory: Optional factory to create additional record
-                                 batch iterators for multiple iterations.
-    """
+        Args:
+            record_batch_iter: A sequence or iterator of Arrow record batches
+            output_types: Tensor dtypes of the output tensors
+            output_shapes: TensorShapes of the output tensors or None to
+                            infer partial
+            columns: Optional list of column indices to be used, if None all are used
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: batch_size does not need to be set if batch_mode='auto'
+            batch_mode: Mode of batching, supported strings:
+                        "keep_remainder" (default, keeps partial batch data),
+                        "drop_remainder" (discard partial batch data),
+                        "auto" (size to number of records in Arrow record batch)
+            record_batch_iter_factory: Optional factory to create additional record
+                                        batch iterators for multiple iterations.
+        """
         import pyarrow as pa  # pylint: disable=import-outside-toplevel
 
         # Create a UDS server by default if not Windows
@@ -597,18 +596,18 @@ class ArrowStreamDataset(ArrowBaseDataset):
         cls, data_frames, columns=None, preserve_index=True, batch_size=None
     ):
         """Create an ArrowStreamDataset by serving a DataFrame, or batches of a
-    DataFrame in a background thread.
-    This constructor requires pandas and pyarrow to be installed.
+        DataFrame in a background thread. This constructor requires pandas and
+        pyarrow to be installed.
 
-    Args:
-      data_frames: A Pandas DataFrame or sequence of DataFrames
-      columns: Optional column indices to use, if None all are used
-      preserve_index: Flag to include the DataFrame index as the last column
-      batch_size: Batch size of output tensors, setting a batch size here
-                  will create batched tensors from Arrow memory and can be more
-                  efficient than using tf.data.Dataset.batch().
-                  NOTE: Currently, only 'keep_remainder' batch mode supported
-    """
+        Args:
+            data_frames: A Pandas DataFrame or sequence of DataFrames
+            columns: Optional column indices to use, if None all are used
+            preserve_index: Flag to include the DataFrame index as the last column
+            batch_size: Batch size of output tensors, setting a batch size here
+                        will create batched tensors from Arrow memory and can be more
+                        efficient than using tf.data.Dataset.batch().
+                        NOTE: Currently, only 'keep_remainder' batch mode supported
+        """
         import pandas as pd  # pylint: disable=import-outside-toplevel
         import pyarrow as pa  # pylint: disable=import-outside-toplevel
 

--- a/tensorflow_io/bigquery/python/ops/bigquery_api.py
+++ b/tensorflow_io/bigquery/python/ops/bigquery_api.py
@@ -38,29 +38,25 @@ from tensorflow_io.core.python.ops import core_ops
 class BigQueryClient:
     """BigQueryClient is the entrypoint for interacting with Cloud BigQuery in TF.
 
-  BigQueryClient encapsulates a connection to Cloud BigQuery, and exposes the
-  `readSession` method to initiate a BigQuery read session.
-  """
+    BigQueryClient encapsulates a connection to Cloud BigQuery, and exposes the
+    `readSession` method to initiate a BigQuery read session.
+    """
 
     class DataFormat(enum.Enum):
-        """Data serialization format to use when reading from BigQuery.
-        """
+        """Data serialization format to use when reading from BigQuery."""
 
         AVRO = "AVRO"
         ARROW = "ARROW"
 
     class FieldMode(enum.Enum):
-        """BigQuery column mode.
-        """
+        """BigQuery column mode."""
 
         NULLABLE = "NULLABLE"
         REQUIRED = "REQUIRED"
         REPEATED = "REPEATED"
 
     def __init__(self):
-        """Creates a BigQueryClient to start BigQuery read sessions.
-
-    """
+        """Creates a BigQueryClient to start BigQuery read sessions."""
         self._client_resource = core_ops.io_big_query_client()
 
     def read_session(
@@ -77,43 +73,43 @@ class BigQueryClient:
     ):
         """Opens a session and returns a `BigQueryReadSession` object.
 
-    Args:
-      parent: String of the form projects/{project_id} indicating the project
-        this ReadSession is associated with. This is the project that will be
-        billed for usage.
-      project_id: The assigned project ID of the project.
-      table_id: The ID of the table in the dataset.
-      dataset_id: The ID of the dataset in the project.
-      selected_fields: This can be a list or a dict. If a list, it has
-        names of the fields in the table that should be read. If a dict,
-        it should be in a form like, i.e:
-        { "field_a_name": {"mode": "repeated", output_type: dtypes.int64},
-          "field_b_name": {"mode": "nullable", output_type: dtypes.string},
-          ...
-          "field_x_name": {"mode": "repeated", output_type: dtypes.string}
-        }
-        "mode" is BigQuery column attribute, it can be 'repeated', 'nullable' or 'required'.
-        The output field order is unrelated to the order of fields in
-        selected_fields. If "mode" not specified, defaults to "nullable".
-        If "output_type" not specified, DT_STRING is implied for all Tensors.
-      output_types: Types for the output tensor in the same sequence as
-        selected_fields. This is only needed when selected_fields is a list,
-        if selected_fields is a dictionary, this output_types information is
-        included in selected_fields as described above.
-        If not specified, DT_STRING is implied for all Tensors.
-      row_restriction: Optional. SQL text filtering statement, similar to a
-        WHERE clause in a query.
-      requested_streams: Initial number of streams. If unset or 0, we will
-        provide a value of streams so as to produce reasonable throughput.
-        Must be non-negative. The number of streams may be lower than the
-        requested number, depending on the amount parallelism that is reasonable
-        for the table and the maximum amount of parallelism allowed by the
-        system.
+        Args:
+            parent: String of the form projects/{project_id} indicating the project
+                this ReadSession is associated with. This is the project that will be
+                billed for usage.
+            project_id: The assigned project ID of the project.
+            table_id: The ID of the table in the dataset.
+            dataset_id: The ID of the dataset in the project.
+            selected_fields: This can be a list or a dict. If a list, it has
+                names of the fields in the table that should be read. If a dict,
+                it should be in a form like, i.e:
+                { "field_a_name": {"mode": "repeated", output_type: dtypes.int64},
+                "field_b_name": {"mode": "nullable", output_type: dtypes.string},
+                ...
+                "field_x_name": {"mode": "repeated", output_type: dtypes.string}
+                }
+                "mode" is BigQuery column attribute, it can be 'repeated', 'nullable' or 'required'.
+                The output field order is unrelated to the order of fields in
+                selected_fields. If "mode" not specified, defaults to "nullable".
+                If "output_type" not specified, DT_STRING is implied for all Tensors.
+            output_types: Types for the output tensor in the same sequence as
+                selected_fields. This is only needed when selected_fields is a list,
+                if selected_fields is a dictionary, this output_types information is
+                included in selected_fields as described above.
+                If not specified, DT_STRING is implied for all Tensors.
+            row_restriction: Optional. SQL text filtering statement, similar to a
+                WHERE clause in a query.
+            requested_streams: Initial number of streams. If unset or 0, we will
+                provide a value of streams so as to produce reasonable throughput.
+                Must be non-negative. The number of streams may be lower than the
+                requested number, depending on the amount parallelism that is reasonable
+                for the table and the maximum amount of parallelism allowed by the
+                system.
 
-    Returns:
-      A `BigQueryReadSession` Python object representing the
-      operations available on the table.
-    """
+        Returns:
+            A `BigQueryReadSession` Python object representing the
+            operations available on the table.
+        """
         if not isinstance(parent, str):
             raise ValueError("`parent` must be a string")
         if not parent:
@@ -236,24 +232,24 @@ class BigQueryReadSession:
     def get_streams(self):
         """Returns Tensor with stream names for reading data from BigQuery.
 
-    Returns:
-      Tensor with stream names.
-    """
+        Returns:
+            Tensor with stream names.
+        """
         return self._streams
 
     def read_rows(self, stream, offset=0):
         """Retrieves rows (including values) from the BigQuery service.
 
-    Args:
-      stream: name of the stream to read from.
-      offset: Position in the stream.
+        Args:
+            stream: name of the stream to read from.
+            offset: Position in the stream.
 
-    Returns:
-      A `tf.data.Dataset` returning the row keys and the cell contents.
+        Returns:
+            A `tf.data.Dataset` returning the row keys and the cell contents.
 
-    Raises:
-      ValueError: If the configured probability is unexpected.
-    """
+        Raises:
+            ValueError: If the configured probability is unexpected.
+        """
         return _BigQueryDataset(
             self._client_resource,
             self._selected_fields,
@@ -276,37 +272,36 @@ class BigQueryReadSession:
     ):
         """Retrieves rows from the BigQuery service in parallel streams.
 
-    ```
-    bq_client = BigQueryClient()
-    bq_read_session = bq_client.read_session(...)
-    ds1 = bq_read_session.parallel_read_rows(...)
-    ```
-    Args:
-      cycle_length: number of threads to run in parallel. If not specified, it
-        is defaulted to the number of streams in a read session.
-      sloppy: If false, elements are produced in deterministic order. If true,
-        the implementation is allowed, for the sake of expediency, to produce
-        elements in a non-deterministic order. Otherwise, whether the order is
-        deterministic or non-deterministic depends on the
-        `tf.data.Options.experimental_deterministic` value.
-      block_length: The number of consecutive elements to pull from an input
-        `Dataset` before advancing to the next input `Dataset`.
-      block_length: The number of consecutive elements to pull from an input
-        `Dataset` before advancing to the next input `Dataset`.
-      num_parallel_calls: If specified, the implementation creates a threadpool,
-        which is used to fetch inputs from cycle elements asynchronously and in
-        parallel. The default behavior is to fetch inputs from cycle elements
-        synchronously with no parallelism.
-        If the value `tf.data.experimental.AUTOTUNE` is used, then the number of
-        parallel calls is set dynamically based on available CPU.
+        ```
+        bq_client = BigQueryClient()
+        bq_read_session = bq_client.read_session(...)
+        ds1 = bq_read_session.parallel_read_rows(...)
+        ```
+        Args:
+            cycle_length: number of threads to run in parallel. If not specified, it
+                is defaulted to the number of streams in a read session.
+            sloppy: If false, elements are produced in deterministic order. If true,
+                the implementation is allowed, for the sake of expediency, to produce
+                elements in a non-deterministic order. Otherwise, whether the order is
+                deterministic or non-deterministic depends on the
+                `tf.data.Options.experimental_deterministic` value.
+            block_length: The number of consecutive elements to pull from an input
+                `Dataset` before advancing to the next input `Dataset`.
+            block_length: The number of consecutive elements to pull from an input
+                `Dataset` before advancing to the next input `Dataset`.
+            num_parallel_calls: If specified, the implementation creates a threadpool,
+                which is used to fetch inputs from cycle elements asynchronously and in
+                parallel. The default behavior is to fetch inputs from cycle elements
+                synchronously with no parallelism.
+                If the value `tf.data.experimental.AUTOTUNE` is used, then the number of
+                parallel calls is set dynamically based on available CPU.
 
-    Returns:
-      A `tf.data.Dataset` returning the row keys and the cell contents.
+        Returns:
+            A `tf.data.Dataset` returning the row keys and the cell contents.
 
-    Raises:
-      ValueError: If the configured probability is unexpected.
-
-    """
+        Raises:
+            ValueError: If the configured probability is unexpected.
+        """
         if cycle_length is None:
             cycle_length = self._requested_streams
         streams_ds = dataset_ops.Dataset.from_tensor_slices(self._streams)
@@ -390,8 +385,8 @@ class BigQueryTestClient(BigQueryClient):
     def __init__(self, fake_server_address):
         """Creates a BigQueryTestClient to start BigQuery read sessions.
 
-    Args:
-      fake_server_address: url for service faking Cloud BigQuery Storage API.
-    """
+        Args:
+            fake_server_address: url for service faking Cloud BigQuery Storage API.
+        """
 
         self._client_resource = core_ops.io_big_query_test_client(fake_server_address)

--- a/tensorflow_io/ignite/python/ops/ignite_dataset_ops.py
+++ b/tensorflow_io/ignite/python/ops/ignite_dataset_ops.py
@@ -28,9 +28,8 @@ from tensorflow_io.core.python.ops import core_ops as ignite_ops
 
 class Readable(metaclass=abc.ABCMeta):
     """Readable abstract class that exposes methods to do reading-related
-
-     operations.
-  """
+    operations.
+    """
 
     @abc.abstractmethod
     def __init__(self):
@@ -73,9 +72,9 @@ class DataBuffer(Readable):
     def __init__(self, data_buffer):
         """Constructs a new instance based on the specified byte  buffer.
 
-    Args:
-      data_buffer: Buffer to be read.
-    """
+        Args:
+            data_buffer: Buffer to be read.
+        """
         Readable.__init__(self)
         self.buffer = data_buffer
         self.ptr = 0
@@ -93,20 +92,20 @@ class TcpClient(Readable):
     def __init__(self, host, port, certfile=None, keyfile=None, password=None):
         """Constructs a new instance based on the specified host and port.
 
-    Args:
-      host: Host to be connected.
-      port: Port to be connected.
-      certfile: File in PEM format containing the certificate as well as any
-        number of CA certificates needed to establish the certificate's
-        authenticity.
-      keyfile: File containing the private key (otherwise the private key will
-        be taken from certfile as well).
-      password: Password to be used if the private key is encrypted and a
-        password is necessary.
+        Args:
+            host: Host to be connected.
+            port: Port to be connected.
+            certfile: File in PEM format containing the certificate as well as any
+                number of CA certificates needed to establish the certificate's
+                authenticity.
+            keyfile: File containing the private key (otherwise the private key will
+                be taken from certfile as well).
+            password: Password to be used if the private key is encrypted and a
+            password is necessary.
 
-    Raises:
-      ValueError: If the wrong combination of arguments is provided.
-    """
+        Raises:
+            ValueError: If the wrong combination of arguments is provided.
+        """
         Readable.__init__(self)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
@@ -225,19 +224,18 @@ types = {
 
 class TypeTreeNode:  # pylint: disable=useless-object-inheritance
     """TypeTreeNode class exposes methods to format object tree structure
-
-     data.
-  """
+    data.
+    """
 
     def __init__(self, name, type_id, fields=None, permutation=None):
         """Constructs a new instance of TypeTreeNode.
 
-    Args:
-      name: Name of the object tree node.
-      type_id: Type id of the object tree node.
-      fields: List of fields (children of the object tree node).
-      permutation: Permutation that should be applied to order object children.
-    """
+        Args:
+            name: Name of the object tree node.
+            type_id: Type id of the object tree node.
+            fields: List of fields (children of the object tree node).
+            permutation: Permutation that should be applied to order object children.
+        """
         self.name = name
         self.type_id = type_id
         self.fields = fields
@@ -323,10 +321,10 @@ class TypeTreeNode:  # pylint: disable=useless-object-inheritance
 class IgniteClient(TcpClient):
     """IgniteClient enables working with Apache Ignite using a thin client.
 
-  This client works with assumption that all object in the cache
-  have the same structure (homogeneous objects) and the cache contains at
-  least one object.
-  """
+    This client works with assumption that all object in the cache
+    have the same structure (homogeneous objects) and the cache contains at
+    least one object.
+    """
 
     def __init__(
         self,
@@ -340,19 +338,19 @@ class IgniteClient(TcpClient):
     ):
         """Constructs a new instance of IgniteClient.
 
-    Args:
-      host: Apache Ignite Thin client host to be connected.
-      port: Apache Ignite Thin client port to be connected.
-      username: Apache Ignite Thin Client authentication username.
-      password: Apache Ignite Thin Client authentication password.
-      certfile: File in PEM format containing the certificate as well as any
-        number of CA certificates needed to establish the certificate's
-        authenticity.
-      keyfile: File containing the private key (otherwise the private key will
-        be taken from certfile as well).
-      cert_password: Password to be used if the private key is encrypted and a
-        password is necessary.
-    """
+        Args:
+            host: Apache Ignite Thin client host to be connected.
+            port: Apache Ignite Thin client port to be connected.
+            username: Apache Ignite Thin Client authentication username.
+            password: Apache Ignite Thin Client authentication password.
+            certfile: File in PEM format containing the certificate as well as any
+                number of CA certificates needed to establish the certificate's
+                authenticity.
+            keyfile: File containing the private key (otherwise the private key will
+                be taken from certfile as well).
+            cert_password: Password to be used if the private key is encrypted and a
+                password is necessary.
+        """
         TcpClient.__init__(self, host, port, certfile, keyfile, cert_password)
         self.username = username
         self.password = password
@@ -699,16 +697,15 @@ class IgniteClient(TcpClient):
 
 class IgniteDataset(data.Dataset):
     """Apache Ignite is a memory-centric distributed database, caching, and
-
-     processing platform for transactional, analytical, and streaming workloads,
-     delivering in-memory speeds at petabyte scale. This contrib package
-     contains an integration between Apache Ignite and TensorFlow. The
-     integration is based on tf.data from TensorFlow side and Binary Client
-     Protocol from Apache Ignite side. It allows to use Apache Ignite as a
-     datasource for neural network training, inference and all other
-     computations supported by TensorFlow. Ignite Dataset is based on Apache
-     Ignite Binary Client Protocol.
-  """
+    processing platform for transactional, analytical, and streaming workloads,
+    delivering in-memory speeds at petabyte scale. This contrib package
+    contains an integration between Apache Ignite and TensorFlow. The
+    integration is based on tf.data from TensorFlow side and Binary Client
+    Protocol from Apache Ignite side. It allows to use Apache Ignite as a
+    datasource for neural network training, inference and all other
+    computations supported by TensorFlow. Ignite Dataset is based on Apache
+    Ignite Binary Client Protocol.
+    """
 
     def __init__(
         self,
@@ -728,25 +725,25 @@ class IgniteDataset(data.Dataset):
     ):
         """Create a IgniteDataset.
 
-    Args:
-      cache_name: Cache name to be used as datasource.
-      host: Apache Ignite Thin Client host to be connected.
-      port: Apache Ignite Thin Client port to be connected.
-      schema_host: Host to be connected to retrieve cache schema.
-      schema_port: Port to be connected to retrieve cache schema.
-      local: Local flag that defines to query only local data.
-      part: Number of partitions to be queried.
-      page_size: Apache Ignite Thin Client page size.
-      username: Apache Ignite Thin Client authentication username.
-      password: Apache Ignite Thin Client authentication password.
-      certfile: File in PEM format containing the certificate as well as any
-        number of CA certificates needed to establish the certificate's
-        authenticity.
-      keyfile: File containing the private key (otherwise the private key will
-        be taken from certfile as well).
-      cert_password: Password to be used if the private key is encrypted and a
-        password is necessary.
-    """
+        Args:
+            cache_name: Cache name to be used as datasource.
+            host: Apache Ignite Thin Client host to be connected.
+            port: Apache Ignite Thin Client port to be connected.
+            schema_host: Host to be connected to retrieve cache schema.
+            schema_port: Port to be connected to retrieve cache schema.
+            local: Local flag that defines to query only local data.
+            part: Number of partitions to be queried.
+            page_size: Apache Ignite Thin Client page size.
+            username: Apache Ignite Thin Client authentication username.
+            password: Apache Ignite Thin Client authentication password.
+            certfile: File in PEM format containing the certificate as well as any
+                number of CA certificates needed to establish the certificate's
+                authenticity.
+            keyfile: File containing the private key (otherwise the private key will
+                be taken from certfile as well).
+            cert_password: Password to be used if the private key is encrypted and a
+                password is necessary.
+        """
         if not schema_host:
             schema_host = host
         if not schema_port:


### PR DESCRIPTION
This PR addressed the issue: https://github.com/tensorflow/io/issues/861 and fixes the docstrings for the arrow, bigquery and ignite python api's. 

Will raise a different PR to fix the API's in `core` as well. 