### PR TITLE
Fix test flakiness caused by pulsar test startup script

### DIFF
--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -36,14 +36,16 @@ bin/pulsar-daemon start standalone
 
 echo "Waiting for Pulsar service ready or 30 seconds passed"
 for i in {1..30}; do
-  RESPONSE=$(curl --write-out '%{http_code}' --silent -o /dev/null -L http://localhost:8080/metrics) || true
+  RESPONSE=$(curl --write-out '%{http_code}' --silent -o /dev/null -L http://localhost:8080/admin/v2/persistent/public/default) || true
   if [[ $RESPONSE == 200 ]]; then
-      echo "[$i] Fetch metrics successfully"
+      echo "[$i] Access namespace public/default successfully"
       break
   fi
-  echo "[$i] Fetch metrics failed: $RESPONSE, sleep for 1 second"
+  echo "[$i] Access namespace public/default failed: $RESPONSE, sleep for 1 second"
   sleep 1
 done
+echo "Sleep for 5 seconds more to avoid flaky test"
+sleep 5
 
 echo "Creating and populating 'test' topic with sample non-keyed messages"
 bin/pulsar-client produce -m "D0,D1,D2,D3,D4,D5" test


### PR DESCRIPTION
The current `pulsar_test.sh` only checks if metrics is available and then start the client to write test data. But in CI environment, the namespace may not be available now. For example, see https://github.com/tensorflow/io/runs/1462090555:

```
05:04:29.719 [pulsar-client-io-1-1] WARN  org.apache.pulsar.client.impl.BinaryProtoLookupService - [persistent://public/default/test] failed to get Partitioned metadata : Policies not found for public/default namespace
876
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$BrokerMetadataException: Policies not found for public/default namespace
```

It means that the default namespace `public/default` was not available when the client tried to create a topic under the namespace.

So this PR changes the REST request to retrieve topics under the namespace instead of broker's metrics. And wait for another 5 seconds, which may be useless but could avoid the unexpected test failure IMO.