### PR TITLE
[docker] add version specific local tag before pushing to registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,6 +491,7 @@ jobs:
           docker push tfsigio/tfio:latest
           python --version
           TFIO_VERSION=$(python setup.py --version)
+          docker tag tfsigio/tfio:latest tfsigio/tfio:${TFIO_VERSION}
           docker push tfsigio/tfio:${TFIO_VERSION}
           bash -x -e tools/docker/tests/dockerfile_nightly_test.sh
           docker push tfsigio/tfio:nightly


### PR DESCRIPTION
This PR adds the missing local tag to the docker image before pushing to the registry.
Error from GH Action:

```
+ docker push tfsigio/tfio:0.15.0
The push refers to repository [docker.io/tfsigio/tfio]
tag does not exist: tfsigio/tfio:0.15.0
```