### PR TITLE
Add Pulsar support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,7 @@ jobs:
           bash -x -e tests/test_azure/start_azure.sh
           bash -x -e tests/test_pubsub/pubsub_test.sh
           bash -x -e tests/test_aws/aws_test.sh
+          bash -x -e tests/test_pulsar/pulsar_test.sh
       - name: Install ${{ matrix.python }} macOS
         run: |
           set -x -e
@@ -304,6 +305,7 @@ jobs:
           bash -x -e tests/test_azure/start_azure.sh
           bash -x -e tests/test_sql/sql_test.sh
           bash -x -e tests/test_gcloud/test_gcs.sh gcs-emulator
+          bash -x -e tests/test_pulsar/pulsar_test.sh
       - name: Test Linux
         run: |
           set -x -e

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1065,9 +1065,24 @@ http_archive(
 )
 
 http_archive(
+    name = "dlfcn-win32",
+    build_file = "//third_party:dlfcn-win32.BUILD",
+    sha256 = "f18a412e84d8b701e61a78252411fe8c72587f52417c1ef21ca93604de1b9c55",
+    strip_prefix = "dlfcn-win32-1.2.0",
+    urls = [
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/dlfcn-win32/dlfcn-win32/archive/v1.2.0.tar.gz",
+        "https://github.com/dlfcn-win32/dlfcn-win32/archive/v1.2.0.tar.gz",
+    ],
+)
+
+http_archive(
     name = "pulsar",
     build_file = "//third_party:pulsar.BUILD",
-    patch_cmds = ["cp pulsar-common/src/main/proto/PulsarApi.proto pulsar-client-cpp/lib"],
+    patch_cmds = [
+        "cp pulsar-common/src/main/proto/PulsarApi.proto pulsar-client-cpp/lib",
+        "sed -i.bak 's/define PULSAR_DEFINES_H_/define PULSAR_DEFINES_H_\\'$'\\n''#if defined(_MSC_VER)\\'$'\\n''#include <Windows.h>\\'$'\\n''#undef ERROR\\'$'\\n''#endif/g' pulsar-client-cpp/include/pulsar/defines.h",
+        "sed -i.bak 's/define LIB_ACKGROUPINGTRACKER_H_/define LIB_ACKGROUPINGTRACKER_H_\\'$'\\n''#include <pulsar\\/defines.h>/g' pulsar-client-cpp/lib/AckGroupingTracker.h",
+    ],
     sha256 = "08f19ca6d6353751ff0661403b16b71425bf7ada3d8835a38e426ae303b0e385",
     strip_prefix = "pulsar-2.6.1",
     urls = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1063,3 +1063,14 @@ http_archive(
         "https://downloads.apache.org/hadoop/common/hadoop-3.3.0/hadoop-3.3.0-src.tar.gz",
     ],
 )
