### PR TITLE
fix auto.offset.reset bug while consuming messages using KafkaGroupIODataset

### DIFF
--- a/tensorflow_io/core/python/experimental/kafka_batch_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_batch_io_dataset_ops.py
@@ -84,13 +84,13 @@ class KafkaBatchIODataset(tf.data.Dataset):
           group_id: The id of the consumer group. For example: cgstream
           servers: An optional list of bootstrap servers.
             For example: `localhost:9092`.
-          stream_timeout: An optional timeout value (in milliseconds) to wait for 
+          stream_timeout: An optional timeout value (in milliseconds) to wait for
             the new messages from kafka to be retrieved by the consumers.
             By default it is set to -1 to block indefinitely.
           message_poll_timeout: An optional timeout duration (in milliseconds)
             after which the kafka consumer throws a timeout error while fetching
             a single message. This value also represents the intervals at which
-            the kafka topic(s) are polled for new messages while using the `stream_timeout`.  
+            the kafka topic(s) are polled for new messages while using the `stream_timeout`.
           configuration: An optional `tf.string` tensor containing
             configurations in [Key=Value] format.
             Global configuration: please refer to 'Global configuration properties'

--- a/tensorflow_io/core/python/experimental/kafka_batch_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_batch_io_dataset_ops.py
@@ -38,7 +38,12 @@ class KafkaBatchIODataset(tf.data.Dataset):
     >>> dataset = tfio.experimental.streaming.KafkaBatchIODataset(
                         topics=["topic1"],
                         group_id="cg",
-                        servers="localhost:9092"
+                        servers="localhost:9092",
+                        configuration=[
+                            "session.timeout.ms=7000",
+                            "max.poll.interval.ms=8000",
+                            "auto.offset.reset=earliest",
+                        ],
                     )
 
     >>> for mini_batch in dataset:
@@ -46,7 +51,11 @@ class KafkaBatchIODataset(tf.data.Dataset):
     ...            lambda m, k: (tf.cast(m, tf.float32), tf.cast(k, tf.float32)))
 
     Since `mini_batch` is of type `tf.data.Dataset` we can perform all the operations that it
-    inherits from `tf.data.Dataset`.
+    inherits from `tf.data.Dataset`. Also, the `auto.offset.reset` configuration is set to
+    `earliest` so that in case the consumer group is being newly created, it will start
+    reading the messages from the beginning. If it is not set, it defaults to `latest`.
+    For additional configurations, please refer the librdkafka's configurations:
+    https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 
     To train a keras model on this stream of incoming data:
 
@@ -89,8 +98,9 @@ class KafkaBatchIODataset(tf.data.Dataset):
               ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
             Topic configuration: please refer to 'Topic configuration properties'
               in librdkafka doc. Note all topic configurations should be
-              prefixed with `configuration.topic.`. Examples include
+              prefixed with `conf.topic.`. Examples include
               ["conf.topic.auto.offset.reset=earliest"]
+            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
           internal: Whether the dataset is being created from within the named scope.
             Default: True
         """

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -66,7 +66,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
                             "auto.offset.reset=earliest",
                         ],
                     )
-    
+
     In the above example, the `auto.offset.reset` configuration is set to `earliest` so that
     in case the consumer group is being newly created, it will start reading the messages from
     the beginning. If it is not set, it defaults to `latest`. For additional configurations,
@@ -98,7 +98,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
     As the kafka deployments vary in configuration as per various use-cases, the time required for
     the consumers to fetch a single message might also vary. This timeout value can be adjusted
     using the `message_poll_timeout` parameter.
-    
+
     The `message_poll_timeout` value represents the duration which the consumers
     have to wait while fetching a new message. However, even if we receive a new message
     before the `message_poll_timeout` interval finishes, the consumer doesn't resume the
@@ -127,7 +127,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
           group_id: The id of the consumer group. For example: cgstream
           servers: An optional list of bootstrap servers.
             For example: `localhost:9092`.
-          stream_timeout: An optional timeout duration (in milliseconds) to block until 
+          stream_timeout: An optional timeout duration (in milliseconds) to block until
             the new messages from kafka are fetched.
             By default it is set to 0 milliseconds and doesn't block for new messages.
             To block indefinitely, set it to -1.
@@ -144,7 +144,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
               in librdkafka doc. Note all topic configurations should be
               prefixed with `conf.topic.`. Examples include
               ["conf.topic.auto.offset.reset=earliest"]
-            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md  
+            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
           internal: Whether the dataset is being created from within the named scope.
             Default: True
         """

