### PR TITLE
Re-enable AWS Localstack emulator and add a s3 stub test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
         python: ['3.6', '3.7']
     steps:
       - uses: actions/checkout@v2
-      - uses: docker-practice/actions-setup-docker@master
+      - uses: docker-practice/actions-setup-docker@v1
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
         python: ['3.6', '3.7']
     steps:
       - uses: actions/checkout@v2
+      - uses: docker-practice/actions-setup-docker@master
       - uses: actions/download-artifact@v1
         with:
           name: ${{ runner.os }}-${{ matrix.python }}-wheel
@@ -196,9 +197,11 @@ jobs:
       - name: Setup ${{ matrix.python }} macOS
         run: |
           set -x -e
+          docker version
           bash -x -e tests/test_kafka/kafka_test.sh
           bash -x -e tests/test_azure/start_azure.sh
           bash -x -e tests/test_pubsub/pubsub_test.sh
+          bash -x -e tests/test_aws/aws_test.sh
       - name: Install ${{ matrix.python }} macOS
         run: |
           set -x -e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
           set -x -e
           bash -x -e .github/workflows/build.space.sh
           bash -x -e tests/test_kafka/kafka_test.sh
-          bash -x -e tests/test_kinesis/kinesis_test.sh
+          bash -x -e tests/test_aws/aws_test.sh
           bash -x -e tests/test_pubsub/pubsub_test.sh
           bash -x -e tests/test_prometheus/prometheus_test.sh start
           bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start

--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -73,7 +73,7 @@ ls wheelhouse/*
 ## Set test services
 bash -x -e tests/test_ignite/start_ignite.sh
 bash -x -e tests/test_kafka/kafka_test.sh
-bash -x -e tests/test_kinesis/kinesis_test.sh kinesis
+bash -x -e tests/test_aws/aws_test.sh
 bash -x -e tests/test_pubsub/pubsub_test.sh pubsub
 bash -x -e tests/test_prometheus/prometheus_test.sh start
 bash -x -e tests/test_azure/start_azure.sh

--- a/tests/test_aws/aws_test.sh
+++ b/tests/test_aws/aws_test.sh
@@ -17,25 +17,10 @@
 set -e
 set -o pipefail
 
-if [ "$#" -eq 1 ]; then
-  container=$1
-  echo pull localstack/localstack:0.8.10
-  docker pull localstack/localstack:0.8.10
-  echo pull localstack/localstack:0.8.10 successfully
-  docker run -d --rm -p 4568:4568 --name=$container localstack/localstack:0.8.10
-  echo Container $container started successfully
-
-  exit 0
-fi
-
-if [[ $(uname) == "Darwin" ]]; then
-    pip install -q --user localstack
-    $HOME/Library/Python/2.7/bin/localstack start --host &
-else
-    sudo apt-get install -y -qq python-dev libsasl2-dev gcc
-    python -m pip install --user -U pip
-    python -m pip install --user -U setuptools wheel
-    python -m pip install --user localstack
-    $HOME/.local/bin/localstack start --host &
-fi
+LOCALSTACK_VERSION=0.12.2
+docker pull localstack/localstack:$LOCALSTACK_VERSION
+docker run -d --rm --net=host --name=tensorflow-io-aws localstack/localstack:$LOCALSTACK_VERSION
+echo "Waiting for 10 secs until localstack is up and running"
+sleep 10
+echo "Localstack up"
 exit 0

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -312,10 +312,10 @@ def fixture_kinesis(request):
     os.environ["AWS_ACCESS_KEY_ID"] = "ACCESS_KEY"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "SECRET_KEY"
     os.environ["KINESIS_USE_HTTPS"] = "0"
-    os.environ["KINESIS_ENDPOINT"] = "localhost:4568"
+    os.environ["KINESIS_ENDPOINT"] = "localhost:4566"
 
     client = boto3.client(
-        "kinesis", region_name="us-east-1", endpoint_url="http://localhost:4568"
+        "kinesis", region_name="us-east-1", endpoint_url="http://localhost:4566"
     )
 
     # Setup the Kinesis with 1 shard.
@@ -1052,7 +1052,15 @@ def fixture_video_mp4():
                 ),
             ],
         ),
-        pytest.param("kinesis", marks=[pytest.mark.skip(reason="TODO")],),
+        pytest.param(
+            "kinesis",
+            marks=[
+                pytest.mark.skipif(
+                    sys.platform in ("win32", "darwin"),
+                    reason="TODO Localstack not setup properly on macOS/Windows yet",
+                ),
+            ],
+        ),
         pytest.param("pubsub"),
         pytest.param("hdf5"),
         pytest.param("grpc"),

--- a/tests/test_s3_eager.py
+++ b/tests/test_s3_eager.py
@@ -22,12 +22,11 @@ import tensorflow as tf
 import tensorflow_io as tfio
 import pytest
 
-pytest.mark.skipif(
+
+@pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),
     reason="TODO Localstack not setup properly on macOS/Windows yet",
-),
-
-
+)
 def test_read_file():
     """Test case for reading S3"""
     import boto3

--- a/tests/test_s3_eager.py
+++ b/tests/test_s3_eager.py
@@ -1,0 +1,62 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for S3 file system"""
+
+import os
+import sys
+import time
+import tempfile
+import tensorflow as tf
+import tensorflow_io as tfio
+import pytest
+
+pytest.mark.skipif(
+    sys.platform in ("win32", "darwin"),
+    reason="TODO Localstack not setup properly on macOS/Windows yet",
+),
+
+
+def test_read_file():
+    """Test case for reading S3"""
+    import boto3
+
+    os.environ["AWS_REGION"] = "us-east-1"
+    os.environ["AWS_ACCESS_KEY_ID"] = "ACCESS_KEY"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "SECRET_KEY"
+
+    client = boto3.client(
+        "s3", region_name="us-east-1", endpoint_url="http://localhost:4566"
+    )
+
+    body = b"1234567"
+
+    # Setup the S3 bucket and key
+    key_name = "TEST"
+    bucket_name = "s3e{}e".format(time.time())
+
+    client.create_bucket(Bucket=bucket_name)
+    client.put_object(Bucket=bucket_name, Key=key_name, Body=body)
+
+    response = client.get_object(Bucket=bucket_name, Key=key_name)
+    assert response["Body"].read() == body
+
+    os.environ["S3_ENDPOINT"] = "localhost:4566"
+    os.environ["S3_USE_HTTPS"] = "0"
+    os.environ["S3_VERIFY_SSL"] = "0"
+
+    # TODO: The following is not working yet, need update to use
+    # s3 implementation with module file system
+    content = tf.io.read_file("s3://{}/{}".format(bucket_name, key_name))
+    # assert content == body


### PR DESCRIPTION
The AWS Localstack setup was disabled at one point due to the API endpoint port change in Localstack (4568 => 4566).

Now as we are looking into AWS S3 file systems, this PR re-enables localstack setup so that we can test AWS services through this emulator.

This PR also add a stub s3 test case so that we can continue working on s3 file system.

This PR is a prerequisite of #1183.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>