### PR TITLE
Use --enable_platform_specific_config flag in bazelrc to specify macos specific rules in bazel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,8 +128,6 @@ jobs:
           bazel build \
             ${BAZEL_OPTIMIZATION} \
             --copt -Wunguarded-availability \
-            --copt -mmacosx-version-min=10.13 \
-            --linkopt -mmacosx-version-min=10.13 \
             --noshow_progress \
             --noshow_loading_progress \
             --verbose_failures \

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -101,12 +101,6 @@ def write_config():
                 'build --action_env TF_SHARED_LIBRARY_NAME="{}"\n'.format(library_name)
             )
             bazel_rc.write('build --cxxopt="-std=c++14"\n')
-            # Needed for GRPC build
-            if sys.platform == "darwin":
-                bazel_rc.write('build --copt="-DGRPC_BAZEL_BUILD"\n')
-            # Use llvm toolchain
-            if sys.platform == "darwin":
-                bazel_rc.write('build --crosstool_top=@llvm_toolchain//:toolchain"\n')
             for argv in sys.argv[1:]:
                 if argv == "--cuda":
                     bazel_rc.write('build --action_env TF_NEED_CUDA="1"\n')
@@ -118,6 +112,15 @@ def write_config():
                     )
                     bazel_rc.write('build --action_env TF_CUDA_VERSION="10.1"\n')
                     bazel_rc.write('build --action_env TF_CUDNN_VERSION="7"\n')
+            # Enable platform specific config
+            bazel_rc.write('build --enable_platform_specific_config\n')
+            # Use llvm toolchain
+            bazel_rc.write('build:macos --crosstool_top=@llvm_toolchain//:toolchain"\n')
+            # Needed for GRPC build
+            bazel_rc.write('build:macos --copt="-DGRPC_BAZEL_BUILD"\n')
+            # Stay with 10.13 for macOS
+            bazel_rc.write('build:macos --copt="-mmacosx-version-min=10.13"\n')
+            bazel_rc.write('build:macos --linkopt="-mmacosx-version-min=10.13"\n')
             bazel_rc.close()
     except OSError:
         print("ERROR: Writing .bazelrc")


### PR DESCRIPTION
Bazel has an option of --enable_platform_specific_config which allows specification of platform specific flags. The effect is that `bazel:macos`, `bazel:windows`, `bazel:linux` inside .bazelrc will be automatically picked up bazed on the platform. So rules specified for macos, windows, and linux can co-exist in .bazelrc.

This helps in avoiding specifying different .bazelrc files for different platforms.

This PR utilize this flag to simplify the bazelrc generation.

Also, on macos, `--copt="-mmacosx-version-min=10.13"` and `--linkopt="-mmacosx-version-min=10.13"` are specified by default so that local build and GitHub Actions build will remain the same.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>