### PR TITLE
fix kafka dataset OOM ,Update kafka_kernels_deprecated.cc

### DIFF
--- a/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
@@ -210,6 +210,7 @@ class KafkaDatasetOp : public DatasetOpKernel {
           : DatasetIterator<Dataset>(params) {}
       
       virtual ~Iterator() {
+          // destruction is needed to release rdkafka resources
           ResetStreamsLocked();
       }
       

--- a/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels_deprecated.cc
@@ -208,7 +208,11 @@ class KafkaDatasetOp : public DatasetOpKernel {
      public:
       explicit Iterator(const Params& params)
           : DatasetIterator<Dataset>(params) {}
-
+      
+      virtual ~Iterator() {
+          ResetStreamsLocked();
+      }
+      
       Status GetNextInternal(IteratorContext* ctx,
                              std::vector<Tensor>* out_tensors,
                              bool* end_of_sequence) override {


### PR DESCRIPTION
fix kafka dataset OOM problem, when use kafka dataset in online learning, the evaluation will create session and create dataset many times ,then that's problem will be every clearly to appear!