### PR TITLE
Remove test for Ubuntu 18.04 and leave only Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,19 +59,6 @@ jobs:
           bash -x -e source.sh
           python3 -c 'import tensorflow as tf; print(tf.version.VERSION)'
 
-  ubuntu-1804:
-    name: Ubuntu 18.04
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
-          cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:18.04 \
-            bash -x -e source.sh
-
   ubuntu-2004:
     name: Ubuntu 20.04
     runs-on: ubuntu-latest
@@ -80,7 +67,7 @@ jobs:
       - run: |
           set -x -e
           bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 18.04/20.04" > source.sh
+          python3 .github/workflows/build.instruction.py README.md "##### Ubuntu 20.04" > source.sh
           cat source.sh
           docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:20.04 \
             bash -x -e source.sh

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ Development of tensorflow-io on Linux is similar to macOS. The required packages
 are gcc, g++, git, bazel, and python 3. Newer versions of gcc or python, other than the default system installed
 versions might be required though.
 
-##### Ubuntu 18.04/20.04
+##### Ubuntu 20.04
 
-Ubuntu 18.04/20.04 requires gcc/g++, git, and python 3. The following will install dependencies and build
-the shared libraries on Ubuntu 18.04/20.04:
+Ubuntu 20.04 requires gcc/g++, git, and python 3. The following will install dependencies and build
+the shared libraries on Ubuntu 20.04:
 ```sh
 #!/usr/bin/env bash
 


### PR DESCRIPTION
Currently we test build instructions for both Ubuntu 18.04 and Ubuntu 20.04.
However they are pretty much the same other than this is one more test
that may fail when GitHub Action is not too reliable (see https://github.com/tensorflow/io/runs/1532063166)

Since Ubuntu 20.04 is becomming more widely adopted than 18.04 now,
for that reason I think it makes sense to remove the Ubuntu 18.04 test
and leave only Ubuntu 20.04 test.

This can avoid some intermittent test failures.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>