### PR TITLE
Migrated curl_http_request.[h|cc] so that HTTP file system to not depends on TensorFlow C++ API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,6 +409,7 @@ jobs:
           (python -m pytest -s -v test_image_eager.py -k "webp or ppm or bmp or bounding or exif or hdr or openexr or tiff or avif")
           (python -m pytest -s -v test_serialization_eager.py)
           (python -m pytest -s -v test_io_dataset_eager.py -k "numpy or hdf5 or audio or to_file")
+          (python -m pytest -s -v test_http_eager.py)
           python -m pip install google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
           (python -m pytest -s -v test_bigquery_eager.py)
           (python -m pytest -s -v test_dicom_eager.py)

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -590,6 +590,8 @@ cc_library(
     deps = [
         "@com_github_azure_azure_storage_cpplite//:azure",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
         "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_header_lib",
     ],

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -579,12 +579,8 @@ cc_library(
         "kernels/azfs_kernels.cc",
         "kernels/file_system_plugins.cc",
         "kernels/file_system_plugins.h",
-    ] + select({
-        "@bazel_tools//src/conditions:windows": [],
-        "//conditions:default": [
-            "kernels/http_kernels.cc",
-        ],
-    }),
+        "kernels/http_kernels.cc",
+    ],
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [

--- a/tensorflow_io/core/kernels/file_system_plugins.cc
+++ b/tensorflow_io/core/kernels/file_system_plugins.cc
@@ -18,16 +18,10 @@ limitations under the License.
 void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
   info->plugin_memory_allocate = tensorflow::io::plugin_memory_allocate;
   info->plugin_memory_free = tensorflow::io::plugin_memory_free;
-#if !defined(_MSC_VER)
   info->num_schemes = 2;
-#else
-  info->num_schemes = 1;
-#endif
   info->ops = static_cast<TF_FilesystemPluginOps*>(
       tensorflow::io::plugin_memory_allocate(info->num_schemes *
                                              sizeof(info->ops[0])));
   tensorflow::io::az::ProvideFilesystemSupportFor(&info->ops[0], "az");
-#if !defined(_MSC_VER)
   tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[1], "http");
-#endif
 }

--- a/tensorflow_io/core/kernels/http_kernels.cc
+++ b/tensorflow_io/core/kernels/http_kernels.cc
@@ -125,7 +125,7 @@ uint64_t Length(const TF_ReadOnlyMemoryRegion* region) { return 0; }
 
 // SECTION 4. Implementation for `TF_Filesystem`, the actual filesystem
 // ----------------------------------------------------------------------------
-namespace tf_azfs_filesystem {
+namespace tf_http_filesystem {
 
 static void Init(TF_Filesystem* filesystem, TF_Status* status) {
   TF_SetStatus(status, TF_OK, "");
@@ -275,7 +275,7 @@ static char* TranslateName(const TF_Filesystem* filesystem, const char* uri) {
   return strdup(uri);
 }
 
-}  // namespace tf_azfs_filesystem
+}  // namespace tf_http_filesystem
 
 }  // namespace
 
