### PR TITLE
test elasticsearch and mongodb datasets on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run Lint Script for Bazel/Pyupgrade/Black/Clang

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,8 @@ jobs:
           bash -x -e tests/test_pubsub/pubsub_test.sh
           bash -x -e tests/test_aws/aws_test.sh
           bash -x -e tests/test_pulsar/pulsar_test.sh
+          bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
+          bash -x -e tests/test_mongodb/mongodb_test.sh start
       - name: Install ${{ matrix.python }} macOS
         run: |
           set -x -e

--- a/tests/test_elasticsearch/elasticsearch_test.sh
+++ b/tests/test_elasticsearch/elasticsearch_test.sh
@@ -46,7 +46,7 @@ ${ELASTICSEARCH_IMAGE}
 echo ""
 echo "Waiting for the elasticsearch cluster to be up and running..."
 echo ""
-sleep 20
+sleep 40
 
 echo ""
 echo "Checking the base REST-API endpoint..."

--- a/tests/test_elasticsearch/elasticsearch_test.sh
+++ b/tests/test_elasticsearch/elasticsearch_test.sh
@@ -43,21 +43,23 @@ docker run -d --rm --name=tfio-elasticsearch \
 --ulimit memlock=-1:-1 \
 ${ELASTICSEARCH_IMAGE}
 
-echo ""
 echo "Waiting for the elasticsearch cluster to be up and running..."
-echo ""
-sleep 40
+for i in {1..120}; do
+  RESPONSE=$(curl -w '%{http_code}' -H 'Authorization: Basic ZWxhc3RpYzpkZWZhdWx0X3Bhc3N3b3Jk' -so /dev/null -L localhost:9200/) || true
+  if [[ $RESPONSE == 200 ]]; then
+      echo "[$i] Accessed base endpoint successfully"
+      break
+  fi
+  echo "[$i] Access base endpoint failed: $RESPONSE, sleep for 1 second"
+  sleep 1
+done
 
-echo ""
-echo "Checking the base REST-API endpoint..."
-echo ""
-# The Authorization header contains the base64 encoded value of "elastic:default_password"
-# As per the environment variable set while starting the container.
-curl -X GET localhost:9200/ --header 'Authorization: Basic ZWxhc3RpYzpkZWZhdWx0X3Bhc3N3b3Jk'
 
 echo ""
 echo "Checking the healthcheck REST-API endpoint..."
 echo ""
+# The Authorization header contains the base64 encoded value of "elastic:default_password"
+# As per the environment variable set while starting the container.
 curl -X GET localhost:9200/_cluster/health --header 'Authorization: Basic ZWxhc3RpYzpkZWZhdWx0X3Bhc3N3b3Jk'
 
 echo ""

--- a/tests/test_mongodb/mongodb_test.sh
+++ b/tests/test_mongodb/mongodb_test.sh
@@ -35,7 +35,7 @@ docker run --rm -d -p 27017-27019:27017-27019 --name tfio-mongodb \
 echo ""
 echo "Waiting for mongodb to be up and running..."
 echo ""
-sleep 20
+sleep 60
 
 elif [ "$action" == "stop" ]; then
 echo ""


### PR DESCRIPTION
This PR:
- enables the tests for Elasticsearch and MongoDB datasets on macOS environment in Github actions.
- switches to `ubuntu-latest` for lint checks.