### PR TITLE
Use system default python3 for bazel building on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,10 @@ jobs:
       - name: Bazel on macOS
         run: |
           set -x -e
+          echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
+          export PATH=/usr/bin:$PATH
+          python3 --version
+          python3 -c 'import site; print(site.getsitepackages())'
           BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
           BAZEL_VERSION=$(cat .bazelversion)
           curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh


### PR DESCRIPTION
GitHub Actions recently changed the python3 version on macOS to 3.9.
However, as tensorflow does not have 3.9 support yet, this is failing
our build.

This PR changes to use system default python3 instead.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>