### PR TITLE
Bump AWS CPP SDK to 1.7.336 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -382,11 +382,11 @@ http_archive(
 http_archive(
     name = "aws-sdk-cpp",
     build_file = "//third_party:aws-sdk-cpp.BUILD",
-    sha256 = "8724a2c3f00478e5f9af00d1d9bc67b7a0a557cc587a10f7097b1257008c2e68",
-    strip_prefix = "aws-sdk-cpp-1.7.270",
+    sha256 = "758174f9788fed6cc1e266bcecb20bf738bd5ef1c3d646131c9ed15c2d6c5720",
+    strip_prefix = "aws-sdk-cpp-1.7.336",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.7.270.tar.gz",
-        "https://github.com/aws/aws-sdk-cpp/archive/1.7.270.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
+        "https://github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -382,6 +382,9 @@ http_archive(
 http_archive(
     name = "aws-sdk-cpp",
     build_file = "//third_party:aws-sdk-cpp.BUILD",
+    patch_cmds = [
+        """sed -i.bak 's/UUID::RandomUUID/Aws::Utils::UUID::RandomUUID/g' aws-cpp-sdk-core/source/client/AWSClient.cpp""",
+    ],
     sha256 = "758174f9788fed6cc1e266bcecb20bf738bd5ef1c3d646131c9ed15c2d6c5720",
     strip_prefix = "aws-sdk-cpp-1.7.336",
     urls = [

--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -51,12 +51,13 @@ cc_library(
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
     ],
     defines = [
-        'AWS_SDK_VERSION_STRING=\\"1.7.270\\"',
+        'AWS_SDK_VERSION_STRING=\\"1.7.366\\"',
         "AWS_SDK_VERSION_MAJOR=1",
         "AWS_SDK_VERSION_MINOR=7",
-        "AWS_SDK_VERSION_PATCH=270",
-        "ENABLE_CURL_CLIENT",
-        "ENABLE_NO_ENCRYPTION",
+        "AWS_SDK_VERSION_PATCH=366",
+        "ENABLE_OPENSSL_ENCRYPTION=1",
+        "ENABLE_CURL_CLIENT=1",
+        "OPENSSL_IS_BORINGSSL=1",
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "PLATFORM_WINDOWS",
@@ -84,7 +85,10 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
+        "@aws-c-common",
         "@aws-c-event-stream",
+        "@aws-checksums",
+        "@boringssl//:crypto",
         "@curl",
     ],
 )

--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -36,6 +36,8 @@ cc_library(
         "aws-cpp-sdk-kinesis/source/**/*.cpp",
         "aws-cpp-sdk-s3/include/**/*.h",
         "aws-cpp-sdk-s3/source/**/*.cpp",
+        "aws-cpp-sdk-transfer/include/**/*.h",
+        "aws-cpp-sdk-transfer/source/**/*.cpp",
     ]) + select({
         "@bazel_tools//src/conditions:windows": glob([
             "aws-cpp-sdk-core/source/http/windows/*.cpp",
@@ -71,6 +73,7 @@ cc_library(
         "aws-cpp-sdk-core/include",
         "aws-cpp-sdk-kinesis/include",
         "aws-cpp-sdk-s3/include",
+        "aws-cpp-sdk-transfer/include",
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "aws-cpp-sdk-core/include/aws/core/platform/refs",

--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -25,7 +25,7 @@ cc_library(
         "aws-cpp-sdk-core/source/utils/base64/**/*.cpp",
         "aws-cpp-sdk-core/source/utils/crypto/*.cpp",
         "aws-cpp-sdk-core/source/utils/crypto/factory/*.cpp",
-        "aws-cpp-sdk-core/source/utils/crypto/opsnssl/*.cpp",
+        "aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp",
         "aws-cpp-sdk-core/source/utils/event/**/*.cpp",
         "aws-cpp-sdk-core/source/utils/json/**/*.cpp",
         "aws-cpp-sdk-core/source/utils/logging/**/*.cpp",

--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -25,6 +25,7 @@ cc_library(
         "aws-cpp-sdk-core/source/utils/base64/**/*.cpp",
         "aws-cpp-sdk-core/source/utils/crypto/*.cpp",
         "aws-cpp-sdk-core/source/utils/crypto/factory/*.cpp",
+        "aws-cpp-sdk-core/source/utils/crypto/opsnssl/*.cpp",
         "aws-cpp-sdk-core/source/utils/event/**/*.cpp",
         "aws-cpp-sdk-core/source/utils/json/**/*.cpp",
         "aws-cpp-sdk-core/source/utils/logging/**/*.cpp",


### PR DESCRIPTION
This PR bumpds AWS CPP SDK to 1.7.336, so that it matches the verison
in tensorflow (and in preparation of upcoming s3 file system migration).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>