### PR TITLE
[docker] push version specific tag during docker release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,6 +486,8 @@ jobs:
           docker login --username tfsigio --password ${{ secrets.DOCKER_PASSWORD }}
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           docker push tfsigio/tfio:latest
+          TFIO_VERSION=$(python setup.py --version)
+          docker push tfsigio/tfio:${TFIO_VERSION}
           bash -x -e tools/docker/tests/dockerfile_nightly_test.sh
           docker push tfsigio/tfio:nightly
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh


### PR DESCRIPTION
Currently, we push `latest`, `latest-devel` and `nightly` tags to the docker registry. However, we do not have a tag which captures the version of the release. This PR addresses the issue by tagging the images with version obtained from `setup.py`