### PR TITLE
Remove python 3.5 from build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -242,7 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -344,7 +344,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -421,10 +421,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: macOS-3.5-wheel
-          path: macOS-3.5-wheel
-      - uses: actions/download-artifact@v1
-        with:
           name: macOS-3.6-wheel
           path: macOS-3.6-wheel
       - uses: actions/download-artifact@v1
@@ -437,10 +433,6 @@ jobs:
           path: macOS-3.8-wheel
       - uses: actions/download-artifact@v1
         with:
-          name: Linux-3.5-wheel
-          path: Linux-3.5-wheel
-      - uses: actions/download-artifact@v1
-        with:
           name: Linux-3.6-wheel
           path: Linux-3.6-wheel
       - uses: actions/download-artifact@v1
@@ -451,10 +443,6 @@ jobs:
         with:
           name: Linux-3.8-wheel
           path: Linux-3.8-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.5-wheel
-          path: Windows-3.5-wheel
       - uses: actions/download-artifact@v1
         with:
           name: Windows-3.6-wheel
@@ -470,15 +458,12 @@ jobs:
       - run: |
           set -e -x
           mkdir -p wheelhouse
-          cp macOS-3.5-wheel/*.whl wheelhouse/
           cp macOS-3.6-wheel/*.whl wheelhouse/
           cp macOS-3.7-wheel/*.whl wheelhouse/
           cp macOS-3.8-wheel/*.whl wheelhouse/
-          cp Linux-3.5-wheel/*.whl wheelhouse/
           cp Linux-3.6-wheel/*.whl wheelhouse/
           cp Linux-3.7-wheel/*.whl wheelhouse/
           cp Linux-3.8-wheel/*.whl wheelhouse/
-          cp Windows-3.5-wheel/*.whl wheelhouse/
           cp Windows-3.6-wheel/*.whl wheelhouse/
           cp Windows-3.7-wheel/*.whl wheelhouse/
           cp Windows-3.8-wheel/*.whl wheelhouse/
@@ -527,7 +512,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -570,17 +555,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
-        python: ['3.5', '3.6', '3.7', '3.8']
-        exclude:
-          - os: ubuntu-16.04
-            python: '3.6'
-          - os: ubuntu-16.04
-            python: '3.7'
-          - os: ubuntu-16.04
-            python: '3.8'
-          - os: ubuntu-18.04
-            python: '3.5'
+        os: [ubuntu-18.04]
+        python: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -618,7 +594,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.5', '3.6', '3.7', 3.8]
+        python: ['3.6', '3.7', 3.8]
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -654,10 +630,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: macOS-3.5-nightly
-          path: macOS-3.5-nightly
-      - uses: actions/download-artifact@v1
-        with:
           name: macOS-3.6-nightly
           path: macOS-3.6-nightly
       - uses: actions/download-artifact@v1
@@ -670,10 +642,6 @@ jobs:
           path: macOS-3.8-nightly
       - uses: actions/download-artifact@v1
         with:
-          name: Linux-3.5-nightly
-          path: Linux-3.5-nightly
-      - uses: actions/download-artifact@v1
-        with:
           name: Linux-3.6-nightly
           path: Linux-3.6-nightly
       - uses: actions/download-artifact@v1
@@ -684,10 +652,6 @@ jobs:
         with:
           name: Linux-3.8-nightly
           path: Linux-3.8-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.5-nightly
-          path: Windows-3.5-nightly
       - uses: actions/download-artifact@v1
         with:
           name: Windows-3.6-nightly
@@ -703,15 +667,12 @@ jobs:
       - run: |
           set -e -x
           mkdir -p dist
-          cp macOS-3.5-nightly/*.whl dist/
           cp macOS-3.6-nightly/*.whl dist/
           cp macOS-3.7-nightly/*.whl dist/
           cp macOS-3.8-nightly/*.whl dist/
-          cp Linux-3.5-nightly/*.whl dist/
           cp Linux-3.6-nightly/*.whl dist/
           cp Linux-3.7-nightly/*.whl dist/
           cp Linux-3.8-nightly/*.whl dist/
-          cp Windows-3.5-nightly/*.whl dist/
           cp Windows-3.6-nightly/*.whl dist/
           cp Windows-3.7-nightly/*.whl dist/
           cp Windows-3.8-nightly/*.whl dist/


### PR DESCRIPTION
As TensorFlow dropped Python 3.5 support
(see https://groups.google.com/a/tensorflow.org/g/developers/c/Ip-UJMTXVx8),
This PR removes python 3.5 from our build and release.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>