### PR TITLE
[fs tests] refactor and extend test cases

### DIFF
--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -40,11 +40,11 @@ class AZFSTest(tf.test.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         super().setUp()
-        if not tf.io.gfile.IsDirectory(self.path_root):
-            tf.io.gfile.MakeDirs(self.path_root)
+        if not tf.io.gfile.isdir(self.path_root):
+            tf.io.gfile.makedirs(self.path_root)
 
     def test_exists(self):
-        self.assertTrue(tf.io.gfile.IsDirectory(self.path_root))
+        self.assertTrue(tf.io.gfile.isdir(self.path_root))
 
     def test_also_works_with_full_dns_name(self):
         """Test the file system also works when we're given
@@ -52,31 +52,31 @@ class AZFSTest(tf.test.TestCase):
         az://<account>.blob.core.windows.net/<container>/<path>
         """
         file_name = self.account + ".blob.core.windows.net" + self.container
-        if not tf.io.gfile.IsDirectory(file_name):
-            tf.io.gfile.MakeDirs(file_name)
+        if not tf.io.gfile.isdir(file_name):
+            tf.io.gfile.makedirs(file_name)
 
-        self.assertTrue(tf.io.gfile.IsDirectory(file_name))
+        self.assertTrue(tf.io.gfile.isdir(file_name))
 
     def test_create_file(self):
         """Test create file."""
         # Setup and check preconditions.
         file_name = self._path_to("testfile")
-        if tf.io.gfile.Exists(file_name):
-            tf.io.gfile.Remove(file_name)
+        if tf.io.gfile.exists(file_name):
+            tf.io.gfile.remove(file_name)
         # Create file.
         with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
         # Check that file was created.
-        self.assertTrue(tf.io.gfile.Exists(file_name))
+        self.assertTrue(tf.io.gfile.exists(file_name))
 
-        tf.io.gfile.Remove(file_name)
+        tf.io.gfile.remove(file_name)
 
     def test_write_read_file(self):
         """Test write/read file."""
         # Setup and check preconditions.
         file_name = self._path_to("writereadfile")
-        if tf.io.gfile.Exists(file_name):
-            tf.io.gfile.Remove(file_name)
+        if tf.io.gfile.exists(file_name):
+            tf.io.gfile.remove(file_name)
 
         # Write data.
         with tf.io.gfile.Open(file_name, "w") as w:
@@ -108,19 +108,19 @@ class AZFSTest(tf.test.TestCase):
         dir_name = self._path_to("recursive")
         file_name = self._path_to("recursive/1")
 
-        tf.io.gfile.MkDir(dir_name)
+        tf.io.gfile.mkdir(dir_name)
         with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
 
-        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
-        self.assertTrue(tf.io.gfile.Exists(file_name))
+        self.assertTrue(tf.io.gfile.isdir(dir_name))
+        self.assertTrue(tf.io.gfile.exists(file_name))
 
         # Delete directory recursively.
         tf.io.gfile.DeleteRecursively(dir_name)
 
         # Check that directory was deleted.
-        self.assertFalse(tf.io.gfile.Exists(dir_name))
-        self.assertFalse(tf.io.gfile.Exists(file_name))
+        self.assertFalse(tf.io.gfile.exists(dir_name))
+        self.assertFalse(tf.io.gfile.exists(file_name))
 
     def test_is_directory(self):
         """Test is directory."""
@@ -129,11 +129,11 @@ class AZFSTest(tf.test.TestCase):
         file_name = self._path_to("isdir/2")
         with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
-        tf.io.gfile.MkDir(dir_name)
+        tf.io.gfile.mkdir(dir_name)
         # Check that directory is a directory.
-        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
+        self.assertTrue(tf.io.gfile.isdir(dir_name))
         # Check that file is not a directory.
-        self.assertFalse(tf.io.gfile.IsDirectory(file_name))
+        self.assertFalse(tf.io.gfile.isdir(file_name))
 
     def test_list_directory(self):
         """Test list directory."""
@@ -145,7 +145,7 @@ class AZFSTest(tf.test.TestCase):
             with tf.io.gfile.Open(file_name, "w") as w:
                 w.write("")
         # Get list of files in directory.
-        ls_result = tf.io.gfile.ListDirectory(dir_name)
+        ls_result = tf.io.gfile.listdir(dir_name)
         # Check that list of files is correct.
         self.assertEqual(len(file_names), len(ls_result))
         for e in ["1", "2", "3"]:
@@ -156,26 +156,26 @@ class AZFSTest(tf.test.TestCase):
         # Setup and check preconditions.
         dir_name = self.path_root
         # Make directory.
-        tf.io.gfile.MkDir(dir_name)
+        tf.io.gfile.mkdir(dir_name)
         # Check that directory was created.
-        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
+        self.assertTrue(tf.io.gfile.isdir(dir_name))
 
         dir_name = self._path_to("test/directory")
-        tf.io.gfile.MkDir(dir_name)
-        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
+        tf.io.gfile.mkdir(dir_name)
+        self.assertTrue(tf.io.gfile.isdir(dir_name))
 
     def test_remove(self):
         """Test remove."""
         # Setup and check preconditions.
         file_name = self._path_to("1")
-        self.assertFalse(tf.io.gfile.Exists(file_name))
+        self.assertFalse(tf.io.gfile.exists(file_name))
         with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
-        self.assertTrue(tf.io.gfile.Exists(file_name))
+        self.assertTrue(tf.io.gfile.exists(file_name))
         # Remove file.
-        tf.io.gfile.Remove(file_name)
+        tf.io.gfile.remove(file_name)
         # Check that file was removed.
-        self.assertFalse(tf.io.gfile.Exists(file_name))
+        self.assertFalse(tf.io.gfile.exists(file_name))
 
     def _test_read_file_offset_and_dataset(self):
         """Test read file with dataset"""
@@ -183,8 +183,8 @@ class AZFSTest(tf.test.TestCase):
         # all moved to eager mode
         # Setup and check preconditions.
         file_name = self._path_to("readfiledataset")
-        if tf.io.gfile.Exists(file_name):
-            tf.io.gfile.Remove(file_name)
+        if tf.io.gfile.exists(file_name):
+            tf.io.gfile.remove(file_name)
 
         # Write data.
         with tf.io.gfile.Open(file_name, "w") as w:

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -26,9 +26,9 @@ import tensorflow_io as tfio  # pylint: disable=unused-import
 class AZFSTest(test.TestCase):
     """[summary]
 
-  Arguments:
-    test {[type]} -- [description]
-  """
+    Arguments:
+      test {[type]} -- [description]
+    """
 
     def __init__(self, methodName="runTest"):  # pylint: disable=invalid-name
         self.account = "devstoreaccount1"
@@ -49,9 +49,9 @@ class AZFSTest(test.TestCase):
 
     def test_also_works_with_full_dns_name(self):
         """Test the file system also works when we're given
-       a path of the form
-       az://<account>.blob.core.windows.net/<container>/<path>
-    """
+        a path of the form
+        az://<account>.blob.core.windows.net/<container>/<path>
+        """
         file_name = self.account + ".blob.core.windows.net" + self.container
         if not gfile.IsDirectory(file_name):
             gfile.MakeDirs(file_name)
@@ -59,8 +59,7 @@ class AZFSTest(test.TestCase):
         self.assertTrue(gfile.IsDirectory(file_name))
 
     def test_create_file(self):
-        """Test create file.
-    """
+        """Test create file."""
         # Setup and check preconditions.
         file_name = self._path_to("testfile")
         if gfile.Exists(file_name):
@@ -74,8 +73,7 @@ class AZFSTest(test.TestCase):
         gfile.Remove(file_name)
 
     def test_write_read_file(self):
-        """Test write/read file.
-    """
+        """Test write/read file."""
         # Setup and check preconditions.
         file_name = self._path_to("writereadfile")
         if gfile.Exists(file_name):
@@ -106,8 +104,7 @@ class AZFSTest(test.TestCase):
         gfile.DeleteRecursively(self._path_to("wildcard"))
 
     def test_delete_recursively(self):
-        """Test delete recursively.
-    """
+        """Test delete recursively."""
         # Setup and check preconditions.
         dir_name = self._path_to("recursive")
         file_name = self._path_to("recursive/1")
@@ -127,9 +124,7 @@ class AZFSTest(test.TestCase):
         self.assertFalse(gfile.Exists(file_name))
 
     def test_is_directory(self):
-        """Test is directory.
-
-    """
+        """Test is directory."""
         # Setup and check preconditions.
         dir_name = self._path_to("isdir/1")
         file_name = self._path_to("isdir/2")
@@ -142,9 +137,7 @@ class AZFSTest(test.TestCase):
         self.assertFalse(gfile.IsDirectory(file_name))
 
     def test_list_directory(self):
-        """Test list directory.
-
-    """
+        """Test list directory."""
         # Setup and check preconditions.
         dir_name = self._path_to("listdir")
         file_names = [self._path_to("listdir/{}".format(i)) for i in range(1, 4)]
@@ -160,8 +153,7 @@ class AZFSTest(test.TestCase):
             self.assertTrue(e in ls_result)
 
     def test_make_dirs(self):
-        """Test make dirs.
-    """
+        """Test make dirs."""
         # Setup and check preconditions.
         dir_name = self.path_root
         # Make directory.
@@ -174,8 +166,7 @@ class AZFSTest(test.TestCase):
         self.assertTrue(gfile.IsDirectory(dir_name))
 
     def test_remove(self):
-        """Test remove.
-    """
+        """Test remove."""
         # Setup and check preconditions.
         file_name = self._path_to("1")
         self.assertFalse(gfile.Exists(file_name))
@@ -188,8 +179,7 @@ class AZFSTest(test.TestCase):
         self.assertFalse(gfile.Exists(file_name))
 
     def _test_read_file_offset_and_dataset(self):
-        """Test read file with dataset
-    """
+        """Test read file with dataset"""
         # Note: disabled for now. Will enable once
         # all moved to eager mode
         # Setup and check preconditions.

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -64,7 +64,7 @@ class AZFSTest(tf.test.TestCase):
         if tf.io.gfile.exists(file_name):
             tf.io.gfile.remove(file_name)
         # Create file.
-        with tf.io.gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.GFile(file_name, "w") as w:
             w.write("")
         # Check that file was created.
         self.assertTrue(tf.io.gfile.exists(file_name))
@@ -79,11 +79,11 @@ class AZFSTest(tf.test.TestCase):
             tf.io.gfile.remove(file_name)
 
         # Write data.
-        with tf.io.gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.GFile(file_name, "w") as w:
             w.write("Hello\n, world!")
 
         # Read data.
-        with tf.io.gfile.Open(file_name, "r") as r:
+        with tf.io.gfile.GFile(file_name, "r") as r:
             file_read = r.read()
             self.assertEqual(file_read, "Hello\n, world!")
 
@@ -92,15 +92,15 @@ class AZFSTest(tf.test.TestCase):
         for ext in [".txt", ".md"]:
             for i in range(3):
                 file_path = self._path_to("wildcard/{}{}".format(i, ext))
-                with tf.io.gfile.Open(file_path, "w") as f:
+                with tf.io.gfile.GFile(file_path, "w") as f:
                     f.write("")
 
-        txt_files = tf.io.gfile.Glob(self._path_to("wildcard/*.txt"))
+        txt_files = tf.io.gfile.glob(self._path_to("wildcard/*.txt"))
         self.assertEqual(3, len(txt_files))
         for i, name in enumerate(txt_files):
             self.assertEqual(self._path_to("wildcard/{}.txt".format(i)), name)
 
-        tf.io.gfile.DeleteRecursively(self._path_to("wildcard"))
+        tf.io.gfile.rmtree(self._path_to("wildcard"))
 
     def test_delete_recursively(self):
         """Test delete recursively."""
@@ -109,14 +109,14 @@ class AZFSTest(tf.test.TestCase):
         file_name = self._path_to("recursive/1")
 
         tf.io.gfile.mkdir(dir_name)
-        with tf.io.gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.GFile(file_name, "w") as w:
             w.write("")
 
         self.assertTrue(tf.io.gfile.isdir(dir_name))
         self.assertTrue(tf.io.gfile.exists(file_name))
 
         # Delete directory recursively.
-        tf.io.gfile.DeleteRecursively(dir_name)
+        tf.io.gfile.rmtree(dir_name)
 
         # Check that directory was deleted.
         self.assertFalse(tf.io.gfile.exists(dir_name))
@@ -127,7 +127,7 @@ class AZFSTest(tf.test.TestCase):
         # Setup and check preconditions.
         dir_name = self._path_to("isdir/1")
         file_name = self._path_to("isdir/2")
-        with tf.io.gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.GFile(file_name, "w") as w:
             w.write("")
         tf.io.gfile.mkdir(dir_name)
         # Check that directory is a directory.
@@ -142,7 +142,7 @@ class AZFSTest(tf.test.TestCase):
         file_names = [self._path_to("listdir/{}".format(i)) for i in range(1, 4)]
 
         for file_name in file_names:
-            with tf.io.gfile.Open(file_name, "w") as w:
+            with tf.io.gfile.GFile(file_name, "w") as w:
                 w.write("")
         # Get list of files in directory.
         ls_result = tf.io.gfile.listdir(dir_name)
@@ -169,7 +169,7 @@ class AZFSTest(tf.test.TestCase):
         # Setup and check preconditions.
         file_name = self._path_to("1")
         self.assertFalse(tf.io.gfile.exists(file_name))
-        with tf.io.gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.GFile(file_name, "w") as w:
             w.write("")
         self.assertTrue(tf.io.gfile.exists(file_name))
         # Remove file.
@@ -187,7 +187,7 @@ class AZFSTest(tf.test.TestCase):
             tf.io.gfile.remove(file_name)
 
         # Write data.
-        with tf.io.gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.GFile(file_name, "w") as w:
             w.write("Hello1,world1!\nHello2,world2!")
         dataset = tf.data.experimental.CsvDataset(file_name, [tf.string, tf.string])
         expected = [[b"Hello1", b"world1!"], [b"Hello2", b"world2!"]]

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -16,7 +16,7 @@
 
 import os
 
-from tensorflow.python.platform import test
+from tensorflow import test
 from tensorflow.python.platform import gfile
 import tensorflow_io as tfio  # pylint: disable=unused-import
 

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -16,14 +16,13 @@
 
 import os
 
-from tensorflow import test
-from tensorflow.python.platform import gfile
+import tensorflow as tf
 import tensorflow_io as tfio  # pylint: disable=unused-import
 
 # Note: export TF_AZURE_USE_DEV_STORAGE=1 to enable emulation
 
 
-class AZFSTest(test.TestCase):
+class AZFSTest(tf.test.TestCase):
     """[summary]
 
     Arguments:
@@ -41,11 +40,11 @@ class AZFSTest(test.TestCase):
 
     def setUp(self):  # pylint: disable=invalid-name
         super().setUp()
-        if not gfile.IsDirectory(self.path_root):
-            gfile.MakeDirs(self.path_root)
+        if not tf.io.gfile.IsDirectory(self.path_root):
+            tf.io.gfile.MakeDirs(self.path_root)
 
     def test_exists(self):
-        self.assertTrue(gfile.IsDirectory(self.path_root))
+        self.assertTrue(tf.io.gfile.IsDirectory(self.path_root))
 
     def test_also_works_with_full_dns_name(self):
         """Test the file system also works when we're given
@@ -53,38 +52,38 @@ class AZFSTest(test.TestCase):
         az://<account>.blob.core.windows.net/<container>/<path>
         """
         file_name = self.account + ".blob.core.windows.net" + self.container
-        if not gfile.IsDirectory(file_name):
-            gfile.MakeDirs(file_name)
+        if not tf.io.gfile.IsDirectory(file_name):
+            tf.io.gfile.MakeDirs(file_name)
 
-        self.assertTrue(gfile.IsDirectory(file_name))
+        self.assertTrue(tf.io.gfile.IsDirectory(file_name))
 
     def test_create_file(self):
         """Test create file."""
         # Setup and check preconditions.
         file_name = self._path_to("testfile")
-        if gfile.Exists(file_name):
-            gfile.Remove(file_name)
+        if tf.io.gfile.Exists(file_name):
+            tf.io.gfile.Remove(file_name)
         # Create file.
-        with gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
         # Check that file was created.
-        self.assertTrue(gfile.Exists(file_name))
+        self.assertTrue(tf.io.gfile.Exists(file_name))
 
-        gfile.Remove(file_name)
+        tf.io.gfile.Remove(file_name)
 
     def test_write_read_file(self):
         """Test write/read file."""
         # Setup and check preconditions.
         file_name = self._path_to("writereadfile")
-        if gfile.Exists(file_name):
-            gfile.Remove(file_name)
+        if tf.io.gfile.Exists(file_name):
+            tf.io.gfile.Remove(file_name)
 
         # Write data.
-        with gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.Open(file_name, "w") as w:
             w.write("Hello\n, world!")
 
         # Read data.
-        with gfile.Open(file_name, "r") as r:
+        with tf.io.gfile.Open(file_name, "r") as r:
             file_read = r.read()
             self.assertEqual(file_read, "Hello\n, world!")
 
@@ -93,15 +92,15 @@ class AZFSTest(test.TestCase):
         for ext in [".txt", ".md"]:
             for i in range(3):
                 file_path = self._path_to("wildcard/{}{}".format(i, ext))
-                with gfile.Open(file_path, "w") as f:
+                with tf.io.gfile.Open(file_path, "w") as f:
                     f.write("")
 
-        txt_files = gfile.Glob(self._path_to("wildcard/*.txt"))
+        txt_files = tf.io.gfile.Glob(self._path_to("wildcard/*.txt"))
         self.assertEqual(3, len(txt_files))
         for i, name in enumerate(txt_files):
             self.assertEqual(self._path_to("wildcard/{}.txt".format(i)), name)
 
-        gfile.DeleteRecursively(self._path_to("wildcard"))
+        tf.io.gfile.DeleteRecursively(self._path_to("wildcard"))
 
     def test_delete_recursively(self):
         """Test delete recursively."""
@@ -109,32 +108,32 @@ class AZFSTest(test.TestCase):
         dir_name = self._path_to("recursive")
         file_name = self._path_to("recursive/1")
 
-        gfile.MkDir(dir_name)
-        with gfile.Open(file_name, "w") as w:
+        tf.io.gfile.MkDir(dir_name)
+        with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
 
-        self.assertTrue(gfile.IsDirectory(dir_name))
-        self.assertTrue(gfile.Exists(file_name))
+        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
+        self.assertTrue(tf.io.gfile.Exists(file_name))
 
         # Delete directory recursively.
-        gfile.DeleteRecursively(dir_name)
+        tf.io.gfile.DeleteRecursively(dir_name)
 
         # Check that directory was deleted.
-        self.assertFalse(gfile.Exists(dir_name))
-        self.assertFalse(gfile.Exists(file_name))
+        self.assertFalse(tf.io.gfile.Exists(dir_name))
+        self.assertFalse(tf.io.gfile.Exists(file_name))
 
     def test_is_directory(self):
         """Test is directory."""
         # Setup and check preconditions.
         dir_name = self._path_to("isdir/1")
         file_name = self._path_to("isdir/2")
-        with gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
-        gfile.MkDir(dir_name)
+        tf.io.gfile.MkDir(dir_name)
         # Check that directory is a directory.
-        self.assertTrue(gfile.IsDirectory(dir_name))
+        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
         # Check that file is not a directory.
-        self.assertFalse(gfile.IsDirectory(file_name))
+        self.assertFalse(tf.io.gfile.IsDirectory(file_name))
 
     def test_list_directory(self):
         """Test list directory."""
@@ -143,10 +142,10 @@ class AZFSTest(test.TestCase):
         file_names = [self._path_to("listdir/{}".format(i)) for i in range(1, 4)]
 
         for file_name in file_names:
-            with gfile.Open(file_name, "w") as w:
+            with tf.io.gfile.Open(file_name, "w") as w:
                 w.write("")
         # Get list of files in directory.
-        ls_result = gfile.ListDirectory(dir_name)
+        ls_result = tf.io.gfile.ListDirectory(dir_name)
         # Check that list of files is correct.
         self.assertEqual(len(file_names), len(ls_result))
         for e in ["1", "2", "3"]:
@@ -157,26 +156,26 @@ class AZFSTest(test.TestCase):
         # Setup and check preconditions.
         dir_name = self.path_root
         # Make directory.
-        gfile.MkDir(dir_name)
+        tf.io.gfile.MkDir(dir_name)
         # Check that directory was created.
-        self.assertTrue(gfile.IsDirectory(dir_name))
+        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
 
         dir_name = self._path_to("test/directory")
-        gfile.MkDir(dir_name)
-        self.assertTrue(gfile.IsDirectory(dir_name))
+        tf.io.gfile.MkDir(dir_name)
+        self.assertTrue(tf.io.gfile.IsDirectory(dir_name))
 
     def test_remove(self):
         """Test remove."""
         # Setup and check preconditions.
         file_name = self._path_to("1")
-        self.assertFalse(gfile.Exists(file_name))
-        with gfile.Open(file_name, "w") as w:
+        self.assertFalse(tf.io.gfile.Exists(file_name))
+        with tf.io.gfile.Open(file_name, "w") as w:
             w.write("")
-        self.assertTrue(gfile.Exists(file_name))
+        self.assertTrue(tf.io.gfile.Exists(file_name))
         # Remove file.
-        gfile.Remove(file_name)
+        tf.io.gfile.Remove(file_name)
         # Check that file was removed.
-        self.assertFalse(gfile.Exists(file_name))
+        self.assertFalse(tf.io.gfile.Exists(file_name))
 
     def _test_read_file_offset_and_dataset(self):
         """Test read file with dataset"""
@@ -184,11 +183,11 @@ class AZFSTest(test.TestCase):
         # all moved to eager mode
         # Setup and check preconditions.
         file_name = self._path_to("readfiledataset")
-        if gfile.Exists(file_name):
-            gfile.Remove(file_name)
+        if tf.io.gfile.Exists(file_name):
+            tf.io.gfile.Remove(file_name)
 
         # Write data.
-        with gfile.Open(file_name, "w") as w:
+        with tf.io.gfile.Open(file_name, "w") as w:
             w.write("Hello1,world1!\nHello2,world2!")
         dataset = tf.data.experimental.CsvDataset(file_name, [tf.string, tf.string])
         expected = [[b"Hello1", b"world1!"], [b"Hello2", b"world2!"]]
@@ -202,4 +201,4 @@ class AZFSTest(test.TestCase):
 
 
 if __name__ == "__main__":
-    test.main()
+    tf.test.main()

--- a/tests/test_http_eager.py
+++ b/tests/test_http_eager.py
@@ -15,7 +15,7 @@
 """Tests for HTTP file system"""
 
 import os
-from tensorflow.python.platform import test
+from tensorflow import test
 import tensorflow as tf
 import tensorflow_io as tfio  # pylint: disable=unused-import
 

--- a/tests/test_http_eager.py
+++ b/tests/test_http_eager.py
@@ -15,38 +15,72 @@
 """Tests for HTTP file system"""
 
 import os
-
+from tensorflow.python.platform import test
 import tensorflow as tf
 import tensorflow_io as tfio  # pylint: disable=unused-import
 
 
-def test_http_file_system():
-    """Test case for http file system"""
-    local_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "test_http", "LICENSE-2.0.txt"
-    )
-    with open(local_path) as f:
-        lines = list(f)
-    local = "".join(lines)
+class HTTPFSTest(test.TestCase):
+    """TestCase class to test the HTTP file system plugins
+    functionality.
+    """
 
-    filename = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-    remote = tf.io.read_file(filename)
+    def __init__(self, methodName="runTest"):  # pylint: disable=invalid-name
+        self.local_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "test_http", "LICENSE-2.0.txt"
+        )
+        self.remote_filename = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        super().__init__(methodName)
 
-    assert remote == local
+    def setUp(self):  # pylint: disable=invalid-name
+        with open(self.local_path) as f:
+            self.local_lines = list(f)
+        self.local_content = "".join(self.local_lines)
+        super().setUp()
 
-    dataset = tf.data.TextLineDataset(filename)
-    i = 0
-    for d in dataset:
-        assert d == lines[i].rstrip()
-        i += 1
-    assert i == len(lines)
+    def test_read_remote_file(self):
+        """Test case for reading the entire content of the http file"""
 
-    remote = tf.io.gfile.GFile(filename)
-    assert remote.size() == len(local)
-    offset_start = list(range(0, len(local), 100))
-    offset_stop = offset_start[1:] + [len(local)]
-    for (start, stop) in zip(offset_start, offset_stop):
-        assert remote.read(100) == local[start:stop]
+        remote_content = tf.io.read_file(self.remote_filename)
+
+        assert remote_content == self.local_content
+
+    def test_dataset_from_remote_filename(self):
+        """Test case to prepare a tf.data Dataset from a remote http file"""
+
+        dataset = tf.data.TextLineDataset(self.remote_filename)
+        i = 0
+        for d in dataset:
+            assert d == self.local_lines[i].rstrip()
+            i += 1
+        assert i == len(self.local_lines)
+
+    def test_gfile_read(self):
+        """Test case to read chunks of content from the http file"""
+
+        remote_gfile = tf.io.gfile.GFile(self.remote_filename)
+        assert remote_gfile.size() == len(self.local_content)
+        offset_start = list(range(0, len(self.local_content), 100))
+        offset_stop = offset_start[1:] + [len(self.local_content)]
+        for (start, stop) in zip(offset_start, offset_stop):
+            assert remote_gfile.read(100) == self.local_content[start:stop]
+
+    def test_gfile_seek(self):
+        """Test case to seek an offset after reading the content from the http file"""
+
+        remote_gfile = tf.io.gfile.GFile(self.remote_filename)
+        assert remote_gfile.read() == self.local_content
+        assert remote_gfile.read() == ""
+        remote_gfile.seek(0)
+        assert remote_gfile.read() == self.local_content
+
+    def test_gfile_tell(self):
+        """Test case to tell the current position in the http file"""
+
+        remote_gfile = tf.io.gfile.GFile(self.remote_filename)
+        assert remote_gfile.tell() == 0
+        remote_gfile.read(100)
+        assert remote_gfile.tell() == 100
 
 
 if __name__ == "__main__":

--- a/tests/test_http_eager.py
+++ b/tests/test_http_eager.py
@@ -15,12 +15,11 @@
 """Tests for HTTP file system"""
 
 import os
-from tensorflow import test
 import tensorflow as tf
 import tensorflow_io as tfio  # pylint: disable=unused-import
 
 
-class HTTPFSTest(test.TestCase):
+class HTTPFSTest(tf.test.TestCase):
     """TestCase class to test the HTTP file system plugins
     functionality.
     """
@@ -84,4 +83,4 @@ class HTTPFSTest(test.TestCase):
 
 
 if __name__ == "__main__":
-    test.main()
+    tf.test.main()


### PR DESCRIPTION
This PR:
- Refactors and extends the test cases for the HTTP File System related functionality.
- Fixes the docstrings for the AZFS test cases.
- Switches to compatible tf public api's for AZFS and HTTP FS tests.