### PR TITLE
Add a stub gcs tests with gcloud-storage-emulator

### DIFF
--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -6,7 +6,7 @@ run_test() {
   entry=$1
   CPYTHON_VERSION=$($entry -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
   (cd wheelhouse && $entry -m pip install tensorflow_io-*-cp${CPYTHON_VERSION}-*.whl)
-  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.16.0 pandas==0.24.2 scikit-learn==0.20.4 google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro avro-python3 scikit-image
+  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.16.0 pandas==0.24.2 scikit-learn==0.20.4 google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro avro-python3 scikit-image google-cloud-storage==1.22.0
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*.py" ! \( -iname "test_*_eager.py" \) \)))
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \)))
   # GRPC and test_bigquery_eager tests have to be executed separately because of https://github.com/grpc/grpc/issues/20034

--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -6,7 +6,7 @@ run_test() {
   entry=$1
   CPYTHON_VERSION=$($entry -c 'import sys; print(str(sys.version_info[0])+str(sys.version_info[1]))')
   (cd wheelhouse && $entry -m pip install tensorflow_io-*-cp${CPYTHON_VERSION}-*.whl)
-  $entry -m pip install -q pytest pytest-benchmark boto3 python-dateutil==2.8.0 google-cloud-pubsub==0.39.1 pyarrow==0.16.0 pandas==0.24.2 scikit-learn==0.20.4 google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro avro-python3 scikit-image google-cloud-storage==1.22.0
+  $entry -m pip install -q pytest pytest-benchmark boto3 fastavro avro-python3 scikit-image pyarrow==0.16.0 pandas==0.24.2 google-cloud-pubsub==2.1.0 google-cloud-bigquery-storage==1.1.0 google-cloud-bigquery==2.3.1 google-cloud-storage==1.32.0
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*.py" ! \( -iname "test_*_eager.py" \) \)))
   (cd tests && $entry -m pytest --benchmark-disable -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \)))
   # GRPC and test_bigquery_eager tests have to be executed separately because of https://github.com/grpc/grpc/issues/20034

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
           bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
           bash -x -e tests/test_azure/start_azure.sh
           bash -x -e tests/test_sql/sql_test.sh
-          bash -x -e tests/test_gcloud/test_gcs.sh
+          bash -x -e tests/test_gcloud/test_gcs.sh gcs-emulator
       - name: Test Linux
         run: |
           set -x -e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,6 +299,7 @@ jobs:
           bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
           bash -x -e tests/test_azure/start_azure.sh
           bash -x -e tests/test_sql/sql_test.sh
+          bash -x -e tests/test_gcloud/test_gcs.sh
       - name: Test Linux
         run: |
           set -x -e

