### PR TITLE
Update the API Compatibility test to include tf-nightly vs. tensorflow-io==0.17.0

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.4.0rc4:tensorflow-io-nightly', 'tf-nightly:tensorflow-io-nightly']
+        version: ['tensorflow==2.4.0:tensorflow-io-nightly', 'tf-nightly:tensorflow-io==0.17.0', 'tf-nightly:tensorflow-io-nightly']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.4.0rc4:tensorflow-io-nightly', 'tf-nightly:tensorflow-io-nightly']
+        version: ['tensorflow==2.4.0:tensorflow-io-nightly', 'tf-nightly:tensorflow-io==0.17.0', 'tf-nightly:tensorflow-io-nightly']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,6 +1,9 @@
 name: API Compatibility
 
 on:
+  push:
+    branches:
+      - master
   schedule:
     - cron: "0 12 * * *"
 
@@ -15,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.4.0rc4:tensorflow-io-nightly', 'tf-nightly:tensorflow-io-nightly']
+        version: ['tensorflow==2.4.0:tensorflow-io-nightly', 'tf-nightly:tensorflow-io==0.17.0', 'tf-nightly:tensorflow-io-nightly']
     steps:
       - uses: actions/checkout@v2
       - uses: docker-practice/actions-setup-docker@v1


### PR DESCRIPTION
Update the API Compatibility test to include tf-nightly vs. tensorflow-io==0.17.0, as we released tensorflow-io==0.17.0

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>