+
+http_archive(
+    name = "pulsar",
+    build_file = "//third_party:pulsar.BUILD",
+    patch_cmds = ["cp pulsar-common/src/main/proto/PulsarApi.proto pulsar-client-cpp/lib"],
+    sha256 = "08f19ca6d6353751ff0661403b16b71425bf7ada3d8835a38e426ae303b0e385",
+    strip_prefix = "pulsar-2.6.1",
+    urls = [
+        "https://github.com/apache/pulsar/archive/v2.6.1.tar.gz",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -405,6 +405,9 @@ http_archive(
 
 http_archive(
     name = "boringssl",
+    patch_cmds = [
+        """sed -i.bak 's/bio.c",/bio.c","src\\/decrepit\\/bio\\/base64_bio.c",/g' BUILD.generated.bzl""",
+    ],
     sha256 = "1188e29000013ed6517168600fc35a010d58c5d321846d6a6dfee74e4c788b45",
     strip_prefix = "boringssl-7f634429a04abc48e2eb041c81c5235816c96514",
     urls = [

--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -663,6 +663,22 @@ cc_library(
     alwayslink = 1,
 )
 
+cc_library(
+    name = "pulsar_ops",
+    srcs = [
+        "kernels/pulsar_kernel.cc",
+        "ops/pulsar_ops.cc",
+    ],
+    copts = tf_io_copts(),
+    linkstatic = True,
+    deps = [
+        "@local_config_tf//:libtensorflow_framework",
+        "@local_config_tf//:tf_header_lib",
+        "@pulsar",
+    ],
+    alwayslink = 1,
+)
+
 cc_binary(
     name = "python/ops/libtensorflow_io.so",
     copts = tf_io_copts(),
@@ -684,6 +700,7 @@ cc_binary(
         "//tensorflow_io/core:numpy_ops",
         "//tensorflow_io/core:parquet_ops",
         "//tensorflow_io/core:pcap_ops",
+        "//tensorflow_io/core:pulsar_ops",
         "//tensorflow_io/core:operation_ops",
         "//tensorflow_io/core:pubsub_ops",
         "//tensorflow_io/core:serialization_ops",

--- a/tensorflow_io/core/kernels/pulsar_kernel.cc
+++ b/tensorflow_io/core/kernels/pulsar_kernel.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorflow_io/core/kernels/pulsar_kernel.cc
+++ b/tensorflow_io/core/kernels/pulsar_kernel.cc
@@ -1,0 +1,206 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "pulsar/Client.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+#include "tensorflow/core/framework/resource_op_kernel.h"
+
+namespace tensorflow {
+namespace io {
+namespace {
+
+class PulsarReadableResource : public ResourceBase {
+ public:
+  PulsarReadableResource() = default;
+
+  ~PulsarReadableResource() {
+    if (client_.get()) {
+      client_->close();
+      client_.reset(nullptr);
+    }
+  }
+
+  Status Init(const std::string& service_url, const std::string& topic,
+              const std::string& subscription, int64 ack_grouping_time) {
+    mutex_lock l(mu_);
+    client_.reset(new pulsar::Client(service_url));
+
+    pulsar::ConsumerConfiguration conf;
+    conf.setConsumerType(pulsar::ConsumerFailover);
+    conf.setSubscriptionInitialPosition(pulsar::InitialPositionEarliest);
+    conf.setAckGroupingTimeMs(ack_grouping_time);
+
+    auto result = client_->subscribe(topic, subscription, conf, consumer_);
+    if (result != pulsar::ResultOk) {
+      return errors::Internal("failed to subscribe ", topic,
+                              " subscription: ", subscription,
+                              " error: ", pulsar::strResult(result));
+    }
+
+    LOG(INFO) << "Subscribing to the pulsar topic: " << topic
+              << " with subscription: " << subscription;
+    return Status::OK();
+  }
+
+  Status Next(const int32 timeout, const int32 poll_timeout,
+              std::function<Status(const TensorShape& shape, Tensor** message,
+                                   Tensor** key, Tensor** continue_fetch)>
+                  allocate_func) {
+    mutex_lock l(mu_);
+
+    constexpr size_t max_num_messages = 1024;
+    std::vector<std::string> values;
+    std::vector<std::string> keys;
+    values.reserve(max_num_messages);
+    keys.reserve(max_num_messages);
+
+    int32 elapsed_time = 0;
+    int num_messages = 0;
+    while (elapsed_time < timeout && num_messages < max_num_messages) {
+      pulsar::Message message;
+      auto result = consumer_.receive(message, poll_timeout);
+      if (result == pulsar::ResultOk) {
+        keys.emplace_back(message.hasPartitionKey() ? message.getPartitionKey()
+                                                    : "");
+        values.emplace_back(message.getDataAsString());
+        num_messages++;
+        elapsed_time = 0;  // reset the current timeout
+        consumer_.acknowledgeAsync(message, [&](pulsar::Result result) {
+          if (result != pulsar::ResultOk) {
+            LOG(ERROR) << "Failed to acknowledge " << message.getMessageId();
+          }
+        });
+      } else if (result == pulsar::ResultTimeout) {
+        elapsed_time += poll_timeout;
+      } else {
+        return errors::Internal("failed to receive messages, error: ",
+                                pulsar::strResult(result));
+      }
+    }
+
+    TensorShape shape({static_cast<int32>(values.size())});
+    Tensor* value_tensor;
+    Tensor* key_tensor;
+    Tensor* continue_fetch_tensor;
+    TF_RETURN_IF_ERROR(allocate_func(shape, &value_tensor, &key_tensor,
+                                     &continue_fetch_tensor));
+
+    // If no messages were received when timeout exceeded, we treat it as a
+    // failure and don't continue receiving messages.
+    continue_fetch_tensor->scalar<int64>()() = (values.empty() ? 0 : 1);
+    for (size_t i = 0; i < values.size(); i++) {
+      value_tensor->flat<tstring>()(i) = values[i];
+      key_tensor->flat<tstring>()(i) = keys[i];
+    }
+
+    return Status::OK();
+  }
+
+  std::string DebugString() const override { return "PulsarReadableResource"; }
+
+ private:
+  mutable mutex mu_;
+
+  std::unique_ptr<pulsar::Client> client_;
+  pulsar::Consumer consumer_;
+};
+
+class PulsarReadableInitOp : public ResourceOpKernel<PulsarReadableResource> {
+ public:
+  explicit PulsarReadableInitOp(OpKernelConstruction* context)
+      : ResourceOpKernel<PulsarReadableResource>(context) {}
+
+ private:
+  void Compute(OpKernelContext* context) override {
+    ResourceOpKernel<PulsarReadableResource>::Compute(context);
+
+    const Tensor* service_url_tensor;
+    OP_REQUIRES_OK(context, context->input("service_url", &service_url_tensor));
+    const std::string service_url = service_url_tensor->flat<tstring>()(0);
+
+    const Tensor* topic_tensor;
+    OP_REQUIRES_OK(context, context->input("topic", &topic_tensor));
+    const std::string topic = topic_tensor->flat<tstring>()(0);
+
+    const Tensor* subscription_tensor;
+    OP_REQUIRES_OK(context,
+                   context->input("subscription", &subscription_tensor));
+    const std::string subscription = subscription_tensor->flat<tstring>()(0);
+
+    const Tensor* ack_grouping_time_tensor;
+    OP_REQUIRES_OK(context, context->input("ack_grouping_time",
+                                           &ack_grouping_time_tensor));
+    const int64 ack_grouping_time = ack_grouping_time_tensor->scalar<int64>()();
+
+    OP_REQUIRES_OK(context, resource_->Init(service_url, topic, subscription,
+                                            ack_grouping_time));
+  }
+
+  Status CreateResource(PulsarReadableResource** resource)
+      TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) override {
+    *resource = new PulsarReadableResource();
+    return Status::OK();
+  }
+
+ private:
+  mutable mutex mu_;
+};
+
+class PulsarReadableNextOp : public OpKernel {
+ public:
+  explicit PulsarReadableNextOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    PulsarReadableResource* resource;
+    OP_REQUIRES_OK(context,
+                   GetResourceFromContext(context, "input", &resource));
+    core::ScopedUnref unref(resource);
+
+    const Tensor* timeout_tensor;
+    OP_REQUIRES_OK(context, context->input("timeout", &timeout_tensor));
+    const int64 timeout = timeout_tensor->scalar<int64>()();
+
+    const Tensor* poll_timeout_tensor;
+    OP_REQUIRES_OK(context,
+                   context->input("poll_timeout", &poll_timeout_tensor));
+    const int64 poll_timeout = poll_timeout_tensor->scalar<int64>()();
+
+    OP_REQUIRES_OK(
+        context,
+        resource->Next(
+            timeout, poll_timeout,
+            [&](const TensorShape& shape, Tensor** message, Tensor** key,
+                Tensor** continue_fetch) -> Status {
+              TF_RETURN_IF_ERROR(context->allocate_output(0, shape, message));
+              TF_RETURN_IF_ERROR(context->allocate_output(1, shape, key));
+              TF_RETURN_IF_ERROR(
+                  context->allocate_output(2, TensorShape({}), continue_fetch));
+              return Status::OK();
+            }));
+  }
+
+ private:
+  mutable mutex mu_;
+};
+
+REGISTER_KERNEL_BUILDER(Name("IO>PulsarReadableInit").Device(DEVICE_CPU),
+                        PulsarReadableInitOp);
+REGISTER_KERNEL_BUILDER(Name("IO>PulsarReadableNext").Device(DEVICE_CPU),
+                        PulsarReadableNextOp);
+
+}  // namespace
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/ops/pulsar_ops.cc
+++ b/tensorflow_io/core/ops/pulsar_ops.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorflow_io/core/ops/pulsar_ops.cc
+++ b/tensorflow_io/core/ops/pulsar_ops.cc
@@ -48,6 +48,24 @@ REGISTER_OP("IO>PulsarReadableNext")
       return Status::OK();
     });
 
+REGISTER_OP("IO>PulsarWritableInit")
+    .Input("service_url: string")
+    .Input("topic: string")
+    .Output("resource: resource")
+    .Attr("container: string = ''")
+    .Attr("shared_name: string = ''")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Scalar());
+      return Status::OK();
+    });
+
+REGISTER_OP("IO>PulsarWritableWrite")
+    .Input("input: resource")
+    .Input("value: string")
+    .Input("key: string");
+
+REGISTER_OP("IO>PulsarWritableFlush").Input("input: resource");
+
 }  // namespace
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/ops/pulsar_ops.cc
+++ b/tensorflow_io/core/ops/pulsar_ops.cc
@@ -1,0 +1,53 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+namespace io {
+namespace {
+
+REGISTER_OP("IO>PulsarReadableInit")
+    .Input("service_url: string")
+    .Input("topic: string")
+    .Input("subscription: string")
+    .Input("ack_grouping_time: int64")
+    .Output("resource: resource")
+    .Attr("container: string = ''")
+    .Attr("shared_name: string = ''")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Scalar());
+      return Status::OK();
+    });
+
+REGISTER_OP("IO>PulsarReadableNext")
+    .Input("input: resource")
+    .Input("timeout: int32")
+    .Input("poll_timeout: int32")
+    .Output("message: string")
+    .Output("key: string")
+    .Output("continue_fetch: int64")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->MakeShape({c->UnknownDim()}));
+      c->set_output(1, c->MakeShape({c->UnknownDim()}));
+      c->set_output(2, c->Scalar());
+      return Status::OK();
+    });
+
+}  // namespace
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/python/api/experimental/streaming.py
+++ b/tensorflow_io/core/python/api/experimental/streaming.py
@@ -23,3 +23,6 @@ from tensorflow_io.core.python.experimental.kafka_batch_io_dataset_ops import ( 
 from tensorflow_io.core.python.experimental.pulsar_dataset_ops import (  # pylint: disable=unused-import
     PulsarIODataset,
 )
+from tensorflow_io.core.python.experimental.pulsar_writer_ops import (  # pylint: disable=unused-import
+    PulsarWriter,
+)

--- a/tensorflow_io/core/python/api/experimental/streaming.py
+++ b/tensorflow_io/core/python/api/experimental/streaming.py
@@ -20,3 +20,6 @@ from tensorflow_io.core.python.experimental.kafka_group_io_dataset_ops import ( 
 from tensorflow_io.core.python.experimental.kafka_batch_io_dataset_ops import (  # pylint: disable=unused-import
     KafkaBatchIODataset,
 )
+from tensorflow_io.core.python.experimental.pulsar_dataset_ops import (  # pylint: disable=unused-import
+    PulsarIODataset,
+)

--- a/tensorflow_io/core/python/experimental/pulsar_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/pulsar_dataset_ops.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow_io/core/python/experimental/pulsar_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/pulsar_dataset_ops.py
@@ -1,0 +1,99 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""PulsarDataset"""
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
+
+class PulsarIODataset(tf.data.Dataset):
+    """PulsarIODataset"""
+
+    def __init__(
+        self, service_url, topic, subscription, timeout, ack_grouping_time=-1, poll_timeout=100
+    ):
+        """Creates a `PulsarIODataset` from pulsar server with a subscription
+
+        Args:
+          service_url: A `tf.string` tensor containing the service url of pulsar broker.
+            For example: "pulsar://localhost:6650".
+          topic: A `tf.string` tensor containing the topic name.
+          subscription: A `tf.string` tensor containing the subscription name.
+          ack_grouping_time: A `tf.int64` tensor containing the ack grouping time.
+            If it's non-negative, each time a message was received, the consumer would add it to
+            a batch and acknowledge all pending messages later. `ack_grouping_time` is the interval
+            between two acknowledgements in milliseconds.
+            If it's negative, the message would be acknowledged immediately.
+            Default: -1
+          timeout: A `tf.int64` tensor containing the timeout in milliseconds. If no messages
+            were received after `timeout` milliseconds, we can treat it as no more messages.
+            `timeout` must be positive.
+          poll_timeout: A `tf.int64` tensor containing the poll timeout in milliseconds. The
+            pulsar consumer would try to receive a single message with the poll timeout, if no
+            message was received, it would try again until `timeout` exceeds.
+            `poll_timeout` must be positive and not larger than `timeout`.
+            Default: 100
+        """
+        with tf.name_scope("PulsarIODataset"):
+            if timeout <= 0:
+                raise ValueError("Invalid timeout value: {}, must be > 0".format(timeout))
+
+            if poll_timeout <= 0:
+                raise ValueError(
+                    "Invalid poll_timeout value: {}, must be > 0".format(
+                        poll_timeout
+                    )
+                )
+
+            if poll_timeout > timeout:
+                raise ValueError(
+                    "Invalid poll_timeout value: {}, must be <= timeout({})".format(
+                        poll_timeout, timeout
+                    )
+                )
+
+            resource = core_ops.io_pulsar_readable_init(
+                service_url,
+                topic,
+                subscription,
+                ack_grouping_time
+            )
+            self._resource = resource
+            dataset = tf.data.experimental.Counter()
+            dataset = dataset.map(
+                lambda i: core_ops.io_pulsar_readable_next(
+                    input=self._resource,
+                    timeout=timeout,
+                    poll_timeout=poll_timeout
+                )
+            )
+            dataset = dataset.apply(
+                tf.data.experimental.take_while(
+                    lambda v: tf.greater(v.continue_fetch, 0)
+                )
+            )
+            dataset = dataset.map(lambda v: (v.message, v.key))
+            dataset = dataset.unbatch()
+
+            self._dataset = dataset
+            super().__init__(
+                self._dataset._variant_tensor
+            )  # pylint: disable=protected-access
+
+    def _inputs(self):
+        return []
+
+    @property
+    def element_spec(self):
+        return self._dataset.element_spec

--- a/tensorflow_io/core/python/experimental/pulsar_dataset_ops.py
+++ b/tensorflow_io/core/python/experimental/pulsar_dataset_ops.py
@@ -17,11 +17,18 @@
 import tensorflow as tf
 from tensorflow_io.core.python.ops import core_ops
 
+
 class PulsarIODataset(tf.data.Dataset):
     """PulsarIODataset"""
 
     def __init__(
-        self, service_url, topic, subscription, timeout, ack_grouping_time=-1, poll_timeout=100
+        self,
+        service_url,
+        topic,
+        subscription,
+        timeout,
+        ack_grouping_time=-1,
+        poll_timeout=100,
     ):
         """Creates a `PulsarIODataset` from pulsar server with a subscription
 
@@ -47,13 +54,13 @@ class PulsarIODataset(tf.data.Dataset):
         """
         with tf.name_scope("PulsarIODataset"):
             if timeout <= 0:
-                raise ValueError("Invalid timeout value: {}, must be > 0".format(timeout))
+                raise ValueError(
+                    "Invalid timeout value: {}, must be > 0".format(timeout)
+                )
 
             if poll_timeout <= 0:
                 raise ValueError(
-                    "Invalid poll_timeout value: {}, must be > 0".format(
-                        poll_timeout
-                    )
+                    "Invalid poll_timeout value: {}, must be > 0".format(poll_timeout)
                 )
 
             if poll_timeout > timeout:
@@ -64,18 +71,13 @@ class PulsarIODataset(tf.data.Dataset):
                 )
 
             resource = core_ops.io_pulsar_readable_init(
-                service_url,
-                topic,
-                subscription,
-                ack_grouping_time
+                service_url, topic, subscription, ack_grouping_time
             )
             self._resource = resource
             dataset = tf.data.experimental.Counter()
             dataset = dataset.map(
                 lambda i: core_ops.io_pulsar_readable_next(
-                    input=self._resource,
-                    timeout=timeout,
-                    poll_timeout=poll_timeout
+                    input=self._resource, timeout=timeout, poll_timeout=poll_timeout
                 )
             )
             dataset = dataset.apply(

--- a/tensorflow_io/core/python/experimental/pulsar_writer_ops.py
+++ b/tensorflow_io/core/python/experimental/pulsar_writer_ops.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow_io/core/python/experimental/pulsar_writer_ops.py
+++ b/tensorflow_io/core/python/experimental/pulsar_writer_ops.py
@@ -34,7 +34,7 @@ class PulsarWriter:
             self._resource = resource
 
     def write(self, value, key=""):
-        """Write a message to pulsar topic
+        """Write a message to pulsar topic asynchronously
 
         Args:
           value: A `tf.string` tensor containing the value of message
@@ -44,5 +44,5 @@ class PulsarWriter:
         return core_ops.io_pulsar_writable_write(self._resource, value, key)
 
     def flush(self):
-        """Flush the queued messages"""
+        """Flush the queued messages, it will wait async write operations completed."""
         return core_ops.io_pulsar_writable_flush(self._resource)

--- a/tensorflow_io/core/python/experimental/pulsar_writer_ops.py
+++ b/tensorflow_io/core/python/experimental/pulsar_writer_ops.py
@@ -1,0 +1,48 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""PulsarWriter"""
+
+import tensorflow as tf
+from tensorflow_io.core.python.ops import core_ops
+
+
+class PulsarWriter:
+    """PulsarWriter"""
+
+    def __init__(self, service_url, topic):
+        """Creates a `PulsarWriter` for writing messages to a pulsar topic
+
+        Args:
+          service_url: A `tf.string` tensor containing the service url of pulsar broker.
+            For example: "pulsar://localhost:6650".
+          topic: A `tf.string` tensor containing the topic name.
+        """
+        with tf.name_scope("PulsarWriter"):
+            resource = core_ops.io_pulsar_writable_init(service_url, topic)
+            self._resource = resource
+
+    def write(self, value, key=""):
+        """Write a message to pulsar topic
+
+        Args:
+          value: A `tf.string` tensor containing the value of message
+          key: A `tf.string` tensor containing the key of message, if it's an empty string, the message will have no key.
+            Default: ""
+        """
+        return core_ops.io_pulsar_writable_write(self._resource, value, key)
+
+    def flush(self):
+        """Flush the queued messages"""
+        return core_ops.io_pulsar_writable_flush(self._resource)

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+set -o pipefail
+
+VERSION=2.6.1
+TAR_FILE="apache-pulsar-${VERSION}-bin.tar.gz"
+
+echo "Downloading pulsar ${VERSION}"
+if [[ ! -f apache-pulsar-2.6.1-bin.tar.gz ]]; then
+  curl -sSOL "https://downloads.apache.org/pulsar/pulsar-2.6.1/${TAR_FILE}"
+fi
+
+tar -xzf ${TAR_FILE}
+cd "apache-pulsar-${VERSION}"
+
+echo "Disable deleting inactive topics"
+sed -i '' "s/brokerDeleteInactiveTopicsFrequencySeconds=.*/brokerDeleteInactiveTopicsFrequencySeconds=86400/" conf/standalone.conf
+
+bin/pulsar-daemon start standalone
+
+echo "-- Wait for Pulsar service to be ready"
+until curl http://localhost:8080/metrics > /dev/null 2>&1 ; do sleep 1; done
+echo "-- Pulsar service is ready -- Configure permissions"
+
+echo "Creating and populating 'test' topic with sample non-keyed messages"
+bin/pulsar-client produce -m "D0,D1,D2,D3,D4,D5" test
+
+echo "Creating and populating 'key-test' topic with sample keyed messages"
+bin/pulsar-client produce -m "D0" -k "K0" key-test
+bin/pulsar-client produce -m "D1" -k "K1" key-test
+bin/pulsar-client produce -m "D2" -k "K0" key-test
+bin/pulsar-client produce -m "D3" -k "K1" key-test
+bin/pulsar-client produce -m "D4" -k "K0" key-test
+bin/pulsar-client produce -m "D5" -k "K1" key-test
+
+echo "Pulsar test setup completed"
+exit 0

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -21,8 +21,8 @@ VERSION=2.6.1
 TAR_FILE="apache-pulsar-${VERSION}-bin.tar.gz"
 
 echo "Downloading pulsar ${VERSION}"
-if [[ ! -f apache-pulsar-2.6.1-bin.tar.gz ]]; then
-  curl -sSOL "https://downloads.apache.org/pulsar/pulsar-2.6.1/${TAR_FILE}"
+if [[ ! -f ${TAR_FILE} ]]; then
+  curl -sSOL "https://downloads.apache.org/pulsar/pulsar-${VERSION}/${TAR_FILE}"
 fi
 
 tar -xzf ${TAR_FILE}

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -29,6 +29,7 @@ tar -xzf ${TAR_FILE}
 cd "apache-pulsar-${VERSION}"
 
 echo "Disable deleting inactive topics"
+sed -i.bak 's/zookeeperServers=.*/zookeeperServers=localhost:2182/' conf/standalone.conf
 sed -i.bak "s/brokerDeleteInactiveTopicsFrequencySeconds=.*/brokerDeleteInactiveTopicsFrequencySeconds=86400/" conf/standalone.conf
 
 bin/pulsar-daemon start standalone

--- a/tests/test_pulsar_eager.py
+++ b/tests/test_pulsar_eager.py
@@ -1,0 +1,133 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# ==============================================================================
+"""Tests for Pulsar Dataset"""
+
+import numpy as np
+
+import tensorflow as tf
+import tensorflow_io as tfio
+
+def test_pulsar_simple_messages():
+    """Test consuming simple messages from a Pulsar topic with PulsarIODataset. 
+
+    NOTE: After the pulsar standalone is setup during the testing phase, 6 messages
+    (D0, D1, ..., D5) are sent to the `test` topic.
+    """
+
+    dataset = tfio.experimental.streaming.PulsarIODataset(
+        service_url="pulsar://localhost:6650",
+        topic="test",
+        subscription="subscription-0",
+        timeout=1000,
+    )
+    assert np.all(
+        [k.numpy() for (k, _) in dataset]
+        == [("D" + str(i)).encode() for i in range(6)]
+    )
+
+
+def test_pulsar_keyed_messages():
+    """Test consuming keyed messages from a Pulsar topic with PulsarIODataset
+
+    NOTE: After the pulsar standalone is setup during the testing phase, 6 messages
+    are sent to the `test` topic:
+
+    K0:D0, K1:D1, K0:D2, K1:D3, K0:D4, K1:D5.
+    """
+
+    dataset = tfio.experimental.streaming.PulsarIODataset(
+        service_url="pulsar://localhost:6650",
+        topic="key-test",
+        subscription="subscription-0",
+        timeout=1000,
+    )
+    kv = dict()
+    for (msg, key) in dataset:
+        kv.setdefault(key.numpy().decode(), []).append(msg.numpy())
+    assert kv["K0"] == [("D" + str(i)).encode() for i in range(0, 6, 2)]
+    assert kv["K1"] == [("D" + str(i)).encode() for i in range(1, 6, 2)]
+
+
+def test_pulsar_resubscribe():
+    """Test resubscribing the same topic.
+
+    If a topic is resubscribed with an existed subscription, the consumer will continue
+    consuming from the last position.
+
+    NOTE: This test must be run after `test_pulsar_simple_messages`.
+    """
+
+    dataset = tfio.experimental.streaming.PulsarIODataset(
+        service_url="pulsar://localhost:6650",
+        topic="test",
+        subscription="subscription-0",
+        timeout=1000,
+    )
+    assert len([msg for (msg, _) in dataset]) == 0
+
+
+def test_pulsar_invalid_arguments():
+    """Test the invalid arguments when a PulsarIODataset is created
+
+    The following cases are included:
+    1. timeout is non-positive
+    2. poll_timeout is non-positive
+    3. poll_timeout is larger than timeout
+    """
+
+    INVALID_TIMEOUT = -123
+    try:
+        tfio.experimental.streaming.PulsarIODataset(
+            service_url="pulsar://localhost:6650",
+            topic="test",
+            subscription="subscription-0",
+            timeout=INVALID_TIMEOUT,
+        )
+    except ValueError as e:
+        assert str(e) == "Invalid timeout value: {}, must be > 0".format(INVALID_TIMEOUT)
+
+    VALID_TIMEOUT = 1000
+    INVALID_POLL_TIMEOUT = -45
+    try:
+        tfio.experimental.streaming.PulsarIODataset(
+            service_url="pulsar://localhost:6650",
+            topic="test",
+            subscription="subscription-0",
+            timeout=VALID_TIMEOUT,
+            poll_timeout=INVALID_POLL_TIMEOUT,
+        )
+    except ValueError as e:
+        assert str(e) == "Invalid poll_timeout value: {}, must be > 0".format(INVALID_POLL_TIMEOUT)
+
+    LARGE_POLL_TIMEOUT = VALID_TIMEOUT + 1
+    try:
+        tfio.experimental.streaming.PulsarIODataset(
+            service_url="pulsar://localhost:6650",
+            topic="test",
+            subscription="subscription-0",
+            timeout=VALID_TIMEOUT,
+            poll_timeout=LARGE_POLL_TIMEOUT,
+        )
+    except ValueError as e:
+        assert str(
+            e
+        ) == "Invalid poll_timeout value: {}, must be <= timeout({})".format(
+            LARGE_POLL_TIMEOUT,
+            VALID_TIMEOUT
+        )
+
+
+if __name__ == "__main__":
+    test.main()

--- a/tests/test_pulsar_eager.py
+++ b/tests/test_pulsar_eager.py
@@ -19,6 +19,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_io as tfio
 
+
 def test_pulsar_simple_messages():
     """Test consuming simple messages from a Pulsar topic with PulsarIODataset. 
 
@@ -33,8 +34,7 @@ def test_pulsar_simple_messages():
         timeout=1000,
     )
     assert np.all(
-        [k.numpy() for (k, _) in dataset]
-        == [("D" + str(i)).encode() for i in range(6)]
+        [k.numpy() for (k, _) in dataset] == [("D" + str(i)).encode() for i in range(6)]
     )
 
 
@@ -96,7 +96,9 @@ def test_pulsar_invalid_arguments():
             timeout=INVALID_TIMEOUT,
         )
     except ValueError as e:
-        assert str(e) == "Invalid timeout value: {}, must be > 0".format(INVALID_TIMEOUT)
+        assert str(e) == "Invalid timeout value: {}, must be > 0".format(
+            INVALID_TIMEOUT
+        )
 
     VALID_TIMEOUT = 1000
     INVALID_POLL_TIMEOUT = -45
@@ -109,7 +111,9 @@ def test_pulsar_invalid_arguments():
             poll_timeout=INVALID_POLL_TIMEOUT,
         )
     except ValueError as e:
-        assert str(e) == "Invalid poll_timeout value: {}, must be > 0".format(INVALID_POLL_TIMEOUT)
+        assert str(e) == "Invalid poll_timeout value: {}, must be > 0".format(
+            INVALID_POLL_TIMEOUT
+        )
 
     LARGE_POLL_TIMEOUT = VALID_TIMEOUT + 1
     try:
@@ -124,8 +128,7 @@ def test_pulsar_invalid_arguments():
         assert str(
             e
         ) == "Invalid poll_timeout value: {}, must be <= timeout({})".format(
-            LARGE_POLL_TIMEOUT,
-            VALID_TIMEOUT
+            LARGE_POLL_TIMEOUT, VALID_TIMEOUT
         )
 
 

--- a/tests/test_pulsar_eager.py
+++ b/tests/test_pulsar_eager.py
@@ -20,6 +20,9 @@ import tensorflow as tf
 import tensorflow_io as tfio
 
 
+default_pulsar_timeout = 5000
+
+
 def test_pulsar_simple_messages():
     """Test consuming simple messages from a Pulsar topic with PulsarIODataset. 
 
@@ -31,7 +34,7 @@ def test_pulsar_simple_messages():
         service_url="pulsar://localhost:6650",
         topic="test",
         subscription="subscription-0",
-        timeout=1000,
+        timeout=default_pulsar_timeout,
     )
     assert np.all(
         [k.numpy() for (k, _) in dataset] == [("D" + str(i)).encode() for i in range(6)]
@@ -51,7 +54,7 @@ def test_pulsar_keyed_messages():
         service_url="pulsar://localhost:6650",
         topic="key-test",
         subscription="subscription-0",
-        timeout=1000,
+        timeout=default_pulsar_timeout,
     )
     kv = dict()
     for (msg, key) in dataset:
@@ -83,7 +86,7 @@ def test_pulsar_resubscribe():
         service_url="pulsar://localhost:6650",
         topic=topic,
         subscription="subscription-0",
-        timeout=1000,
+        timeout=default_pulsar_timeout,
     )
     assert np.all(
         [k.numpy() for (k, _) in dataset]
@@ -95,7 +98,7 @@ def test_pulsar_resubscribe():
         service_url="pulsar://localhost:6650",
         topic=topic,
         subscription="subscription-1",
-        timeout=1000,
+        timeout=default_pulsar_timeout,
     )
     assert np.all(
         [k.numpy() for (k, _) in dataset]
@@ -125,7 +128,7 @@ def test_pulsar_invalid_arguments():
             INVALID_TIMEOUT
         )
 
