### PR TITLE
elasticsearch support for tf.bool data

### DIFF
--- a/tensorflow_io/core/kernels/elasticsearch_kernels.cc
+++ b/tensorflow_io/core/kernels/elasticsearch_kernels.cc
@@ -80,6 +80,8 @@ class ElasticsearchReadableResource : public ResourceBase {
           dtype = DT_DOUBLE;
         } else if (itr->value.IsString()) {
           dtype = DT_STRING;
+        } else if (itr->value.IsBool()) {
+          dtype = DT_BOOL;
         } else {
           return errors::InvalidArgument(
               "field: ", itr->name.GetString(),
@@ -106,6 +108,8 @@ class ElasticsearchReadableResource : public ResourceBase {
           dtypes_tensor->flat<tstring>()(column_idx) = "DT_DOUBLE";
         } else if (base_dtypes_[column_idx] == DT_STRING) {
           dtypes_tensor->flat<tstring>()(column_idx) = "DT_STRING";
+        } else if (base_dtypes_[column_idx] == DT_BOOL) {
+          dtypes_tensor->flat<tstring>()(column_idx) = "DT_BOOL";
         }
       }
 

--- a/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/elasticsearch_dataset_ops.py
@@ -112,6 +112,8 @@ class _ElasticsearchHandler:
                         dtypes.append(tf.double)
                     elif dtype == "DT_STRING":
                         dtypes.append(tf.string)
+                    elif dtype == "DT_BOOL":
+                        dtypes.append(tf.bool)
                 return resource, columns.numpy(), dtypes, request_url
             except Exception:
                 print("Skipping node: {}".format(healthcheck_url))

--- a/tests/test_elasticsearch_eager.py
+++ b/tests/test_elasticsearch_eager.py
@@ -35,7 +35,7 @@ HEADERS = {
     "Content-Type": "application/json",
     "Authorization": "Basic ZWxhc3RpYzpkZWZhdWx0X3Bhc3N3b3Jk",
 }
-ATTRS = ["name", "gender", "age", "fare", "survived"]
+ATTRS = ["name", "gender", "age", "fare", "vip", "survived"]
 
 
 def is_container_running():
@@ -63,10 +63,10 @@ def test_create_index():
 @pytest.mark.parametrize(
     "record",
     [
-        (("person1", "Male", 20, 80.52, 1)),
-        (("person2", "Female", 30, 40.88, 0)),
-        (("person3", "Male", 40, 20.73, 0)),
-        (("person4", "Female", 50, 100.99, 1)),
+        (("person1", "Male", 20, 80.52, False, 1)),
+        (("person2", "Female", 30, 40.88, True, 0)),
+        (("person3", "Male", 40, 20.73, True, 0)),
+        (("person4", "Female", 50, 100.99, False, 1)),
     ],
 )
 @pytest.mark.skipif(not is_container_running(), reason="The container is not running")


### PR DESCRIPTION
This PR extends the functionality of the `ElasticsearchIODataset` by adding support for consuming `tf.bool` data. Test cases have been included as well.
