### PR TITLE
fix the failing lint jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           set -x -e
           git log --pretty -1
           sudo python3 --version
+          sudo python3 -m pip install dataclasses
           sudo python3 -m pip install setuptools
           sudo python3 -m pip install -U git+https://github.com/tensorflow/docs
           find docs -name '*.ipynb' | xargs python3 -m tensorflow_docs.tools.nbfmt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           set -x -e
           git log --pretty -1
+          sudo python3 --version
           sudo python3 -m pip install setuptools
           sudo python3 -m pip install -U git+https://github.com/tensorflow/docs
           find docs -name '*.ipynb' | xargs python3 -m tensorflow_docs.tools.nbfmt


### PR DESCRIPTION
This PR addresses the failing lint jobs in GitHub actions due to the absence of `dataclasses` module in python3.6 by default.