### PR TITLE
Bump macOS support to 10.14

### DIFF
--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -118,9 +118,9 @@ def write_config():
             bazel_rc.write('build:macos --crosstool_top=@llvm_toolchain//:toolchain"\n')
             # Needed for GRPC build
             bazel_rc.write('build:macos --copt="-DGRPC_BAZEL_BUILD"\n')
-            # Stay with 10.13 for macOS
-            bazel_rc.write('build:macos --copt="-mmacosx-version-min=10.13"\n')
-            bazel_rc.write('build:macos --linkopt="-mmacosx-version-min=10.13"\n')
+            # Stay with 10.14 for macOS
+            bazel_rc.write('build:macos --copt="-mmacosx-version-min=10.14"\n')
+            bazel_rc.write('build:macos --linkopt="-mmacosx-version-min=10.14"\n')
             # MSVC (Windows): Standards-conformant preprocessor mode
             bazel_rc.write('build:windows --copt="/Zc:preprocessor"\n')
             bazel_rc.close()

--- a/tools/build/swift/BUILD
+++ b/tools/build/swift/BUILD
@@ -10,13 +10,13 @@ swift_library(
     ],
     copts = [
         "-target",
-        "x86_64-apple-macosx10.13",
+        "x86_64-apple-macosx10.14",
     ],
     linkopts = [
         "-L/usr/lib/swift",
         "-Wl,-rpath,/usr/lib/swift",
         "-target",
-        "x86_64-apple-macosx10.13",
+        "x86_64-apple-macosx10.14",
     ],
     module_name = "audio_video",
     alwayslink = True,


### PR DESCRIPTION
While building tensorflow-io on my macOS I noticed the following:
```
ld: warning: dylib (bazel-out/darwin-fastbuild/bin/_solib_darwin/_U@local_Uconfig_Utf_S_S_Clibtensorflow_Uframework___Uexternal_Slocal_Uconfig_Utf/libtensorflow_framework.so) was built for newer macOS version (10.14) than being linked (10.13)
```

This is caused by the fact that libtensorflow_framework.so (from TensorFlow)
is built against 10.14.

For that we will need to bump our build flag to only support 10.14+ as well.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>