### PR TITLE
[kafka] improve verbosity while rebalancing consumers

### DIFF
--- a/tensorflow_io/core/kernels/kafka_kernels.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels.cc
@@ -786,8 +786,8 @@ class KafkaRebalanceCb : public RdKafka::RebalanceCb {
 
       LOG(INFO) << "REBALANCE: " << partitions[partition]->topic() << "["
                 << partitions[partition]->partition() << "], "
-                << partitions[partition]->offset() << " "
-                << partitions[partition]->err();
+                << "OFFSET: " << partitions[partition]->offset() << " "
+                << "ERROR_CODE: " << partitions[partition]->err();
     }
     if (err == RdKafka::ERR__ASSIGN_PARTITIONS) {
       // librdkafka does not actually look up the stored offsets before


### PR DESCRIPTION
This PR improves the log information while using the `KafkaGroupIODataset` and `KafkaBatchIODataset` by improving the verbosity of the message while rebalancing consumers. This prevents confusion and enables users to track offsets and error codes.

current log:
```console
REBALANCE: key-partition-test[0], 5 0
```

new log:
```console
REBALANCE: key-partition-test[0], OFFSET: 5 ERROR_CODE: 0
```