### PR TITLE
Bump einaregilsson/build-number to v3 as set-env was deprecated in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -527,7 +527,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: BUILD_NUMBER
-      - uses: einaregilsson/build-number@v2
+      - uses: einaregilsson/build-number@v3
       - run: echo "Build number is $BUILD_NUMBER"
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -571,7 +571,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: BUILD_NUMBER
-      - uses: einaregilsson/build-number@v2
+      - uses: einaregilsson/build-number@v3
       - run: echo "Build number is $BUILD_NUMBER"
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -609,7 +609,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: BUILD_NUMBER
-      - uses: einaregilsson/build-number@v2
+      - uses: einaregilsson/build-number@v3
       - run: echo "Build number is $BUILD_NUMBER"
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1


### PR DESCRIPTION
```
Error: Unable to process command '::set-env name=BUILD_NUMBER::20201118053615' successfully.
8
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>