@@ -306,30 +306,30 @@ void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops, const char* uri) {
 
   ops->filesystem_ops = static_cast<TF_FilesystemOps*>(
       plugin_memory_allocate(TF_FILESYSTEM_OPS_SIZE));
-  ops->filesystem_ops->init = tf_azfs_filesystem::Init;
-  ops->filesystem_ops->cleanup = tf_azfs_filesystem::Cleanup;
+  ops->filesystem_ops->init = tf_http_filesystem::Init;
+  ops->filesystem_ops->cleanup = tf_http_filesystem::Cleanup;
   ops->filesystem_ops->new_random_access_file =
-      tf_azfs_filesystem::NewRandomAccessFile;
-  ops->filesystem_ops->new_writable_file = tf_azfs_filesystem::NewWritableFile;
+      tf_http_filesystem::NewRandomAccessFile;
+  ops->filesystem_ops->new_writable_file = tf_http_filesystem::NewWritableFile;
   ops->filesystem_ops->new_appendable_file =
-      tf_azfs_filesystem::NewAppendableFile;
+      tf_http_filesystem::NewAppendableFile;
   ops->filesystem_ops->new_read_only_memory_region_from_file =
-      tf_azfs_filesystem::NewReadOnlyMemoryRegionFromFile;
-  ops->filesystem_ops->create_dir = tf_azfs_filesystem::CreateDir;
+      tf_http_filesystem::NewReadOnlyMemoryRegionFromFile;
+  ops->filesystem_ops->create_dir = tf_http_filesystem::CreateDir;
   ops->filesystem_ops->recursively_create_dir =
-      tf_azfs_filesystem::RecursivelyCreateDir;
-  ops->filesystem_ops->delete_file = tf_azfs_filesystem::DeleteFile;
+      tf_http_filesystem::RecursivelyCreateDir;
+  ops->filesystem_ops->delete_file = tf_http_filesystem::DeleteFile;
   ops->filesystem_ops->delete_recursively =
-      tf_azfs_filesystem::DeleteRecursively;
-  ops->filesystem_ops->delete_dir = tf_azfs_filesystem::DeleteDir;
-  ops->filesystem_ops->copy_file = tf_azfs_filesystem::CopyFile;
-  ops->filesystem_ops->rename_file = tf_azfs_filesystem::RenameFile;
-  ops->filesystem_ops->path_exists = tf_azfs_filesystem::PathExists;
-  ops->filesystem_ops->stat = tf_azfs_filesystem::Stat;
-  ops->filesystem_ops->is_directory = tf_azfs_filesystem::IsDirectory;
-  ops->filesystem_ops->get_file_size = tf_azfs_filesystem::GetFileSize;
-  ops->filesystem_ops->get_children = tf_azfs_filesystem::GetChildren;
-  ops->filesystem_ops->translate_name = tf_azfs_filesystem::TranslateName;
+      tf_http_filesystem::DeleteRecursively;
+  ops->filesystem_ops->delete_dir = tf_http_filesystem::DeleteDir;
+  ops->filesystem_ops->copy_file = tf_http_filesystem::CopyFile;
+  ops->filesystem_ops->rename_file = tf_http_filesystem::RenameFile;
+  ops->filesystem_ops->path_exists = tf_http_filesystem::PathExists;
+  ops->filesystem_ops->stat = tf_http_filesystem::Stat;
+  ops->filesystem_ops->is_directory = tf_http_filesystem::IsDirectory;
+  ops->filesystem_ops->get_file_size = tf_http_filesystem::GetFileSize;
+  ops->filesystem_ops->get_children = tf_http_filesystem::GetChildren;
+  ops->filesystem_ops->translate_name = tf_http_filesystem::TranslateName;
 }
 
 }  // namespace http

