### PR TITLE
Convert to C API logging

### DIFF
--- a/tensorflow_io/core/plugins/az/az_file_system.cc
+++ b/tensorflow_io/core/plugins/az/az_file_system.cc
@@ -31,6 +31,12 @@ limitations under the License.
 #include "storage_account.h"
 #include "storage_credential.h"
 #include "storage_errno.h"
+// TODO: Restore logging.h
+#define TF_Log(...)
+#define TF_VLog(...)
+// #include "tensorflow/c/logging.h"
+// TODO: Restore logging.h
+#include "tensorflow/c/tf_status.h"
 #include "tensorflow_io/core/plugins/file_system_plugins.h"
 
 namespace tensorflow {
@@ -191,21 +197,20 @@ std::shared_ptr<azure::storage_lite::storage_credential> get_credential(
   }
 }
 
-// TODO: Enable logging
 azure::storage_lite::blob_client_wrapper CreateAzBlobClientWrapper(
     const std::string& account) {
   azure::storage_lite::logger::set_logger(
       [](azure::storage_lite::log_level level, const std::string& log_msg) {
         switch (level) {
           case azure::storage_lite::log_level::info:
-            // _TF_LOG_INFO << log_msg;
+            TF_Log(TF_INFO, log_msg.c_str());
             break;
           case azure::storage_lite::log_level::error:
           case azure::storage_lite::log_level::critical:
-            // _TF_LOG_ERROR << log_msg;
+            TF_Log(TF_ERROR, log_msg.c_str());
             break;
           case azure::storage_lite::log_level::warn:
-            // _TF_LOG_WARNING << log_msg;
+            TF_Log(TF_WARNING, log_msg.c_str());
             break;
           case azure::storage_lite::log_level::trace:
           case azure::storage_lite::log_level::debug:

--- a/tensorflow_io/core/plugins/hdfs/hadoop_filesystem.cc
+++ b/tensorflow_io/core/plugins/hdfs/hadoop_filesystem.cc
@@ -31,13 +31,13 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
 #include "hdfs/hdfs.h"
-#include "tensorflow/c/tf_status.h"
-#include "tensorflow_io/core/plugins/file_system_plugins.h"
 // TODO: Restore logging.h
 #define TF_Log(...)
 #define TF_VLog(...)
 // #include "tensorflow/c/logging.h"
 // TODO: Restore logging.h
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow_io/core/plugins/file_system_plugins.h"
 
 namespace tensorflow {
 namespace io {

--- a/tensorflow_io/core/plugins/http/http_file_system.cc
+++ b/tensorflow_io/core/plugins/http/http_file_system.cc
@@ -22,6 +22,12 @@ limitations under the License.
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
 #include "absl/synchronization/mutex.h"
+// TODO: Restore logging.h
+#define TF_Log(...)
+#define TF_VLog(...)
+// #include "tensorflow/c/logging.h"
+// TODO: Restore logging.h
+#include "tensorflow/c/tf_status.h"
 #include "tensorflow_io/core/plugins/file_system_plugins.h"
 
 namespace tensorflow {
@@ -473,20 +479,21 @@ class CurlHttpRequest {
       const auto starttransfer_time_status = curl_easy_getinfo(
           that->curl_, CURLINFO_STARTTRANSFER_TIME, &starttransfer_time);
 
-      // TODO: Use C API from TensorFlow for Logging.
-      // LOG(ERROR) << "The transmission  of request " << this_object
-      //            << " (URI: " << that->uri_ << ") has been stuck at "
-      //            << current_progress << " of " << dltotal + ultotal
-      //            << " bytes for " << now - that->last_progress_timestamp_
-      //            << " seconds and will be aborted. CURL timing information: "
-      //            << "lookup time: " << lookup_time << " ("
-      //            << curl_easy_strerror(lookup_time_status)
-      //            << "), connect time: " << connect_time << " ("
-      //            << curl_easy_strerror(connect_time_status)
-      //            << "), pre-transfer time: " << pretransfer_time << " ("
-      //            << curl_easy_strerror(pretransfer_time_status)
-      //            << "), start-transfer time: " << starttransfer_time << " ("
-      //            << curl_easy_strerror(starttransfer_time_status) << ")";
+      std::string error_message = absl::StrCat(
+          "The transmission  of request ", (int64_t)(this_object),
+          " (URI: ", that->uri_, ") has been stuck at ", current_progress,
+          " of ", dltotal + ultotal, " bytes for ",
+          now - that->last_progress_timestamp_,
+          " seconds and will be aborted. CURL timing information: ",
+          "lookup time: ", lookup_time, " (",
+          curl_easy_strerror(lookup_time_status),
+          "), connect time: ", connect_time, " (",
+          curl_easy_strerror(connect_time_status),
+          "), pre-transfer time: ", pretransfer_time, " (",
+          curl_easy_strerror(pretransfer_time_status),
+          "), start-transfer time: ", starttransfer_time, " (",
+          curl_easy_strerror(starttransfer_time_status), ")");
+      TF_Log(TF_ERROR, error_message.c_str());
       return 1;  // Will abort the request.
     }
     // No progress was made since the last call, but we should wait a bit


### PR DESCRIPTION
This PR convert to C API logging in modular file system plugins. The `tensorflow/c/logging.h` is already available, however, the library didn't link the API (will be fixed by https://github.com/tensorflow/tensorflow/pull/44993).

For the moment this PR converts the C++ `LOG` call which will be needed very soon anyway.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>