### PR TITLE
[hdfs] register viewfs and har schemes

### DIFF
--- a/tensorflow_io/core/plugins/file_system_plugins.cc
+++ b/tensorflow_io/core/plugins/file_system_plugins.cc
@@ -18,7 +18,7 @@ limitations under the License.
 void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
   info->plugin_memory_allocate = tensorflow::io::plugin_memory_allocate;
   info->plugin_memory_free = tensorflow::io::plugin_memory_free;
-  info->num_schemes = 4;
+  info->num_schemes = 6;
   info->ops = static_cast<TF_FilesystemPluginOps*>(
       tensorflow::io::plugin_memory_allocate(info->num_schemes *
                                              sizeof(info->ops[0])));
@@ -26,4 +26,6 @@ void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
   tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[1], "http");
   tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
   tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfse");
+  tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfse");
+  tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "hare");
 }


### PR DESCRIPTION
This PR is a follow up of https://github.com/tensorflow/io/pull/1197 and address the filesystem migration issue https://github.com/tensorflow/io/issues/1183 by registering `viewfse://` and `hare://` schemes with the hdfs implementation. Schemes will be changed to `viewfs://` and `har://` after the migration completes.

cc: @yongtang @vnvo2409