### PR TITLE
Add missed function RecursivelyCreateDir for hdfs file system implementation

### DIFF
--- a/tensorflow_io/core/plugins/hdfs/hadoop_filesystem.cc
+++ b/tensorflow_io/core/plugins/hdfs/hadoop_filesystem.cc
@@ -774,6 +774,11 @@ void CreateDir(const TF_Filesystem* filesystem, const char* path,
     TF_SetStatus(status, TF_OK, "");
 }
 
+static void RecursivelyCreateDir(const TF_Filesystem* filesystem,
+                                 const char* path, TF_Status* status) {
+  CreateDir(filesystem, path, status);
+}
+
 void DeleteDir(const TF_Filesystem* filesystem, const char* path,
                TF_Status* status) {
   auto hadoop_file =
@@ -931,6 +936,8 @@ void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops, const char* uri) {
   ops->filesystem_ops->new_read_only_memory_region_from_file =
       tf_hdfs_filesystem::NewReadOnlyMemoryRegionFromFile;
   ops->filesystem_ops->create_dir = tf_hdfs_filesystem::CreateDir;
+  ops->filesystem_ops->recursively_create_dir =
+      tf_hdfs_filesystem::RecursivelyCreateDir;
   ops->filesystem_ops->delete_file = tf_hdfs_filesystem::DeleteFile;
   ops->filesystem_ops->delete_dir = tf_hdfs_filesystem::DeleteDir;
   ops->filesystem_ops->rename_file = tf_hdfs_filesystem::RenameFile;


### PR DESCRIPTION
This PR adds missed function RecursivelyCreateDir for hdfs file system implementation

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>