### PR TITLE
fix python api docstrings in tensorflow_io/core

### DIFF
--- a/tensorflow_io/core/python/experimental/avro_record_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/avro_record_dataset_ops.py
@@ -75,6 +75,7 @@ class _AvroRecordDataset(tf.data.Dataset):
 
     def __init__(self, filenames, buffer_size=None, reader_schema=None):
         """Creates a `AvroRecordDataset`.
+
         Args:
           filenames: A `tf.string` tensor containing one or more filenames.
           buffer_size: (Optional.) A `tf.int64` scalar representing the number of
@@ -130,6 +131,7 @@ class AvroRecordDataset(tf.data.Dataset):
         self, filenames, buffer_size=None, num_parallel_reads=None, reader_schema=None
     ):
         """Creates a `AvroRecordDataset` to read one or more AvroRecord files.
+
         Args:
           filenames: A `tf.string` tensor or `tf.data.Dataset` containing one or
             more filenames.
@@ -145,6 +147,7 @@ class AvroRecordDataset(tf.data.Dataset):
             read sequentially.
           reader_schema: (Optional.) A `tf.string` scalar representing the reader
             schema or None.
+
         Raises:
           TypeError: If any argument does not have the expected type.
           ValueError: If any argument does not have the expected shape.

--- a/tensorflow_io/core/python/experimental/azure_ops.py
+++ b/tensorflow_io/core/python/experimental/azure_ops.py
@@ -21,10 +21,11 @@ import tensorflow_io.core.python.ops  # pylint: disable=unused-import
 
 def authenticate_with_device_code(account_name):
     """Setup storage tokens by authenticating with device code
-  and use management APIs
-  Args:
-    account_name (str): The storage account name for which to authenticate
-  """
+    and use management APIs.
+
+    Args:
+        account_name (str): The storage account name for which to authenticate
+    """
 
     import urllib  # pylint: disable=import-outside-toplevel
     import json  # pylint: disable=import-outside-toplevel

--- a/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
@@ -34,10 +34,12 @@ class _ElasticsearchHandler:
         self.prepare_connection_data()
 
     def prepare_base_urls(self):
-        """Prepares the base url for establish connection with the elasticsearch master
+        """Prepares the base url for establish connection with the
+        elasticsearch master.
 
         Returns:
-            A list of base_url's, each of type tf.string for establishing the connection pool
+            A list of base_url's, each of type tf.string for establishing
+            the connection pool.
         """
 
         if self.nodes is None:
