### PR TITLE
[docker] incompatible python version fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,7 +486,7 @@ jobs:
           docker login --username tfsigio --password ${{ secrets.DOCKER_PASSWORD }}
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           docker push tfsigio/tfio:latest
-          TFIO_VERSION=$(python setup.py --version)
+          TFIO_VERSION=$(python3 setup.py --version)
           docker push tfsigio/tfio:${TFIO_VERSION}
           bash -x -e tools/docker/tests/dockerfile_nightly_test.sh
           docker push tfsigio/tfio:nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -481,12 +481,16 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
       - run: |
           set -e -x
           docker login --username tfsigio --password ${{ secrets.DOCKER_PASSWORD }}
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           docker push tfsigio/tfio:latest
-          TFIO_VERSION=$(python3 setup.py --version)
+          python --version
+          TFIO_VERSION=$(python setup.py --version)
           docker push tfsigio/tfio:${TFIO_VERSION}
           bash -x -e tools/docker/tests/dockerfile_nightly_test.sh
           docker push tfsigio/tfio:nightly


### PR DESCRIPTION
While capturing the tfio version from `setup.py`, github action throws the following error:
```
 python setup.py --version
Traceback (most recent call last):
  File "setup.py", line 97, in <module>
    with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
TypeError: 'encoding' is an invalid keyword argument for this function
```

This PR uses the latest python version in GH Action to handle the issue.