### PR TITLE
[notebooks] use tfio-nightly for kafka.ipynb

### DIFF
--- a/docs/tutorials/kafka.ipynb
+++ b/docs/tutorials/kafka.ipynb
@@ -103,7 +103,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install tensorflow-io\n",
+        "!pip install tensorflow-io-nightly\n",
         "!pip install kafka-python"
       ]
     },


### PR DESCRIPTION
Since the PR https://github.com/tensorflow/io/pull/1143 has been merged. The `tensorflow-io-nightly` packages now uses `tensorflow>=2.4.0rc0,<2.5.0`. 

This might address the issue tensorflow/tensorflow#38064 mentioned in comment https://github.com/tensorflow/io/issues/1156#issuecomment-721310833