@@ -175,10 +177,10 @@ class ElasticsearchIODataset(tf.compat.v2.data.Dataset):
                 in [protocol://hostname:port] format.
                 For example: ["http://localhost:9200"]
             index: A `tf.string` representing the elasticsearch index to query.
-            doc_type: (Optional) A `tf.string` representing the type of documents in the index
-                to query.
+            doc_type: (Optional) A `tf.string` representing the type of documents
+                in the index to query.
             headers: (Optional) A dict of headers. For example:
-                {'Content-Type': 'application/json'}    
+                {'Content-Type': 'application/json'}
         """
         with tf.name_scope("ElasticsearchIODataset"):
             assert internal

--- a/tensorflow_io/core/python/experimental/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/experimental/ffmpeg_ops.py
@@ -18,13 +18,13 @@
 def decode_video(content, index=0, name=None):
     """Decode video stream from a video file.
 
-  Args:
-    content: A `Tensor` of type `string`.
-    index: The stream index.
+    Args:
+      content: A `Tensor` of type `string`.
+      index: The stream index.
 
-  Returns:
-    value: A `uint8` Tensor.
-  """
+    Returns:
+      value: A `uint8` Tensor.
+    """
     from tensorflow_io.core.python.ops import (  # pylint: disable=import-outside-toplevel
         ffmpeg_ops,
     )

--- a/tensorflow_io/core/python/experimental/grpc_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/grpc_dataset_ops.py
@@ -24,9 +24,9 @@ class GRPCStreamIODataset(tf.data.Dataset):
     def __init__(self, endpoint, shape, dtype):
         """Create a GRPC Reader.
 
-    Args:
-      endpoint: A `tf.string` tensor containing one or more endpoints.
-    """
+        Args:
+            endpoint: A `tf.string` tensor containing one or more endpoints.
+        """
         with tf.name_scope("GRPCStreamIODataset"):
             shape = tf.cast(shape, tf.int64)
 

--- a/tensorflow_io/core/python/experimental/io_layer.py
+++ b/tensorflow_io/core/python/experimental/io_layer.py
@@ -20,9 +20,7 @@ from tensorflow_io.core.python.experimental import kafka_io_layer_ops
 
 
 class IOLayer(tf.keras.layers.Layer):
-    """IOLayer
-
-  """
+    """IOLayer"""
 
     # =============================================================================
     # IOLayer (identity)
@@ -42,12 +40,12 @@ class IOLayer(tf.keras.layers.Layer):
     def text(cls, filename):
         """Obtain a TextIOLayer to be used with tf.keras.
 
-    Args:
-      filename: A `string` Tensor of the filename.
+        Args:
+          filename: A `string` Tensor of the filename.
 
-    Returns:
-      A class of `TextIOLayer`.
-    """
+        Returns:
+          A class of `TextIOLayer`.
+        """
         return text_io_layer_ops.TextIOLayer(filename)
 
     # =============================================================================
@@ -58,17 +56,17 @@ class IOLayer(tf.keras.layers.Layer):
     def kafka(cls, topic, partition=0, servers=None, configuration=None):
         """Obtain a KafkaIOLayer to be used with tf.keras.
 
-    Args:
-      topic: A `tf.string` tensor containing topic.
-      partition: A `tf.int32` tensor containing partition.
-      servers: A list of bootstrap servers.
-      configurations: A `tf.string` tensor containing global configuration
-        properties in [Key=Value] format,eg.
-        ["enable.auto.commit=false", "heartbeat.interval.ms=2000"],
-        please refer to 'Global configuration properties'
-        in librdkafka doc.
+        Args:
+          topic: A `tf.string` tensor containing topic.
+          partition: A `tf.int32` tensor containing partition.
+          servers: A list of bootstrap servers.
+          configurations: A `tf.string` tensor containing global configuration
+            properties in [Key=Value] format,eg.
+            ["enable.auto.commit=false", "heartbeat.interval.ms=2000"],
+            please refer to 'Global configuration properties'
+            in librdkafka doc.
 
-    Returns:
-      A class of `KafkaIOLayer`.
-    """
+        Returns:
+          A class of `KafkaIOLayer`.
+        """
         return kafka_io_layer_ops.KafkaIOLayer(topic, partition, servers, configuration)

--- a/tensorflow_io/core/python/experimental/io_tensor.py
+++ b/tensorflow_io/core/python/experimental/io_tensor.py
@@ -30,13 +30,13 @@ class IOTensor(io_tensor.IOTensor):
     def from_exr(cls, filename, **kwargs):
         """Creates an `IOTensor` from a OpenEXR file.
 
-    Args:
-      filename: A string, the filename of a OpenEXR file.
-      name: A name prefix for the IOTensor (optional).
+        Args:
+          filename: A string, the filename of a OpenEXR file.
+          name: A name prefix for the IOTensor (optional).
 
-    Returns:
-      A `IOTensor`.
+        Returns:
+          A `IOTensor`.
 
-    """
+        """
         with tf.name_scope(kwargs.get("name", "IOFromOpenEXR")):
             return openexr_io_tensor_ops.EXRIOTensor(filename, internal=True)

--- a/tensorflow_io/core/python/experimental/kafka_io_layer_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_io_layer_ops.py
@@ -19,9 +19,7 @@ from tensorflow_io.core.python.ops import core_ops
 
 
 class KafkaIOLayer(tf.keras.layers.Layer):
-    """KafkaIOLayer
-
-  """
+    """KafkaIOLayer"""
 
     # =============================================================================
     # KafkaIOLayer

--- a/tensorflow_io/core/python/experimental/kinesis_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kinesis_dataset_ops.py
@@ -22,38 +22,38 @@ from tensorflow_io.core.python.ops import core_ops
 class KinesisIODataset(tf.data.Dataset):
     """A Kinesis Dataset that consumes the message.
 
-  Kinesis is a managed service provided by AWS for data streaming.
-  This dataset reads messages from Kinesis with each message presented
-  as a `tf.string`.
+    Kinesis is a managed service provided by AWS for data streaming.
+    This dataset reads messages from Kinesis with each message presented
+    as a `tf.string`.
 
-  For example, we can construct and use the KinesisIODataset as follows:
-  ```python
-  dataset = KinesisIODataset(
-      "kinesis_stream_name", read_indefinitely=False)
-  next = dataset.make_one_shot_iterator().get_next()
-  with tf.Session() as sess:
-    while True:
-      try:
-        print(sess.run(nxt))
-      except tf.errors.OutOfRangeError:
-        break
-  ```
+    For example, we can construct and use the KinesisIODataset as follows:
+    ```python
+    dataset = KinesisIODataset(
+        "kinesis_stream_name", read_indefinitely=False)
+    next = dataset.make_one_shot_iterator().get_next()
+    with tf.Session() as sess:
+      while True:
+        try:
+          print(sess.run(nxt))
+        except tf.errors.OutOfRangeError:
+          break
+    ```
 
-  Since Kinesis is a data streaming service, data may not be available
-  at the time it is being read. The argument `read_indefinitely` is
-  used to control the behavior in this situation. If `read_indefinitely`
-  is `True`, then `KinesisIODataset` will keep retrying to retrieve data
-  from the stream. If `read_indefinitely` is `False`, an `OutOfRangeError`
-  is returned immediately instead.
-  """
+    Since Kinesis is a data streaming service, data may not be available
+    at the time it is being read. The argument `read_indefinitely` is
+    used to control the behavior in this situation. If `read_indefinitely`
+    is `True`, then `KinesisIODataset` will keep retrying to retrieve data
+    from the stream. If `read_indefinitely` is `False`, an `OutOfRangeError`
+    is returned immediately instead.
+    """
 
     def __init__(self, stream, shard="", internal=False):
         """Create a KinesisIODataset.
 
-    Args:
-      stream: A `tf.string` tensor containing the name of the stream.
-      shard: A `tf.string` tensor containing the id of the shard.
-    """
+        Args:
+          stream: A `tf.string` tensor containing the name of the stream.
+          shard: A `tf.string` tensor containing the id of the shard.
+        """
         with tf.name_scope("KinesisIODataset"):
             assert internal
 

--- a/tensorflow_io/core/python/experimental/parse_avro_ops.py
+++ b/tensorflow_io/core/python/experimental/parse_avro_ops.py
@@ -65,22 +65,22 @@ def parse_avro(serialized, reader_schema, features, avro_names=None, name=None):
     Only works for batched serialized input!
 
     Args:
-      serialized: The batched, serialized string tensors.
+        serialized: The batched, serialized string tensors.
 
-      reader_schema: The reader schema. Note, this MUST match the reader schema
+        reader_schema: The reader schema. Note, this MUST match the reader schema
         from the avro_record_dataset. Otherwise, this op will segfault!
 
-      features: A map of feature names mapped to feature information.
+        features: A map of feature names mapped to feature information.
 
-      avro_names: (Optional.) may contain descriptive names for the
+        avro_names: (Optional.) may contain descriptive names for the
         corresponding serialized avro parts. These may be useful for debugging
         purposes, but they have no effect on the output. If not `None`,
         `avro_names` must be the same length as `serialized`.
 
-      name: The name of the op.
+        name: The name of the op.
 
     Returns:
-      A map of feature names to tensors.
+        A map of feature names to tensors.
     """
     if not features:
         raise ValueError("Missing: features was %s." % features)
@@ -132,37 +132,38 @@ def _parse_avro(
     name=None,
 ):
     """Parses Avro records.
+
     Args:
-    serialized: A vector (1-D Tensor) of strings, a batch of binary
-      serialized `Example` protos.
-    reader_schema: A scalar string representing the reader schema.
-    names: A vector (1-D Tensor) of strings (optional), the names of
-      the serialized protos.
-    sparse_keys: A list of string keys in the examples' features.
-      The results for these keys will be returned as `SparseTensor` objects.
-    sparse_types: A list of `DTypes` of the same length as `sparse_keys`.
-      Only `tf.float32` (`FloatList`), `tf.int64` (`Int64List`),
-      and `tf.string` (`BytesList`) are supported.
-    sparse_ranks: ranks of sparse feature. `tf.int64` (`Int64List`) is supported.
-    dense_keys: A list of string keys in the examples' features.
-      The results for these keys will be returned as `Tensor`s
-    dense_types: A list of DTypes of the same length as `dense_keys`.
-      Only `tf.float32` (`FloatList`), `tf.int64` (`Int64List`),
-      and `tf.string` (`BytesList`) are supported.
-    dense_defaults: A dict mapping string keys to `Tensor`s.
-      The keys of the dict must match the dense_keys of the feature.
-    dense_shapes: A list of tuples with the same length as `dense_keys`.
-      The shape of the data for each dense feature referenced by `dense_keys`.
-      Required for any input tensors identified by `dense_keys`.  Must be
-      either fully defined, or may contain an unknown first dimension.
-      An unknown first dimension means the feature is treated as having
-      a variable number of blocks, and the output shape along this dimension
-      is considered unknown at graph build time.  Padding is applied for
-      minibatch elements smaller than the maximum number of blocks for the
-      given feature along this dimension.
-    name: A name for this operation (optional).
+        serialized: A vector (1-D Tensor) of strings, a batch of binary
+        serialized `Example` protos.
+        reader_schema: A scalar string representing the reader schema.
+        names: A vector (1-D Tensor) of strings (optional), the names of
+        the serialized protos.
+        sparse_keys: A list of string keys in the examples' features.
+        The results for these keys will be returned as `SparseTensor` objects.
+        sparse_types: A list of `DTypes` of the same length as `sparse_keys`.
+        Only `tf.float32` (`FloatList`), `tf.int64` (`Int64List`),
+        and `tf.string` (`BytesList`) are supported.
+        sparse_ranks: ranks of sparse feature. `tf.int64` (`Int64List`) is supported.
+        dense_keys: A list of string keys in the examples' features.
+        The results for these keys will be returned as `Tensor`s
+        dense_types: A list of DTypes of the same length as `dense_keys`.
+        Only `tf.float32` (`FloatList`), `tf.int64` (`Int64List`),
+        and `tf.string` (`BytesList`) are supported.
+        dense_defaults: A dict mapping string keys to `Tensor`s.
+        The keys of the dict must match the dense_keys of the feature.
+        dense_shapes: A list of tuples with the same length as `dense_keys`.
+        The shape of the data for each dense feature referenced by `dense_keys`.
+        Required for any input tensors identified by `dense_keys`.  Must be
+        either fully defined, or may contain an unknown first dimension.
+        An unknown first dimension means the feature is treated as having
+        a variable number of blocks, and the output shape along this dimension
+        is considered unknown at graph build time.  Padding is applied for
+        minibatch elements smaller than the maximum number of blocks for the
+        given feature along this dimension.
+        name: A name for this operation (optional).
     Returns:
-      A `dict` mapping keys to `Tensor`s and `SparseTensor`s.
+        A `dict` mapping keys to `Tensor`s and `SparseTensor`s.
     """
     with tf.name_scope(name or "ParseAvro"):
         (
@@ -229,11 +230,13 @@ def _build_keys_for_sparse_features(features):
     """
     Builds the fully qualified names for keys of sparse features.
 
-    :param features:  A map of features with keys to TensorFlow features.
+    Args:
+        features:  A map of features with keys to TensorFlow features.
 
-    :return: A map of features where for the sparse feature
-             the 'index_key' and the 'value_key' have been expanded
-             properly for the parser in the native code.
+    Returns:
+        A map of features where for the sparse feature
+        the 'index_key' and the 'value_key' have been expanded
+        properly for the parser in the native code.
     """
 
     def resolve_key(parser_key, index_or_value_key):
@@ -304,17 +307,17 @@ def _features_to_raw_params(features, types):
     """Split feature tuples into raw params used by `gen_parsing_ops`.
 
     Args:
-      features: A `dict` mapping feature keys to objects of a type in `types`.
-      types: Type of features to allow, among `FixedLenFeature`, `VarLenFeature`,
-        `SparseFeature`, and `FixedLenSequenceFeature`.
+        features: A `dict` mapping feature keys to objects of a type in `types`.
+        types: Type of features to allow, among `FixedLenFeature`, `VarLenFeature`,
+            `SparseFeature`, and `FixedLenSequenceFeature`.
 
     Returns:
-      Tuple of `sparse_keys`, `sparse_types`, `dense_keys`, `dense_types`,
+        Tuple of `sparse_keys`, `sparse_types`, `dense_keys`, `dense_types`,
         `dense_defaults`, `dense_shapes`.
 
     Raises:
-      ValueError: if `features` contains an item not in `types`, or an invalid
-          feature.
+        ValueError: if `features` contains an item not in `types`, or an invalid
+        feature.
     """
     sparse_keys = []
     sparse_types = []
@@ -463,6 +466,7 @@ def _process_raw_parameters(
     dense_shapes,
 ):
     """Process raw parameters to params used by `gen_parsing_ops`.
+
     Args:
       names: A vector (1-D Tensor) of strings (optional), the names of
         the serialized protos.
@@ -487,9 +491,11 @@ def _process_raw_parameters(
         is considered unknown at graph build time.  Padding is applied for
         minibatch elements smaller than the maximum number of blocks for the
         given feature along this dimension.
+
     Returns:
       Tuple of `names`, `dense_defaults_vec`, `sparse_keys`, `sparse_types`,
       `dense_keys`, `dense_shapes`.
+
     Raises:
       ValueError: If sparse and dense key sets intersect, or input lengths do not
         match up.

--- a/tensorflow_io/core/python/experimental/text_io_layer_ops.py
+++ b/tensorflow_io/core/python/experimental/text_io_layer_ops.py
@@ -19,9 +19,7 @@ from tensorflow_io.core.python.ops import core_ops
 
 
 class TextIOLayer(tf.keras.layers.Layer):
-    """TextIOLayer
-
-  """
+    """TextIOLayer"""
 
     # =============================================================================
     # TextIOLayer

--- a/tensorflow_io/core/python/experimental/text_ops.py
+++ b/tensorflow_io/core/python/experimental/text_ops.py
@@ -20,16 +20,18 @@ from tensorflow_io.core.python.ops import core_ops
 
 def decode_libsvm(content, num_features, dtype=None, label_dtype=None):
     """Convert Libsvm records to a tensor of label and a tensor of feature.
-  Args:
-    content: A `Tensor` of type `string`. Each string is a record/row in
-      the Libsvm format.
-    num_features: The number of features.
-    dtype: The type of the output feature tensor. Default to tf.float32.
-    label_dtype: The type of the output label tensor. Default to tf.int64.
-  Returns:
-    features: A `SparseTensor` of the shape `[input_shape, num_features]`.
-    labels: A `Tensor` of the same shape as content.
-  """
+
+    Args:
+      content: A `Tensor` of type `string`. Each string is a record/row in
+        the Libsvm format.
+      num_features: The number of features.
+      dtype: The type of the output feature tensor. Default to tf.float32.
+      label_dtype: The type of the output label tensor. Default to tf.int64.
+
+    Returns:
+      features: A `SparseTensor` of the shape `[input_shape, num_features]`.
+      labels: A `Tensor` of the same shape as content.
+    """
     labels, indices, values, shape = core_ops.io_decode_libsvm(
         content, num_features, dtype=dtype, label_dtype=label_dtype
     )
@@ -39,10 +41,10 @@ def decode_libsvm(content, num_features, dtype=None, label_dtype=None):
 def re2_full_match(input, pattern):  # pylint: disable=redefined-builtin
     """Extract regex groups
 
-  Args:
-    input: A `tf.string` tensor
-    pattern: A pattern string.
-  """
+    Args:
+      input: A `tf.string` tensor
+      pattern: A pattern string.
+    """
     return core_ops.io_re2_full_match(input, pattern)
 
 
@@ -58,8 +60,7 @@ class TextOutputSequence:
     """TextOutputSequence"""
 
     def __init__(self, filenames):
-        """Create a `TextOutputSequence`.
-    """
+        """Create a `TextOutputSequence`."""
         self._filenames = filenames
         self._resource = core_ops.io_text_output_sequence(destination=filenames)
 


### PR DESCRIPTION
This PR addressed the issue: https://github.com/tensorflow/io/issues/861 and fixes the docstrings for the python API's in `tensorflow_io/core`.