-    VALID_TIMEOUT = 1000
+    VALID_TIMEOUT = default_pulsar_timeout
     INVALID_POLL_TIMEOUT = -45
     try:
         tfio.experimental.streaming.PulsarIODataset(
@@ -175,7 +178,7 @@ def test_pulsar_write_simple_messages():
         service_url="pulsar://localhost:6650",
         topic=topic,
         subscription="subscription-0",
-        timeout=1000,
+        timeout=default_pulsar_timeout,
     )
     assert np.all(
         [k.numpy() for (k, _) in dataset]
@@ -203,7 +206,7 @@ def test_pulsar_write_keyed_messages():
         service_url="pulsar://localhost:6650",
         topic=topic,
         subscription="subscription-0",
-        timeout=1000,
+        timeout=default_pulsar_timeout,
     )
     kv = dict()
     for (msg, key) in dataset:

--- a/tests/test_pulsar_eager.py
+++ b/tests/test_pulsar_eager.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License.  You may obtain a copy of

--- a/third_party/boost.BUILD
+++ b/third_party/boost.BUILD
@@ -13,6 +13,9 @@ cc_library(
         "boost/**/*.hpp",
         "boost/predef/**/*.h",
         "boost/detail/**/*.ipp",
+        "boost/asio/**/*.ipp",
+        "boost/date_time/**/*.ipp",
+        "boost/xpressive/detail/**/*.ipp",
     ]) + glob([
         "libs/filesystem/src/*.cpp",
         "libs/iostreams/src/*.cpp",

--- a/third_party/dlfcn-win32.BUILD
+++ b/third_party/dlfcn-win32.BUILD
@@ -1,0 +1,22 @@
+# Description:
+#   dlfcn-win32
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # MIT
+
+exports_files(["COPYING"])
+
+cc_library(
+    name = "dlfcn-win32",
+    srcs = [
+        "dlfcn.c",
+        "dlfcn.h",
+    ],
+    hdrs = [],
+    defines = [],
+    includes = [
+        ".",
+    ],
+    deps = [],
+)

--- a/third_party/pulsar.BUILD
+++ b/third_party/pulsar.BUILD
@@ -1,0 +1,51 @@
+# Description:
+#   Pulsar C++ client library
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+proto_library(
+    name = "PulsarApi_proto",
+    srcs = ["pulsar-client-cpp/lib/PulsarApi.proto"],
+)
+
+cc_proto_library(
+    name = "PulsarApi_cc_proto",
+    deps = [":PulsarApi_proto"],
+)
+
+cc_library(
+    name = "pulsar",
+    srcs = glob([
+        "pulsar-client-cpp/include/pulsar/*.h",
+        "pulsar-client-cpp/lib/*.h",
+        "pulsar-client-cpp/lib/*.cc",
+        "pulsar-client-cpp/lib/auth/**/*.h",
+        "pulsar-client-cpp/lib/auth/**/*.cc",
+        # lz4 is imported in another package, so we just add the header here
+        "pulsar-client-cpp/lib/lz4/*.h",
+        "pulsar-client-cpp/lib/checksum/*.h",
+        "pulsar-client-cpp/lib/checksum/*.hpp",
+        "pulsar-client-cpp/lib/checksum/*.cc",
+        "pulsar-client-cpp/lib/stats/*.h",
+        "pulsar-client-cpp/lib/stats/*.cc",
+    ]),
+    copts = [
+        "-msse4.2",
+        "-mpclmul",
+    ],
+    defines = ["_PULSAR_VERSION_=\\\"2.6.1\\\""],
+    includes = [
+        "pulsar-client-cpp",
+        "pulsar-client-cpp/include",
+        "pulsar-client-cpp/lib",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":PulsarApi_cc_proto",
+        "@boost",
+        "@curl",
+        "@zstd",
+    ],
+)

--- a/third_party/pulsar.BUILD
+++ b/third_party/pulsar.BUILD
@@ -35,7 +35,11 @@ cc_library(
         "-msse4.2",
         "-mpclmul",
     ],
-    defines = ["_PULSAR_VERSION_=\\\"2.6.1\\\""],
+    defines = [
+        "_PULSAR_VERSION_=\\\"2.6.1\\\"",
+        "WIN32_LEAN_AND_MEAN",
+        "PULSAR_STATIC",
+    ],
     includes = [
         "pulsar-client-cpp",
         "pulsar-client-cpp/include",
@@ -45,7 +49,14 @@ cc_library(
     deps = [
         ":PulsarApi_cc_proto",
         "@boost",
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
         "@curl",
         "@zstd",
-    ],
+    ] + select({
+        "@bazel_tools//src/conditions:windows": [
+            "@dlfcn-win32",
+        ],
+        "//conditions:default": [],
+    }),
 )


### PR DESCRIPTION
This PR is to add support for [Apache Pulsar](http://pulsar.apache.org), which is a cloud-native, distributed messaging and streaming platform.

This PR introduced two classes:
- `PulsarIODataset`: Read streaming messages from Pulsar topics
- `PulsarWriter`: Write messages to Pulsar topics

Since Pulsar has a lot in common with Kafka, the `PulsarIODataset` implementation is similar to `KafkaGroupIODataset` except it cannot check the partition EOF.

Different from the simple `write_kafka` function, `PulsarWriter` has three ops: init, write messages asynchronously, flush pending messages.