--- a/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/kafka_group_io_dataset_ops.py
@@ -63,8 +63,15 @@ class KafkaGroupIODataset(tf.data.Dataset):
                         configuration=[
                             "session.timeout.ms=7000",
                             "max.poll.interval.ms=8000",
+                            "auto.offset.reset=earliest",
                         ],
                     )
+    
+    In the above example, the `auto.offset.reset` configuration is set to `earliest` so that
+    in case the consumer group is being newly created, it will start reading the messages from
+    the beginning. If it is not set, it defaults to `latest`. For additional configurations,
+    please refer the librdkafka's configurations:
+    https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 
     In addition to the standard streaming functionality, there is added support for a timeout
     based stream. Once the existing data has been fetched, this dataset will block for
@@ -78,6 +85,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
                         configuration=[
                             "session.timeout.ms=7000",
                             "max.poll.interval.ms=8000",
+                            "auto.offset.reset=earliest",
                         ],
                     )
     >>> for (message, key) in dataset:
@@ -115,7 +123,7 @@ class KafkaGroupIODataset(tf.data.Dataset):
         """
         Args:
           topics: A `tf.string` tensor containing topic names in [topic] format.
-            For example: ["topic1"]
+            For example: ["topic1", "topic2"]
           group_id: The id of the consumer group. For example: cgstream
           servers: An optional list of bootstrap servers.
             For example: `localhost:9092`.
@@ -134,8 +142,9 @@ class KafkaGroupIODataset(tf.data.Dataset):
               ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
             Topic configuration: please refer to 'Topic configuration properties'
               in librdkafka doc. Note all topic configurations should be
-              prefixed with `configuration.topic.`. Examples include
+              prefixed with `conf.topic.`. Examples include
               ["conf.topic.auto.offset.reset=earliest"]
+            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md  
           internal: Whether the dataset is being created from within the named scope.
             Default: True
         """

--- a/tensorflow_io/core/python/ops/io_dataset.py
+++ b/tensorflow_io/core/python/ops/io_dataset.py
@@ -144,8 +144,9 @@ class IODataset(io_dataset_ops._IODataset):  # pylint: disable=protected-access
               ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
             Topic configuration: please refer to 'Topic configuration properties'
               in librdkafka doc. Note all topic configurations should be
-              prefixed with `configuration.topic.`. Examples include
+              prefixed with `conf.topic.`. Examples include
               ["conf.topic.auto.offset.reset=earliest"]
+            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
           name: A name prefix for the IODataset (optional).
 
         Returns:
