### PR TITLE
Docker image for nightly releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,6 +503,8 @@ jobs:
           docker login --username tfsigio --password ${{ secrets.DOCKER_PASSWORD }}
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           docker push tfsigio/tfio:latest
+          bash -x -e tools/docker/tests/dockerfile_nightly_test.sh
+          docker push tfsigio/tfio:nightly
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh
           docker push tfsigio/tfio:latest-devel
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ People who are a little more adventurous can also try our nightly binaries:
 $ pip install tensorflow-io-nightly
 ```
 
+In addition to the pip packages, the docker images can be used to quickly get started.
+
+For stable builds:
+```sh
+$ docker pull tfsigio/tfio:latest
+$ docker run -it --rm --name tfio-latest tfsigio/tfio:latest
+```
+
+For nightly builds:
+```sh
+$ docker pull tfsigio/tfio:nightly
+$ docker run -it --rm --name tfio-nightly tfsigio/tfio:nightly
+```
+
 ### R Package
 
 Once the `tensorflow-io` Python package has been successfully installed, you
@@ -359,11 +373,11 @@ $ TFIO_DATAPATH=bazel-bin python3
 #### Docker
 
 For Python development, a reference Dockerfile [here](tools/docker/devel.Dockerfile) can be
-used to build the TensorFlow I/O package (`tensorflow-io`) from source:
+used to build the TensorFlow I/O package (`tensorflow-io`) from source. Additionally, the
+pre-built devel images can be used as well:
 ```sh
-# Build and run the Docker image
-$ docker build -f tools/docker/devel.Dockerfile -t tfio-dev .
-$ docker run -it --rm --net=host -v ${PWD}:/v -w /v tfio-dev
+# Pull (if necessary) and start the devel container
+$ docker run -it --rm --name tfio-dev --net=host -v ${PWD}:/v -w /v tfsigio/tfio:latest-devel bash
 
 # Inside the docker container, ./configure.sh will install TensorFlow or use existing install
 (tfio-dev) root@docker-desktop:/v$ ./configure.sh
@@ -371,14 +385,19 @@ $ docker run -it --rm --net=host -v ${PWD}:/v -w /v tfio-dev
 # Clean up exisiting bazel build's (if any)
 (tfio-dev) root@docker-desktop:/v$ rm -rf bazel-*
 
-# Build TensorFlow I/O C++. For compilation optimization flags, the default (-march=native) optimizes the generated code for your machine's CPU type. [see here](https://www.tensorflow.org/install/source#configuration_options). NOTE: Based on the available resources, please change the number of job workers to -j 4/8/16 to prevent bazel server terminations and resource oriented build errors.
+# Build TensorFlow I/O C++. For compilation optimization flags, the default (-march=native)
+# optimizes the generated code for your machine's CPU type.
+# Reference: https://www.tensorflow.orginstall/source#configuration_options).
+
+# NOTE: Based on the available resources, please change the number of job workers to:
+# -j 4/8/16 to prevent bazel server terminations and resource oriented build errors.
 
 (tfio-dev) root@docker-desktop:/v$ bazel build -j 8 --copt=-msse4.2 --copt=-mavx --compilation_mode=opt --verbose_failures --test_output=errors --crosstool_top=//third_party/toolchains/gcc7_manylinux2010:toolchain //tensorflow_io/...
 
 
 # Run tests with PyTest, note: some tests require launching additional containers to run (see below)
 (tfio-dev) root@docker-desktop:/v$ pytest -s -v tests/
- # Build the TensorFlow I/O package
+# Build the TensorFlow I/O package
 (tfio-dev) root@docker-desktop:/v$ python setup.py bdist_wheel
 ```
 
@@ -391,7 +410,7 @@ libraries built by Bazel to run `pytest` and build the `bdist_wheel`. Python
 `python setup.py --data bazel-bin bdist_wheel`.
 
 NOTE: While the tfio-dev container gives developers an easy to work with
-environment, the released whl packages are build differently due to manylinux2010
+environment, the released whl packages are built differently due to manylinux2010
 requirements. Please check [Build Status and CI] section for more details
 on how the released whl packages are generated.
 
@@ -402,8 +421,8 @@ to run all tests, execute the following commands:
 
 ```sh
 $ bash -x -e tests/test_ignite/start_ignite.sh
-$ bash -x -e tests/test_kafka/kafka_test.sh start kafka
-$ bash -x -e tests/test_kinesis/kinesis_test.sh start kinesis
+$ bash -x -e tests/test_kafka/kafka_test.sh
+$ bash -x -e tests/test_kinesis/kinesis_test.sh
 ```
 
 ### R

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ available in TensorFlow's built-in support. A full list of supported file system
 and file formats by TensorFlow I/O can be found [here](https://www.tensorflow.org/io/api_docs/python/tfio).
 
 The use of tensorflow-io is straightforward with keras. Below is an example
-to [Get Started with TensorFlow](https://www.tensorflow.org/tutorials) with
+to [Get Started with TensorFlow](https://www.tensorflow.org/tutorials/quickstart/beginner) with
 the data processing aspect replaced by tensorflow-io:
 
 ```python

--- a/tools/docker/nightly.Dockerfile
+++ b/tools/docker/nightly.Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Python version for the base image
+ARG PYTHON_VERSION=3.7-slim
+
+FROM python:${PYTHON_VERSION}
+
+# tfio package name and version for pip install
+ARG TFIO_PACKAGE=tensorflow-io-nightly
+ARG TFIO_PACKAGE_VERSION=
+
+RUN pip install ${TFIO_PACKAGE}${TFIO_PACKAGE_VERSION:+==${TFIO_PACKAGE_VERSION}}

--- a/tools/docker/tests/dockerfile_nightly_test.sh
+++ b/tools/docker/tests/dockerfile_nightly_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+IMAGE_NAME="tfsigio/tfio"
+IMAGE_TAG="nightly"
+export PYTHON_BIN_PATH=$(which python3)
+
+echo "Build the docker image ..."
+docker build -f tools/docker/nightly.Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+
+echo "Starting the docker container from image: ${IMAGE_NAME}:${IMAGE_TAG} and validating import ..."
+docker run -t --rm ${IMAGE_NAME}:${IMAGE_TAG} python -c "import tensorflow_io as tfio; print(tfio.__version__)"


### PR DESCRIPTION
This PR adds the necessary steps for building, validating and pushing the `tfsigio/tfio:nightly` docker image to the docker registry. Additionally, the README.md file has been updated to inform the users of the availability of the images along with few doc fixes. 

References: https://github.com/tensorflow/io/issues/1087