--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -71,7 +71,7 @@ sudo chown -R $(id -nu):$(id -ng) .
 ls wheelhouse/*
 
 ## Set test services
-docker run -t -d --net=host -v $PWD:/v -w /v python:3 bash -x -e /v/tests/test_gcloud/test_gcs.sh
+bash -x -e tests/test_gcloud/test_gcs.sh gcs-emulator
 bash -x -e tests/test_kafka/kafka_test.sh
 bash -x -e tests/test_aws/aws_test.sh
 bash -x -e tests/test_pubsub/pubsub_test.sh pubsub

--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -71,12 +71,11 @@ sudo chown -R $(id -nu):$(id -ng) .
 ls wheelhouse/*
 
 ## Set test services
-bash -x -e tests/test_ignite/start_ignite.sh
+docker run -t -d --net=host -v $PWD:/v -w /v python:3 bash -x -e /v/tests/test_gcloud/test_gcs.sh
 bash -x -e tests/test_kafka/kafka_test.sh
 bash -x -e tests/test_aws/aws_test.sh
 bash -x -e tests/test_pubsub/pubsub_test.sh pubsub
 bash -x -e tests/test_prometheus/prometheus_test.sh start
-bash -x -e tests/test_gcloud/test_gcs.sh
 bash -x -e tests/test_azure/start_azure.sh
 bash -x -e tests/test_sql/sql_test.sh sql
 bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start

--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -76,6 +76,7 @@ bash -x -e tests/test_kafka/kafka_test.sh
 bash -x -e tests/test_aws/aws_test.sh
 bash -x -e tests/test_pubsub/pubsub_test.sh pubsub
 bash -x -e tests/test_prometheus/prometheus_test.sh start
+bash -x -e tests/test_gcloud/test_gcs.sh
 bash -x -e tests/test_azure/start_azure.sh
 bash -x -e tests/test_sql/sql_test.sh sql
 bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start

--- a/tests/test_gcloud/test_gcs.sh
+++ b/tests/test_gcloud/test_gcs.sh
@@ -1,11 +1,20 @@
 set -e
 set -o pipefail
 
+if [ "$#" -eq 1 ]; then
+  container=$1
+  docker pull python:3.8
+  docker run -d --rm --net=host --name=$container -v $PWD:/v -w /v python:3.8 bash -x -c 'python3 -m pip install gcloud-storage-emulator==0.3.0 && gcloud-storage-emulator start --port=9099'
+  echo wait 30 secs until gcs emulator is up and running
+  sleep 30
+  exit 0
+fi
+
 export PATH=$(python3 -m site --user-base)/bin:$PATH
 
 python3 -m pip install gcloud-storage-emulator==0.3.0
 
-gcloud-storage-emulator start --port=9090 &
+gcloud-storage-emulator start --port=9099 &
 
 sleep 30 # Wait for storage emulator to start
 echo gcs emulator started successfully

--- a/tests/test_gcloud/test_gcs.sh
+++ b/tests/test_gcloud/test_gcs.sh
@@ -1,0 +1,11 @@
+set -e
+set -o pipefail
+
+export PATH=$(python3 -m site --user-base)/bin:$PATH
+
+python3 -m pip install gcloud-storage-emulator==0.3.0
+
+gcloud-storage-emulator start --port=9090 &
+
+sleep 30 # Wait for storage emulator to start
+echo gcs emulator started successfully

--- a/tests/test_gcs_eager.py
+++ b/tests/test_gcs_eager.py
@@ -23,6 +23,9 @@ import tensorflow_io as tfio
 import pytest
 
 
+# GCS emulator setup is in tests/test_gcloud/test_gcs.sh
+
+
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),
     reason="TODO GCS emulator not setup properly on macOS/Windows yet",
@@ -35,14 +38,14 @@ def test_read_file():
     client = storage.Client(
         project="[PROJECT]",
         _http=requests.Session(),
-        client_options={"api_endpoint": "http://localhost:9090"},
+        client_options={"api_endpoint": "http://localhost:9099"},
     )
 
     body = b"1234567"
 
     # Setup the S3 bucket and key
     key_name = "TEST"
-    bucket_name = "s3e{}e".format(time.time())
+    bucket_name = "s3e{}e".format(int(time.time()))
 
     bucket = client.create_bucket(bucket_name)
     print("Project number: {}".format(bucket.project_number))

--- a/tests/test_gcs_eager.py
+++ b/tests/test_gcs_eager.py
@@ -1,0 +1,58 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for GCS file system"""
+
+import os
+import sys
+import time
+import requests
+import tensorflow as tf
+import tensorflow_io as tfio
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.platform in ("win32", "darwin"),
+    reason="TODO GCS emulator not setup properly on macOS/Windows yet",
+)
+def test_read_file():
+    """Test case for reading GCS"""
+
+    from google.cloud import storage
+
+    client = storage.Client(
+        project="[PROJECT]",
+        _http=requests.Session(),
+        client_options={"api_endpoint": "http://localhost:9090"},
+    )
+
+    body = b"1234567"
+
+    # Setup the S3 bucket and key
+    key_name = "TEST"
+    bucket_name = "s3e{}e".format(time.time())
+
+    bucket = client.create_bucket(bucket_name)
+    print("Project number: {}".format(bucket.project_number))
+
+    blob = bucket.blob(key_name)
+    blob.upload_from_string(body)
+
+    response = blob.download_as_string()
+    print("RESPONSE: ", response)
+    assert response == body
+
+    # content = tf.io.read_file("gs://{}/{}".format(bucket_name, key_name))
+    # assert content == body

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -156,7 +156,7 @@ def fixture_pubsub(request):
     os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8085"
     publisher = pubsub_v1.PublisherClient()
     topic_path = publisher.topic_path("pubsub-project", "pubsub_topic_" + channel)
-    publisher.create_topic(topic_path)
+    publisher.create_topic(request={"name": topic_path})
     # print('Topic created: {}'.format(topic))
     subscriber = pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -151,7 +151,7 @@ def fixture_pubsub(request):
     """fixture_pubsub"""
     from google.cloud import pubsub_v1  # pylint: disable=import-outside-toplevel
 
-    channel = "e{}e".format(time.time())
+    channel = "e{}e".format(int(time.time()))
 
     os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8085"
     publisher = pubsub_v1.PublisherClient()

--- a/tests/test_io_dataset_eager.py
+++ b/tests/test_io_dataset_eager.py
@@ -163,7 +163,11 @@ def fixture_pubsub(request):
         "pubsub-project", "pubsub_subscription_{}".format(channel)
     )
     subscription = subscriber.create_subscription(
-        subscription_path, topic_path, retain_acked_messages=True
+        request={
+            "name": subscription_path,
+            "topic": topic_path,
+            "retain_acked_messages": True,
+        }
     )
     print("Subscription created: {}".format(subscription))
     for n in range(0, 10):
@@ -179,7 +183,7 @@ def fixture_pubsub(request):
         subscription_path = subscriber.subscription_path(
             "pubsub-project", "pubsub_subscription_{}".format(channel)
         )
-        subscriber.delete_subscription(subscription_path)
+        subscriber.delete_subscription(request={"subscription": subscription_path})
         print("Subscription {} deleted.".format(subscription_path))
 
     request.addfinalizer(fin)


### PR DESCRIPTION
This PR adds a stub gcs tests, based on gcloud-storage-emulator in pypi.org.

This is a prerequisite for gcs file system migration.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>