### PR TITLE
Bump `aws-sdk-cpp` to 1.18.105

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -385,11 +385,11 @@ http_archive(
     patch_cmds = [
         """sed -i.bak 's/UUID::RandomUUID/Aws::Utils::UUID::RandomUUID/g' aws-cpp-sdk-core/source/client/AWSClient.cpp""",
     ],
-    sha256 = "758174f9788fed6cc1e266bcecb20bf738bd5ef1c3d646131c9ed15c2d6c5720",
-    strip_prefix = "aws-sdk-cpp-1.7.336",
+    sha256 = "e8223d59c4774afa9c1ef40ec68fbb7e9e080725cde024ce0cd8351f98dba00d",
+    strip_prefix = "aws-sdk-cpp-1.8.105",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
-        "https://github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.8.105.tar.gz",
+        "https://github.com/aws/aws-sdk-cpp/archive/1.8.105.tar.gz",
     ],
 )
 

--- a/tensorflow_io/core/plugins/BUILD
+++ b/tensorflow_io/core/plugins/BUILD
@@ -15,9 +15,13 @@ cc_library(
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [
-        "@local_config_tf//:libtensorflow_framework",
         "@local_config_tf//:tf_c_header_lib",
-    ],
+    ] + select({
+        "@bazel_tools//src/conditions:windows": [
+            "@local_config_tf//:libtensorflow_framework",
+        ],
+        "//conditions:default": [],
+    }),
     alwayslink = 1,
 )
 

--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -54,10 +54,10 @@ cc_library(
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
     ],
     defines = [
-        'AWS_SDK_VERSION_STRING=\\"1.7.366\\"',
+        'AWS_SDK_VERSION_STRING=\\"1.8.105\\"',
         "AWS_SDK_VERSION_MAJOR=1",
-        "AWS_SDK_VERSION_MINOR=7",
-        "AWS_SDK_VERSION_PATCH=366",
+        "AWS_SDK_VERSION_MINOR=8",
+        "AWS_SDK_VERSION_PATCH=105",
         "ENABLE_OPENSSL_ENCRYPTION=1",
         "ENABLE_CURL_CLIENT=1",
         "OPENSSL_IS_BORINGSSL=1",

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -112,7 +112,7 @@ genrule(
         "#  define HAVE_SYS_FILIO_H 1",
         "#  define HAVE_SYS_SOCKIO_H 1",
         "#  define OS \"x86_64-apple-darwin15.5.0\"",
-        "#  define USE_DARWINSSL 1",
+        "#  define USE_SECTRANSP 1",
         "#else",
         "#  define CURL_CA_BUNDLE \"/etc/ssl/certs/ca-certificates.crt\"",
         "#  define GETSERVBYPORT_R_ARGS 6",


### PR DESCRIPTION
This PR:

- Bump `aws-sdk-cpp` to 1.18.105
- Remove unused code for getting s3 region since it will be done automatically by [`aws-sdk-cpp`](https://github.com/aws/aws-sdk-cpp/wiki/What’s-New-in-AWS-SDK-for-CPP-Version-1.8#client-configuration-now-reads-environment-variables-configuration-file-and-ec2-metadata-to-get-default-aws-region)
- Enable [`ENABLE_CURL_LOGGING`](https://github.com/aws/aws-sdk-cpp/wiki/What’s-New-in-AWS-SDK-for-CPP-Version-1.8#turn-on-enable_curl_logging-by-default)
- Support more http code for `TF_SetStatusFromAWSError`
- I am introducing a breaking change here. `RecursivelyCreateDir` now calls `CreateDir` instead of relying on TensorFlow fallback. ( Not really a breaking change though )

Part of #1183 