--- a/tensorflow_io/core/kernels/http_kernels.cc
+++ b/tensorflow_io/core/kernels/http_kernels.cc
@@ -13,15 +13,526 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// TODO: Replace curl_http_request.h to not depends on TensorFlow's
-// C++ implementation
-#include "tensorflow/core/platform/cloud/curl_http_request.h"
+#include <curl/curl.h>
+
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
+#include "absl/synchronization/mutex.h"
 #include "tensorflow_io/core/kernels/file_system_plugins.h"
 
 namespace tensorflow {
 namespace io {
 namespace http {
 namespace {
+
+// Set to 1 to enable verbose debug output from curl.
+constexpr uint64_t kVerboseOutput = 0;
+
+static absl::Mutex mu;
+static bool uninitialized(false);
+void CurlInitialize() {
+  absl::MutexLock l(&mu);
+  if (!uninitialized) {
+    curl_global_init(CURL_GLOBAL_ALL);
+    uninitialized = true;
+  }
+}
+
+class CurlHttpRequest {
+ public:
+  CurlHttpRequest() {}
+  ~CurlHttpRequest() {}
+
+  void Initialize(TF_Status* status) {
+    CurlInitialize();
+    curl_ = curl_easy_init();
+    if (curl_ == nullptr) {
+      TF_SetStatus(status, TF_INTERNAL, "Couldn't initialize a curl session.");
+      return;
+    }
+
+    CURLcode s = CURLE_OK;
+
+    const char* ca_bundle = std::getenv("CURL_CA_BUNDLE");
+    if (ca_bundle != nullptr) {
+      if ((s = curl_easy_setopt(curl_, CURLOPT_CAINFO, ca_bundle)) !=
+          CURLE_OK) {
+        std::string error_message =
+            absl::StrCat("Unable to set CURLOPT_CAINFO (", ca_bundle, "): ", s);
+        TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+        return;
+      }
+    }
+
+    if ((s = curl_easy_setopt(curl_, CURLOPT_VERBOSE, kVerboseOutput)) !=
+        CURLE_OK) {
+      std::string error_message = absl::StrCat(
+          "Unable to set CURLOPT_VERBOSE (", kVerboseOutput, "): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    if ((s = curl_easy_setopt(curl_, CURLOPT_USERAGENT,
+                              absl::StrCat("TensorFlowIO/", 0).c_str())) !=
+        CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_USERAGENT (",
+                       absl::StrCat("TensorFlowIO/", 0), "): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    // Do not use signals for timeouts - does not work in multi-threaded
+    // programs.
+    if ((s = curl_easy_setopt(curl_, CURLOPT_NOSIGNAL, 1L)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_NOSIGNAL: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    // TODO: Enable HTTP/2.
+    if ((s = curl_easy_setopt(curl_, CURLOPT_HTTP_VERSION,
+                              CURL_HTTP_VERSION_1_1)) != CURLE_OK) {
+      std::string error_message = absl::StrCat(
+          "Unable to set CURLOPT_HTTP_VERSION (CURL_HTTP_VERSION_1_1): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    // Set up the progress meter.
+    if ((s = curl_easy_setopt(curl_, CURLOPT_NOPROGRESS, 0)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_NOPROGRESS (0): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    if ((s = curl_easy_setopt(curl_, CURLOPT_XFERINFODATA, this)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_XFERINFODATA: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    if ((s = curl_easy_setopt(curl_, CURLOPT_XFERINFOFUNCTION,
+                              &CurlHttpRequest::ProgressCallback)) !=
+        CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_XFERINFOFUNCTION: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    response_buffer_.reserve(CURL_MAX_WRITE_SIZE);
+    if ((s = curl_easy_setopt(curl_, CURLOPT_WRITEDATA,
+                              reinterpret_cast<void*>(this))) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_WRITEDATA: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+    if ((s = curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION,
+                              &CurlHttpRequest::WriteCallback)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_WRITEFUNCTION ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    TF_SetStatus(status, TF_OK, "");
+  }
+
+  void SetUri(const std::string& uri, TF_Status* status) {
+    CURLcode s = CURLE_OK;
+    if ((s = curl_easy_setopt(curl_, CURLOPT_URL, uri.c_str())) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_URL (", uri, "): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    uri_ = uri;
+
+    TF_SetStatus(status, TF_OK, "");
+  }
+
+  void SetRange(uint64_t start, uint64_t end, TF_Status* status) {
+    CURLcode s = CURLE_OK;
+    if ((s = curl_easy_setopt(curl_, CURLOPT_RANGE,
+                              absl::StrCat(start, "-", end).c_str())) !=
+        CURLE_OK) {
+      std::string error_message = absl::StrCat("Unable to set CURLOPT_RANGE (",
+                                               start, "-", end, "): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    TF_SetStatus(status, TF_OK, "");
+  }
+
+  void SetResultBufferDirect(char* buffer, size_t size, TF_Status* status) {
+    direct_response_ = DirectResponseState{buffer, size, 0, 0};
+    CURLcode s = CURLE_OK;
+    if ((s = curl_easy_setopt(curl_, CURLOPT_WRITEDATA,
+                              reinterpret_cast<void*>(this))) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_WRITEDATA: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+    if ((s = curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION,
+                              &CurlHttpRequest::WriteCallbackDirect)) !=
+        CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_WRITEDATA: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+    TF_SetStatus(status, TF_OK, "");
+  }
+
+  size_t GetResultBufferDirectBytesTransferred() {
+    return direct_response_.bytes_transferred_;
+  }
+
+  std::string GetResponseHeader(const std::string& name) {
+    const auto& header = response_headers_.find(name);
+    return header != response_headers_.end() ? header->second : "";
+  }
+
+  void Send(TF_Status* status) {
+    CURLcode s = CURLE_OK;
+
+    if (curl_headers_) {
+      if ((s = curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, curl_headers_)) !=
+          CURLE_OK) {
+        std::string error_message =
+            absl::StrCat("Unable to set CURLOPT_HTTPHEADER: ", s);
+        TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+        return;
+      }
+    }
+    if (resolve_list_) {
+      if ((s = curl_easy_setopt(curl_, CURLOPT_RESOLVE, resolve_list_)) !=
+          CURLE_OK) {
+        std::string error_message =
+            absl::StrCat("Unable to set CURLOPT_RESOLVE: ", s);
+        TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+        return;
+      }
+    }
+    if ((s = curl_easy_setopt(curl_, CURLOPT_HEADERDATA,
+                              reinterpret_cast<void*>(this))) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_HEADERDATA: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+    if ((s = curl_easy_setopt(curl_, CURLOPT_HEADERFUNCTION,
+                              &CurlHttpRequest::HeaderCallback)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_HEADERFUNCTION: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    if ((s = curl_easy_setopt(curl_, CURLOPT_TIMEOUT, request_timeout_secs_)) !=
+        CURLE_OK) {
+      std::string error_message = absl::StrCat(
+          "Unable to set CURLOPT_TIMEOUT (", request_timeout_secs_, "): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+    if ((s = curl_easy_setopt(curl_, CURLOPT_CONNECTTIMEOUT,
+                              connect_timeout_secs_)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_CONNECTTIMEOUT (",
+                       connect_timeout_secs_, "): ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    char error_buffer[CURL_ERROR_SIZE] = {0};
+    if ((s = curl_easy_setopt(curl_, CURLOPT_ERRORBUFFER, error_buffer)) !=
+        CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLOPT_ERRORBUFFER: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    if ((s = curl_easy_perform(curl_)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to perform (", s, "): ", error_buffer);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    double written_size = 0;
+    if ((s = curl_easy_getinfo(curl_, CURLINFO_SIZE_DOWNLOAD, &written_size)) !=
+        CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLINFO_SIZE_DOWNLOAD: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    if ((s = curl_easy_getinfo(curl_, CURLINFO_RESPONSE_CODE,
+                               &response_code_)) != CURLE_OK) {
+      std::string error_message =
+          absl::StrCat("Unable to set CURLINFO_RESPONSE_CODE: ", s);
+      TF_SetStatus(status, TF_INTERNAL, error_message.c_str());
+      return;
+    }
+
+    auto get_error_message = [this]() -> std::string {
+      std::string error_message =
+          absl::StrCat("Error executing an HTTP request: HTTP response code ",
+                       response_code_);
+      absl::string_view body = GetResponse();
+      if (!body.empty()) {
+        return absl::StrCat(
+            error_message, " with body '",
+            body.substr(0, std::min(body.size(), response_to_error_limit_)),
+            "'");
+      }
+      return error_message;
+    };
+
+    switch (response_code_) {
+      // The group of response codes indicating that the request achieved
+      // the expected goal.
+      case 200:  // OK
+      case 201:  // Created
+      case 204:  // No Content
+      case 206:  // Partial Content
+        TF_SetStatus(status, TF_OK, "");
+        break;
+
+      case 416:  // Requested Range Not Satisfiable
+        // The requested range had no overlap with the available range.
+        // This doesn't indicate an error, but we should produce an empty
+        // response body. (Not all servers do; GCS returns a short error message
+        // body.)
+        response_buffer_.clear();
+        if (IsDirectResponse()) {
+          direct_response_.bytes_transferred_ = 0;
+        }
+        TF_SetStatus(status, TF_OK, "");
+        break;
+
+      // INVALID_ARGUMENT indicates a problem with how the request is
+      // constructed.
+      case 400:  // Bad Request
+      case 406:  // Not Acceptable
+      case 411:  // Length Required
+      case 414:  // URI Too Long
+        TF_SetStatus(status, TF_INVALID_ARGUMENT, get_error_message().c_str());
+        break;
+
+      // PERMISSION_DENIED indicates an authentication or an authorization
+      // issue.
+      case 401:  // Unauthorized
+      case 403:  // Forbidden
+      case 407:  // Proxy Authorization Required
+        TF_SetStatus(status, TF_PERMISSION_DENIED, get_error_message().c_str());
+        break;
+
+      // NOT_FOUND indicates that the requested resource does not exist.
+      case 404:  // Not found
+      case 410:  // Gone
+        TF_SetStatus(status, TF_NOT_FOUND, get_error_message().c_str());
+        break;
+
+      // FAILED_PRECONDITION indicates that the request failed because some
+      // of the underlying assumptions were not satisfied. The request
+      // shouldn't be retried unless the external context has changed.
+      case 302:  // Found
+      case 303:  // See Other
+      case 304:  // Not Modified
+      case 307:  // Temporary Redirect
+      case 412:  // Precondition Failed
+      case 413:  // Payload Too Large
+        TF_SetStatus(status, TF_FAILED_PRECONDITION,
+                     get_error_message().c_str());
+        break;
+
+      // UNAVAILABLE indicates a problem that can go away if the request
+      // is just retried without any modification. 308 return codes are intended
+      // for write requests that can be retried. See the documentation and the
+      // official library:
+      // https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+      // https://github.com/google/apitools/blob/master/apitools/base/py/transfer.py
+      case 308:  // Resume Incomplete
+      case 409:  // Conflict
+      case 429:  // Too Many Requests
+      case 500:  // Internal Server Error
+      case 502:  // Bad Gateway
+      case 503:  // Service Unavailable
+      default:   // All other HTTP response codes also should be retried.
+        TF_SetStatus(status, TF_UNAVAILABLE, get_error_message().c_str());
+        break;
+    }
+    if (TF_GetCode(status) != TF_OK) {
+      response_buffer_.clear();
+    }
+  }
+
+ private:
+  std::vector<char> response_buffer_;
+
+  struct DirectResponseState {
+    char* buffer_;
+    size_t buffer_size_;
+    size_t bytes_transferred_;
+    size_t bytes_received_;
+  };
+  DirectResponseState direct_response_ = {};
+
+  CURL* curl_ = nullptr;
+  curl_slist* curl_headers_ = nullptr;
+  curl_slist* resolve_list_ = nullptr;
+
+  std::unordered_map<std::string, std::string> response_headers_;
+  uint64_t response_code_ = 0;
+
+  std::string uri_;
+
+  // The timestamp of the last activity related to the request execution, in
+  // seconds since epoch.
+  uint64_t last_progress_timestamp_ = 0;
+  // The last progress in terms of bytes transmitted.
+  curl_off_t last_progress_bytes_ = 0;
+
+  // The maximum period of request inactivity.
+  uint32_t inactivity_timeout_secs_ = 60;  // 1 minute
+
+  // Timeout for the connection phase.
+  uint32_t connect_timeout_secs_ = 120;  // 2 minutes
+
+  // Timeout for the whole request. Set only to prevent hanging indefinitely.
+  uint32_t request_timeout_secs_ = 3600;  // 1 hour
+
+  // Limit the size of an http response that is copied into an error message.
+  const size_t response_to_error_limit_ = 500;
+
+  bool IsDirectResponse() const { return direct_response_.buffer_ != nullptr; }
+
+  absl::string_view GetResponse() const {
+    absl::string_view response;
+    if (IsDirectResponse()) {
+      response = absl::string_view(direct_response_.buffer_,
+                                   direct_response_.bytes_transferred_);
+    } else {
+      response =
+          absl::string_view(response_buffer_.data(), response_buffer_.size());
+    }
+    return response;
+  }
+
+  // Cancels the transmission if no progress has been made for too long.
+  static int ProgressCallback(void* this_object, curl_off_t dltotal,
+                              curl_off_t dlnow, curl_off_t ultotal,
+                              curl_off_t ulnow) {
+    auto that = reinterpret_cast<CurlHttpRequest*>(this_object);
+    const int64_t now = absl::ToUnixSeconds(absl::Now());
+    const auto current_progress = dlnow + ulnow;
+    if (that->last_progress_timestamp_ == 0 ||
+        current_progress > that->last_progress_bytes_) {
+      // This is the first time the callback is called or some progress
+      // was made since the last tick.
+      that->last_progress_timestamp_ = now;
+      that->last_progress_bytes_ = current_progress;
+      return 0;
+    }
+
+    if (now - that->last_progress_timestamp_ > that->inactivity_timeout_secs_) {
+      double lookup_time = -1;
+      const auto lookup_time_status = curl_easy_getinfo(
+          that->curl_, CURLINFO_NAMELOOKUP_TIME, &lookup_time);
+
+      double connect_time = -1;
+      const auto connect_time_status =
+          curl_easy_getinfo(that->curl_, CURLINFO_CONNECT_TIME, &connect_time);
+
+      double pretransfer_time = -1;
+      const auto pretransfer_time_status = curl_easy_getinfo(
+          that->curl_, CURLINFO_PRETRANSFER_TIME, &pretransfer_time);
+
+      double starttransfer_time = -1;
+      const auto starttransfer_time_status = curl_easy_getinfo(
+          that->curl_, CURLINFO_PRETRANSFER_TIME, &starttransfer_time);
+
+      // LOG(ERROR) << "The transmission  of request " << this_object
+      //            << " (URI: " << that->uri_ << ") has been stuck at "
+      //            << current_progress << " of " << dltotal + ultotal
+      //            << " bytes for " << now - that->last_progress_timestamp_
+      //            << " seconds and will be aborted. CURL timing information: "
+      //            << "lookup time: " << lookup_time << " ("
+      //            << curl_easy_strerror(lookup_time_status)
+      //            << "), connect time: " << connect_time << " ("
+      //            << curl_easy_strerror(connect_time_status)
+      //            << "), pre-transfer time: " << pretransfer_time << " ("
+      //            << curl_easy_strerror(pretransfer_time_status)
+      //            << "), start-transfer time: " << starttransfer_time << " ("
+      //            << curl_easy_strerror(starttransfer_time_status) << ")";
+      return 1;  // Will abort the request.
+    }
+    // No progress was made since the last call, but we should wait a bit
+    // longer.
+    return 0;
+  }
+
+  static size_t WriteCallback(const void* ptr, size_t size, size_t nmemb,
+                              void* this_object) {
+    auto that = reinterpret_cast<CurlHttpRequest*>(this_object);
+    const size_t bytes_to_copy = size * nmemb;
+    that->response_buffer_.insert(
+        that->response_buffer_.end(), reinterpret_cast<const char*>(ptr),
+        reinterpret_cast<const char*>(ptr) + bytes_to_copy);
+
+    return bytes_to_copy;
+  }
+
+  static size_t WriteCallbackDirect(const void* ptr, size_t size, size_t nmemb,
+                                    void* userdata) {
+    auto that = reinterpret_cast<CurlHttpRequest*>(userdata);
+    DirectResponseState* state = &that->direct_response_;
+
+    size_t curl_bytes_received = size * nmemb;
+    size_t user_buffer_bytes_available =
+        state->buffer_size_ - state->bytes_transferred_;
+    size_t bytes_to_copy =
+        std::min<size_t>(curl_bytes_received, user_buffer_bytes_available);
+    memcpy(&state->buffer_[state->bytes_transferred_], ptr, bytes_to_copy);
+    state->bytes_transferred_ += bytes_to_copy;
+    state->bytes_received_ += curl_bytes_received;
+    // If we didn't have room to store the full response, returning less than
+    // curl_bytes_received here will abort the transfer and curl_easy_perform()
+    // will return CURLE_WRITE_ERROR. We will detect and handle this error
+    // there, and can use state->bytes_received_ as stored above for logging
+    // purposes.
+    return bytes_to_copy;
+  }
+  static size_t HeaderCallback(const void* ptr, size_t size, size_t nmemb,
+                               void* this_object) {
+    auto that = reinterpret_cast<CurlHttpRequest*>(this_object);
+    absl::string_view header(reinterpret_cast<const char*>(ptr), size * nmemb);
+    absl::string_view::size_type p = header.find(": ");
+    if (p != absl::string_view::npos) {
+      std::string name(header.substr(0, p));
+      std::string value(header.substr(p + 2, -1));
+      absl::StripTrailingAsciiWhitespace(&value);
+      that->response_headers_[name] = value;
+    }
+    return size * nmemb;
+  }
+};
 
 class HTTPRandomAccessFile {
  public:
@@ -35,17 +546,28 @@ class HTTPRandomAccessFile {
       TF_SetStatus(status, TF_OK, "");
       return 0;
     }
-    std::unique_ptr<HttpRequest> request(http_request_factory_->Create());
-    request->SetUri(uri_);
-    request->SetRange(offset, offset + n - 1);
-    request->SetResultBufferDirect(buffer, n);
-    // TODO: Replace Status with non C++ status
-    Status s = request->Send();
-    if (!s.ok()) {
-      TF_SetStatus(status, TF_INTERNAL, s.error_message().c_str());
+    CurlHttpRequest request;
+    request.Initialize(status);
+    if (TF_GetCode(status) != TF_OK) {
       return 0;
     }
-    size_t bytes_to_read = request->GetResultBufferDirectBytesTransferred();
+    request.SetUri(uri_, status);
+    if (TF_GetCode(status) != TF_OK) {
+      return 0;
+    }
+    request.SetRange(offset, offset + n - 1, status);
+    if (TF_GetCode(status) != TF_OK) {
+      return 0;
+    }
+    request.SetResultBufferDirect(buffer, n, status);
+    if (TF_GetCode(status) != TF_OK) {
+      return 0;
+    }
+    request.Send(status);
+    if (TF_GetCode(status) != TF_OK) {
+      return 0;
+    }
+    size_t bytes_to_read = request.GetResultBufferDirectBytesTransferred();
     if (bytes_to_read < n) {
       TF_SetStatus(status, TF_OUT_OF_RANGE, "EOF reached");
       return bytes_to_read;
@@ -55,15 +577,8 @@ class HTTPRandomAccessFile {
   }
 
  private:
-  string uri_;
-
- public:
-  static std::shared_ptr<HttpRequest::Factory> http_request_factory_;
+  std::string uri_;
 };
-
-std::shared_ptr<HttpRequest::Factory>
-    HTTPRandomAccessFile::http_request_factory_ =
-        std::make_shared<CurlHttpRequest::Factory>();
 
 // SECTION 1. Implementation for `TF_RandomAccessFile`
 // ----------------------------------------------------------------------------
@@ -198,23 +713,28 @@ static void CopyFile(const TF_Filesystem* filesystem, const char* src,
 
 static void Stat(const TF_Filesystem* filesystem, const char* path,
                  TF_FileStatistics* stats, TF_Status* status) {
-  std::unique_ptr<HttpRequest> request(
-      HTTPRandomAccessFile::http_request_factory_->Create());
-  request->SetUri(path);
-  Status s = request->Send();
-  if (!s.ok()) {
-    TF_SetStatus(status, TF_INTERNAL, s.error_message().c_str());
+  CurlHttpRequest request;
+  request.Initialize(status);
+  if (TF_GetCode(status) != TF_OK) {
     return;
   }
-  string length_string = request->GetResponseHeader("Content-Length");
+  request.SetUri(path, status);
+  if (TF_GetCode(status) != TF_OK) {
+    return;
+  }
+  request.Send(status);
+  if (TF_GetCode(status) != TF_OK) {
+    return;
+  }
+  std::string length_string = request.GetResponseHeader("Content-Length");
   if (length_string == "") {
     std::string error_message =
         absl::StrCat("unable to check the Content-Length of the url: ", path);
     TF_SetStatus(status, TF_INVALID_ARGUMENT, error_message.c_str());
     return;
   }
-  int64 length = 0;
-  if (!strings::safe_strto64(length_string, &length)) {
+  int64_t length = 0;
+  if (!absl::SimpleAtoi<int64_t>(length_string, &length)) {
     std::string error_message =
         absl::StrCat("unable to parse the Content-Length of the url: ", path,
                      " [", length_string, "]");
@@ -222,7 +742,7 @@ static void Stat(const TF_Filesystem* filesystem, const char* path,
     return;
   }
 
-  string last_modified_string = request->GetResponseHeader("Last-Modified");
+  std::string last_modified_string = request.GetResponseHeader("Last-Modified");
 
   stats->length = length;
   stats->mtime_nsec = 0;


### PR DESCRIPTION
This PR migrated curl_http_request.[h|cc] in tensorflow to tensorflow-io, so that the HTTP file system does not depends on TensorFlow C++ APIs anymore. With this change, it should be possible to load the plugin so file in any future versions of tensorflow and removes the version match requirement.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>