### PR TITLE
Bump AWS CPP SDK to 1.7.336

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -382,11 +382,11 @@ http_archive(
 http_archive(
     name = "aws-sdk-cpp",
     build_file = "//third_party:aws-sdk-cpp.BUILD",
-    sha256 = "8724a2c3f00478e5f9af00d1d9bc67b7a0a557cc587a10f7097b1257008c2e68",
-    strip_prefix = "aws-sdk-cpp-1.7.270",
+    sha256 = "758174f9788fed6cc1e266bcecb20bf738bd5ef1c3d646131c9ed15c2d6c5720",
+    strip_prefix = "aws-sdk-cpp-1.7.336",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.7.270.tar.gz",
-        "https://github.com/aws/aws-sdk-cpp/archive/1.7.270.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
+        "https://github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
     ],
 )
 

--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -51,12 +51,13 @@ cc_library(
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
     ],
     defines = [
-        'AWS_SDK_VERSION_STRING=\\"1.7.270\\"',
+        'AWS_SDK_VERSION_STRING=\\"1.7.366\\"',
         "AWS_SDK_VERSION_MAJOR=1",
         "AWS_SDK_VERSION_MINOR=7",
-        "AWS_SDK_VERSION_PATCH=270",
+        "AWS_SDK_VERSION_PATCH=366",
+        "ENABLE_OPENSSL_ENCRYPTION",
         "ENABLE_CURL_CLIENT",
-        "ENABLE_NO_ENCRYPTION",
+        "OPENSSL_IS_BORINGSSL",
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "PLATFORM_WINDOWS",
@@ -84,23 +85,21 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
+        "@aws-c-common",
         "@aws-c-event-stream",
+        "@aws-checksums",
+        "@boringssl//:crypto",
         "@curl",
     ],
 )
 
 genrule(
     name = "SDKConfig_h",
+    srcs = [
+        "aws-cpp-sdk-core/include/aws/core/SDKConfig.h.in",
+    ],
     outs = [
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
     ],
-    cmd = "\n".join([
-        "cat <<'EOF' >$@",
-        "#define USE_AWS_MEMORY_MANAGEMENT",
-        "#if defined(_MSC_VER)",
-        "#include <Windows.h>",
-        "#undef IGNORE",
-        "#endif",
-        "EOF",
-    ]),
+    cmd = "sed 's/cmakedefine/undef/g' $< > $@",
 )


### PR DESCRIPTION
This PR bumpds AWS CPP SDK to 1.7.336, so that it matches the verison
in tensorflow (and in preparation of upcoming s3 file system migration).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>