@@ -361,8 +362,9 @@ class StreamIODataset(
               ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
             Topic configuration: please refer to 'Topic configuration properties'
               in librdkafka doc. Note all topic configurations should be
-              prefixed with `configuration.topic.`. Examples include
+              prefixed with `conf.topic.`. Examples include
               ["conf.topic.auto.offset.reset=earliest"]
+            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
           name: A name prefix for the IODataset (optional).
 
         Returns:

--- a/tensorflow_io/core/python/ops/kafka_dataset_ops.py
+++ b/tensorflow_io/core/python/ops/kafka_dataset_ops.py
@@ -40,8 +40,9 @@ class KafkaIODataset(tf.data.Dataset):
               ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
             Topic configuration: please refer to 'Topic configuration properties'
               in librdkafka doc. Note all topic configurations should be
-              prefixed with `configuration.topic.`. Examples include
+              prefixed with `conf.topic.`. Examples include
               ["conf.topic.auto.offset.reset=earliest"]
+            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
           internal: Whether the dataset is being created from within the named scope.
             Default: True
         """
@@ -106,8 +107,9 @@ class KafkaStreamIODataset(tf.data.Dataset):
               ["enable.auto.commit=false", "heartbeat.interval.ms=2000"]
             Topic configuration: please refer to 'Topic configuration properties'
               in librdkafka doc. Note all topic configurations should be
-              prefixed with `configuration.topic.`. Examples include
+              prefixed with `conf.topic.`. Examples include
               ["conf.topic.auto.offset.reset=earliest"]
+            Reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
           internal: Whether the dataset is being created from within the named scope.
             Default: True
         """

--- a/tests/test_kafka_eager.py
+++ b/tests/test_kafka_eager.py
@@ -209,7 +209,11 @@ def test_kafka_group_io_dataset_primary_cg():
         topics=["key-partition-test"],
         group_id="cgtestprimary",
         servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+        ],
     )
     assert np.all(
         sorted([k.numpy() for (k, _) in dataset])
@@ -238,7 +242,11 @@ def test_kafka_group_io_dataset_primary_cg_new_topic():
         topics=["key-test"],
         group_id="cgtestprimary",
         servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+        ],
     )
     assert np.all(
         sorted([k.numpy() for (k, _) in dataset])
@@ -302,7 +310,11 @@ def test_kafka_group_io_dataset_secondary_cg():
         topics=["key-partition-test"],
         group_id="cgtestsecondary",
         servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+        ],
     )
     assert np.all(
         sorted([k.numpy() for (k, _) in dataset])
@@ -319,12 +331,75 @@ def test_kafka_group_io_dataset_tertiary_cg_multiple_topics():
         topics=["key-partition-test", "key-test"],
         group_id="cgtesttertiary",
         servers="localhost:9092",
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+        ],
     )
     assert np.all(
         sorted([k.numpy() for (k, _) in dataset])
         == sorted([("D" + str(i)).encode() for i in range(100)] * 2)
     )
+
+
+def test_kafka_group_io_dataset_auto_offset_reset():
+    """Test the functionality of the `auto.offset.reset` configuration
+    at global and topic level"""
+
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgglobaloffsetearliest",
+        servers="localhost:9092",
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+        ],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(100)])
+    )
+
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgglobaloffsetlatest",
+        servers="localhost:9092",
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=latest",
+        ],
+    )
+    assert np.all(sorted([k.numpy() for (k, _) in dataset]) == [])
+
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtopicoffsetearliest",
+        servers="localhost:9092",
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "conf.topic.auto.offset.reset=earliest",
+        ],
+    )
+    assert np.all(
+        sorted([k.numpy() for (k, _) in dataset])
+        == sorted([("D" + str(i)).encode() for i in range(100)])
+    )
+
+    dataset = tfio.experimental.streaming.KafkaGroupIODataset(
+        topics=["key-partition-test"],
+        group_id="cgtopicoffsetlatest",
+        servers="localhost:9092",
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "conf.topic.auto.offset.reset=latest",
+        ],
+    )
+    assert np.all(sorted([k.numpy() for (k, _) in dataset]) == [])
 
 
 def test_kafka_group_io_dataset_invalid_stream_timeout():
@@ -370,7 +445,11 @@ def test_kafka_group_io_dataset_stream_timeout_check():
         group_id="cgteststreamvalid",
         servers="localhost:9092",
         stream_timeout=20000,
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+        ],
     )
 
     # start writing the new messages to kafka using the background job.
@@ -394,7 +473,7 @@ def test_kafka_batch_io_dataset():
     online-training fashion.
 
     NOTE: This kind of dataset is suitable in scenarios where the 'keys' of 'messages'
-        act as labels.
+        act as labels. If not, additional transformations are required.
     """
 
     dataset = tfio.experimental.streaming.KafkaBatchIODataset(
@@ -402,7 +481,11 @@ def test_kafka_batch_io_dataset():
         group_id="cgminibatch",
         servers=None,
         stream_timeout=5000,
-        configuration=["session.timeout.ms=7000", "max.poll.interval.ms=8000"],
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+        ],
     )
 
     NUM_COLUMNS = 1


### PR DESCRIPTION
This PR addresses the issue: https://github.com/tensorflow/io/issues/1133 on `KafkaGroupIODataset` by:

- fixing the rebalance callback function.
- modifying the order in which topic and global level configurations are set for Kafka consumers.
- adding tests to validate the `auto.offset.reset` functionality.
- adding brief descriptions of the underlying implementation which `librdkafka` follows for rebalancing.

Once this PR is merged, will update the tutorial as well.