### PR TITLE
Add emulator for gcs

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -50,6 +50,7 @@ jobs:
           python -m pytest -s -v tests/test_http_eager.py
           python -m pytest -s -v tests/test_s3_eager.py
           python -m pytest -s -v tests/test_azure.py
+          python -m pytest -s -v tests/test_gcs_eager.py
 
   linux:
     name: Linux ${{ matrix.python }} + ${{ matrix.version }}
@@ -85,6 +86,7 @@ jobs:
           python -m pytest -s -v tests/test_http_eager.py
           python -m pytest -s -v tests/test_s3_eager.py
           python -m pytest -s -v tests/test_azure.py
+          python -m pytest -s -v tests/test_gcs_eager.py
 
   windows:
     name: Windows ${{ matrix.python }} + ${{ matrix.version }}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -584,11 +584,11 @@ http_archive(
         "@com_github_curl_curl": "@curl",
         "@com_github_nlohmann_json": "@nlohmann_json_lib",
     },
-    sha256 = "ff82045b9491f0d880fc8e5c83fd9542eafb156dcac9ff8c6209ced66ed2a7f0",
-    strip_prefix = "google-cloud-cpp-1.17.1",
+    sha256 = "14bf9bf97431b890e0ae5dca8f8904841d4883b8596a7108a42f5700ae58d711",
+    strip_prefix = "google-cloud-cpp-1.21.0",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/googleapis/google-cloud-cpp/archive/v1.17.1.tar.gz",
-        "https://github.com/googleapis/google-cloud-cpp/archive/v1.17.1.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/googleapis/google-cloud-cpp/archive/v1.21.0.tar.gz",
+        "https://github.com/googleapis/google-cloud-cpp/archive/v1.21.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -419,11 +419,11 @@ http_archive(
 http_archive(
     name = "curl",
     build_file = "//third_party:curl.BUILD",
-    sha256 = "e9c37986337743f37fd14fe8737f246e97aec94b39d1b71e8a5973f72a9fc4f5",
-    strip_prefix = "curl-7.60.0",
+    sha256 = "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98",
+    strip_prefix = "curl-7.69.1",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.60.0.tar.gz",
-        "https://curl.haxx.se/download/curl-7.60.0.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.69.1.tar.gz",
+        "https://curl.haxx.se/download/curl-7.69.1.tar.gz",
     ],
 )
 

--- a/tests/test_gcloud/test_gcs.sh
+++ b/tests/test_gcloud/test_gcs.sh
@@ -4,7 +4,7 @@ set -o pipefail
 if [ "$#" -eq 1 ]; then
   container=$1
   docker pull python:3.8
-  docker run -d --rm --net=host --name=$container -v $PWD:/v -w /v python:3.8 bash -x -c 'python3 -m pip install gcloud-storage-emulator==0.3.0 && gcloud-storage-emulator start --port=9099'
+  docker run -d --rm --net=host --name=$container -v $PWD:/v -w /v python:3.8 bash -x -c 'python3 -m pip install -r /v/tests/test_gcloud/testbench/requirements.txt && gunicorn --bind "0.0.0.0:9099" --worker-class gevent --chdir "/v/tests/test_gcloud/testbench" testbench:application'
   echo wait 30 secs until gcs emulator is up and running
   sleep 30
   exit 0
@@ -12,9 +12,11 @@ fi
 
 export PATH=$(python3 -m site --user-base)/bin:$PATH
 
-python3 -m pip install gcloud-storage-emulator==0.3.0
-
-gcloud-storage-emulator start --port=9099 &
-
+python3 -m pip install -r tests/test_gcloud/testbench/requirements.txt
+echo starting gcs-testbench
+gunicorn --bind "0.0.0.0:9099" \
+    --worker-class gevent \
+    --chdir "tests/test_gcloud/testbench" \
+    testbench:application &
 sleep 30 # Wait for storage emulator to start
-echo gcs emulator started successfully
+echo gcs-testbench started successfully

--- a/tests/test_gcloud/testbench/README.md
+++ b/tests/test_gcloud/testbench/README.md
@@ -1,0 +1,15 @@
+# GCS Testbench
+
+This is a minimal testbench for GCS. It only supports data operation and creating/listing/deleteing bucket.
+
+## Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run Test Bench
+
+```bash
+gunicorn --bind "0.0.0.0:9099" --worker-class gevent --chdir "tests/test_gcs/testbench" testbench:application
+```

--- a/tests/test_gcloud/testbench/error_response.py
+++ b/tests/test_gcloud/testbench/error_response.py
@@ -1,0 +1,36 @@
+# Copyright 2018 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A helper class to send error responses in the storage client test bench."""
+
+import flask
+
+
+class ErrorResponse(Exception):
+    """Simplify generation of error responses."""
+
+    status_code = 400
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def as_response(self):
+        kv = dict(self.payload or ())
+        kv["message"] = self.message
+        response = flask.jsonify(kv)
+        response.status_code = self.status_code
+        return response

--- a/tests/test_gcloud/testbench/gcs_bucket.py
+++ b/tests/test_gcloud/testbench/gcs_bucket.py
@@ -1,0 +1,258 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Implement a class to simulate GCS buckets."""
+
+import base64
+import error_response
+import flask
+import gcs_object
+import json
+import re
+import testbench_utils
+import time
+
+
+class GcsBucket:
+    """Represent a GCS Bucket."""
+
+    def __init__(self, gcs_url, name):
+        self.name = name
+        self.gcs_url = gcs_url
+        now = time.gmtime(time.time())
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
+        self.metadata = {
+            "timeCreated": timestamp,
+            "updated": timestamp,
+            "metageneration": "0",
+            "name": self.name,
+            "location": "US",
+            "storageClass": "STANDARD",
+            "etag": "XYZ=",
+            "labels": {"foo": "bar", "baz": "qux"},
+            "owner": {"entity": "project-owners-123456789", "entityId": ""},
+        }
+        self.resumable_uploads = {}
+
+    def versioning_enabled(self):
+        """Return True if versioning is enabled for this Bucket."""
+        v = self.metadata.get("versioning", None)
+        if v is None:
+            return False
+        return v.get("enabled", False)
+
+    def check_preconditions(self, request):
+        """Verify that the preconditions in request are met.
+
+        :param request:flask.Request the contents of the HTTP request.
+        :rtype:NoneType
+        :raises:ErrorResponse if the request does not pass the preconditions,
+            for example, the request has a `ifMetagenerationMatch` restriction
+            that is not met.
+        """
+
+        metageneration_match = request.args.get("ifMetagenerationMatch")
+        metageneration_not_match = request.args.get("ifMetagenerationNotMatch")
+        metageneration = self.metadata.get("metageneration")
+
+        if (
+            metageneration_not_match is not None
+            and metageneration_not_match == metageneration
+        ):
+            raise error_response.ErrorResponse(
+                "Precondition Failed (metageneration = %s)" % metageneration,
+                status_code=412,
+            )
+
+        if metageneration_match is not None and metageneration_match != metageneration:
+            raise error_response.ErrorResponse(
+                "Precondition Failed (metageneration = %s)" % metageneration,
+                status_code=412,
+            )
+
+    def create_resumable_upload(self, upload_url, request):
+        """Capture the details for a resumable upload.
+
+        :param upload_url: str the base URL for uploads.
+        :param request: flask.Request the original http request.
+        :return: the HTTP response to send back.
+        """
+        x_upload_content_type = request.headers.get(
+            "x-upload-content-type", "application/octet-stream"
+        )
+        x_upload_content_length = request.headers.get("x-upload-content-length")
+        expected_bytes = None
+        if x_upload_content_length:
+            expected_bytes = int(x_upload_content_length)
+
+        if request.args.get("name") is not None and len(request.data):
+            raise error_response.ErrorResponse(
+                "The name argument is only supported for empty payloads",
+                status_code=400,
+            )
+        if len(request.data):
+            metadata = json.loads(request.data)
+        else:
+            metadata = {"name": request.args.get("name")}
+
+        if metadata.get("name") is None:
+            raise error_response.ErrorResponse(
+                "Missing object name argument", status_code=400
+            )
+        metadata.setdefault("contentType", x_upload_content_type)
+        upload = {
+            "metadata": metadata,
+            "instructions": request.headers.get("x-goog-testbench-instructions"),
+            "fields": request.args.get("fields"),
+            "next_byte": 0,
+            "expected_bytes": expected_bytes,
+            "object_name": metadata.get("name"),
+            "media": b"",
+            "transfer": set(),
+            "done": False,
+        }
+        # Capture the preconditions, including those that are None.
+        for precondition in [
+            "ifGenerationMatch",
+            "ifGenerationNotMatch",
+            "ifMetagenerationMatch",
+            "ifMetagenerationNotMatch",
+        ]:
+            upload[precondition] = request.args.get(precondition)
+        upload_id = base64.b64encode(bytearray(metadata.get("name"), "utf-8")).decode(
+            "utf-8"
+        )
+        self.resumable_uploads[upload_id] = upload
+        location = "{}?uploadType=resumable&upload_id={}".format(upload_url, upload_id)
+        response = flask.make_response("")
+        response.headers["Location"] = location
+        return response
+
+    def receive_upload_chunk(self, gcs_url, request):
+        """Receive a new upload chunk.
+
+        :param gcs_url: str the base URL for the service.
+        :param request: flask.Request the original http request.
+        :return: the HTTP response.
+        """
+        upload_id = request.args.get("upload_id")
+        if upload_id is None:
+            raise error_response.ErrorResponse(
+                "Missing upload_id in resumable_upload_chunk", status_code=400
+            )
+        upload = self.resumable_uploads.get(upload_id)
+        if upload is None:
+            raise error_response.ErrorResponse(
+                "Cannot find resumable upload %s" % upload_id, status_code=404
+            )
+        # Be gracious in what you accept, if the Content-Range header is not
+        # set we assume it is a good header and it is the end of the file.
+        next_byte = upload["next_byte"]
+        upload["transfer"].add(request.environ.get("HTTP_TRANSFER_ENCODING", ""))
+        end = next_byte + len(request.data)
+        total = end
+        final_chunk = False
+        payload = testbench_utils.extract_media(request)
+        content_range = request.headers.get("content-range")
+        if content_range is not None:
+            if content_range.startswith("bytes */*"):
+                # This is just a query to resume an upload, if it is done, return
+                # the completed upload payload and an empty range header.
+                response = flask.make_response(upload.get("payload", ""))
+                if next_byte > 1 and not upload["done"]:
+                    response.headers["Range"] = "bytes=0-%d" % (next_byte - 1)
+                response.status_code = 200 if upload["done"] else 308
+                return response
+            match = re.match(r"bytes \*/(\*|[0-9]+)", content_range)
+            if match:
+                if match.group(1) == "*":
+                    total = 0
+                else:
+                    total = int(match.group(1))
+                    final_chunk = True
+            else:
+                match = re.match(r"bytes ([0-9]+)-([0-9]+)\/(\*|[0-9]+)", content_range)
+                if not match:
+                    raise error_response.ErrorResponse(
+                        "Invalid Content-Range in upload %s" % content_range,
+                        status_code=400,
+                    )
+                begin = int(match.group(1))
+                end = int(match.group(2))
+                if match.group(3) == "*":
+                    total = 0
+                else:
+                    total = int(match.group(3))
+                    final_chunk = True
+
+                if begin != next_byte:
+                    raise error_response.ErrorResponse(
+                        "Mismatched data range, expected data at %d, got %d"
+                        % (next_byte, begin),
+                        status_code=400,
+                    )
+                if len(payload) != end - begin + 1:
+                    raise error_response.ErrorResponse(
+                        "Mismatched data range (%d) vs. received data (%d)"
+                        % (end - begin + 1, len(payload)),
+                        status_code=400,
+                    )
+
+        upload["media"] = upload.get("media", b"") + payload
+        next_byte = len(upload.get("media", ""))
+        upload["next_byte"] = next_byte
+        response_payload = ""
+        if final_chunk and next_byte >= total:
+            expected_bytes = upload["expected_bytes"]
+            if expected_bytes is not None and expected_bytes != total:
+                raise error_response.ErrorResponse(
+                    "X-Upload-Content-Length"
+                    "validation failed. Expected=%d, got %d." % (expected_bytes, total)
+                )
+            upload["done"] = True
+            object_name = upload.get("object_name")
+            object_path, blob = testbench_utils.get_object(
+                self.name, object_name, gcs_object.GcsObject(self.name, object_name)
+            )
+            # Release a few resources to control memory usage.
+            original_metadata = upload.pop("metadata", None)
+            media = upload.pop("media", None)
+            blob.check_preconditions_by_value(
+                upload.get("ifGenerationMatch"),
+                upload.get("ifGenerationNotMatch"),
+                upload.get("ifMetagenerationMatch"),
+                upload.get("ifMetagenerationNotMatch"),
+            )
+            if upload.pop("instructions", None) == "inject-upload-data-error":
+                media = testbench_utils.corrupt_media(media)
+            revision = blob.insert_resumable(gcs_url, request, media, original_metadata)
+            revision.metadata.setdefault("metadata", {})
+            revision.metadata["metadata"]["x_testbench_transfer_encoding"] = ":".join(
+                upload["transfer"]
+            )
+            response_payload = testbench_utils.filter_fields_from_response(
+                upload.get("fields"), revision.metadata
+            )
+            upload["payload"] = response_payload
+            testbench_utils.insert_object(object_path, blob)
+
+        response = flask.make_response(response_payload)
+        if next_byte == 0:
+            response.headers["Range"] = "bytes=0-0"
+        else:
+            response.headers["Range"] = "bytes=0-%d" % (next_byte - 1)
+        if upload.get("done", False):
+            response.status_code = 200
+        else:
+            response.status_code = 308
+        return response

--- a/tests/test_gcloud/testbench/gcs_object.py
+++ b/tests/test_gcloud/testbench/gcs_object.py
@@ -1,0 +1,770 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Implement a class to simulate GCS objects."""
+
+import base64
+import crc32c
+import error_response
+import hashlib
+import json
+import struct
+import testbench_utils
+import time
+
+
+class GcsObjectVersion:
+    """Represent a single revision of a GCS Object."""
+
+    def __init__(self, gcs_url, bucket_name, name, generation, request, media):
+        """Initialize a new object revision.
+
+        :param gcs_url:str the base URL for the GCS service.
+        :param bucket_name:str the name of the bucket that contains the object.
+        :param name:str the name of the object.
+        :param generation:int the generation number for this object.
+        :param request:flask.Request the contents of the HTTP request.
+        :param media:str the contents of the object.
+        """
+        self.gcs_url = gcs_url
+        self.bucket_name = bucket_name
+        self.name = name
+        self.generation = str(generation)
+        self.object_id = bucket_name + "/o/" + name + "/" + str(generation)
+        now = time.gmtime(time.time())
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
+        self.media = media
+        instructions = request.headers.get("x-goog-testbench-instructions")
+        if instructions == "inject-upload-data-error":
+            self.media = testbench_utils.corrupt_media(media)
+
+        self.metadata = {
+            "timeCreated": timestamp,
+            "updated": timestamp,
+            "metageneration": "0",
+            "generation": str(generation),
+            "location": "US",
+            "storageClass": "STANDARD",
+            "size": str(len(self.media)),
+            "etag": "XYZ=",
+            "owner": {"entity": "project-owners-123456789", "entityId": ""},
+            "md5Hash": base64.b64encode(hashlib.md5(self.media).digest()).decode(
+                "utf-8"
+            ),
+            "crc32c": base64.b64encode(
+                struct.pack(">I", crc32c.crc32(self.media))
+            ).decode("utf-8"),
+        }
+        if request.headers.get("content-type") is not None:
+            self.metadata["contentType"] = request.headers.get("content-type")
+
+    def update_from_metadata(self, metadata):
+        """Update from a metadata dictionary.
+
+        :param metadata:dict a dictionary with new metadata values.
+        :rtype:NoneType
+        """
+        tmp = self.metadata.copy()
+        tmp.update(metadata)
+        tmp["bucket"] = tmp.get("bucket", self.name)
+        tmp["name"] = tmp.get("name", self.name)
+        now = time.gmtime(time.time())
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
+        # Some values cannot be changed via updates, so we always reset them.
+        tmp.update(
+            {
+                "kind": "storage#object",
+                "bucket": self.bucket_name,
+                "name": self.name,
+                "id": self.object_id,
+                "selfLink": self.gcs_url + self.name,
+                "projectNumber": "123456789",
+                "updated": timestamp,
+            }
+        )
+        tmp["metageneration"] = str(int(tmp.get("metageneration", "0")) + 1)
+        self.metadata = tmp
+        self._validate_hashes()
+
+    def _validate_hashes(self):
+        """Validate the md5Hash and crc32c fields against the stored media."""
+        self._validate_md5_hash()
+        self._validate_crc32c()
+
+    def _validate_md5_hash(self):
+        """Validate the md5Hash field against the stored media."""
+        actual = self.metadata.get("md5Hash", "")
+        expected = base64.b64encode(hashlib.md5(self.media).digest()).decode("utf-8")
+        if actual != expected:
+            raise error_response.ErrorResponse(
+                "Mismatched MD5 hash expected={}, actual={}".format(expected, actual)
+            )
+
+    def _validate_crc32c(self):
+        """Validate the crc32c field against the stored media."""
+        actual = self.metadata.get("crc32c", "")
+        expected = base64.b64encode(struct.pack(">I", crc32c.crc32(self.media))).decode(
+            "utf-8"
+        )
+        if actual != expected:
+            raise error_response.ErrorResponse(
+                "Mismatched CRC32C checksum expected={}, actual={}".format(
+                    expected, actual
+                )
+            )
+
+    def validate_encryption_for_read(self, request, prefix="x-goog-encryption"):
+        """Verify that the request includes the correct encryption keys.
+
+        :param request:flask.Request the http request.
+        :param prefix: str the prefix shared by the encryption headers,
+            typically 'x-goog-encryption', but for rewrite requests it can be
+            'x-goog-copy-source-encryption'.
+        :rtype:NoneType
+        """
+        key_header = prefix + "-key"
+        hash_header = prefix + "-key-sha256"
+        algo_header = prefix + "-algorithm"
+        encryption = self.metadata.get("customerEncryption")
+        if encryption is None:
+            # The object is not encrypted, no key is needed.
+            if request.headers.get(key_header) is None:
+                return
+            else:
+                # The data is not encrypted, sending an encryption key is an
+                # error.
+                testbench_utils.raise_csek_error()
+        # The data is encrypted, the key must be present, match, and match its
+        # hash.
+        key_header_value = request.headers.get(key_header)
+        hash_header_value = request.headers.get(hash_header)
+        algo_header_value = request.headers.get(algo_header)
+        testbench_utils.validate_customer_encryption_headers(
+            key_header_value, hash_header_value, algo_header_value
+        )
+        if encryption.get("keySha256") != hash_header_value:
+            testbench_utils.raise_csek_error()
+
+    def _capture_customer_encryption(self, request):
+        """Capture the customer-supplied encryption key, if any.
+
+        :param request:flask.Request the http request.
+        :rtype:NoneType
+        """
+        if request.headers.get("x-goog-encryption-key") is None:
+            return
+        prefix = "x-goog-encryption"
+        key_header = prefix + "-key"
+        hash_header = prefix + "-key-sha256"
+        algo_header = prefix + "-algorithm"
+        key_header_value = request.headers.get(key_header)
+        hash_header_value = request.headers.get(hash_header)
+        algo_header_value = request.headers.get(algo_header)
+        testbench_utils.validate_customer_encryption_headers(
+            key_header_value, hash_header_value, algo_header_value
+        )
+        self.metadata["customerEncryption"] = {
+            "encryptionAlgorithm": algo_header_value,
+            "keySha256": hash_header_value,
+        }
+
+    def x_goog_hash_header(self):
+        """Return the value for the x-goog-hash header."""
+        hashes = {
+            "md5": self.metadata.get("md5Hash", ""),
+            "crc32c": self.metadata.get("crc32c", ""),
+        }
+        hashes = ["{}={}".format(key, val) for key, val in hashes.items() if val]
+        return ",".join(hashes)
+
+
+class GcsObject:
+    """Represent a GCS Object, including all its revisions."""
+
+    def __init__(self, bucket_name, name):
+        """Initialize a fake GCS Blob.
+
+        :param bucket_name:str the bucket that will contain the new object.
+        :param name:str the name of the new object.
+        """
+        self.bucket_name = bucket_name
+        self.name = name
+        # A counter to create new generation numbers for the object revisions.
+        # Note that 0 is an invalid generation number. The application can use
+        # ifGenerationMatch=0 as a pre-condition that means "object does not
+        # exist".
+        self.generation_generator = 0
+        self.current_generation = None
+        self.revisions = {}
+        self.rewrite_token_generator = 0
+        self.rewrite_operations = {}
+
+    def get_revision(self, request, version_field_name="generation"):
+        """Get the information about a particular object revision or raise.
+
+        :param request:flask.Request the contents of the http request.
+        :param version_field_name:str the name of the generation
+            parameter, typically 'generation', but sometimes 'sourceGeneration'.
+        :return: the object revision.
+        :rtype: GcsObjectVersion
+        :raises:ErrorResponse if the request contains an invalid generation
+            number.
+        """
+        generation = request.args.get(version_field_name)
+        if generation is None:
+            return self.get_latest()
+        version = self.revisions.get(generation)
+        if version is None:
+            raise error_response.ErrorResponse(
+                "Precondition Failed: generation %s not found" % generation
+            )
+        return version
+
+    def del_revision(self, request):
+        """Delete a version of a fake GCS Blob.
+
+        :param request:flask.Request the contents of the HTTP request.
+        :return: True if the object entry in the Bucket should be deleted.
+        :rtype: bool
+        """
+        generation = request.args.get("generation") or self.current_generation
+        if generation is None:
+            return True
+        self.revisions.pop(generation)
+        if len(self.revisions) == 0:
+            self.current_generation = None
+            return True
+        self.current_generation = sorted(self.revisions.keys())[-1]
+        return False
+
+    @classmethod
+    def _remove_non_writable_keys(cls, metadata):
+        """Remove the keys from metadata (an update or patch) that are not
+         writable.
+
+         Both `Objects: patch` and `Objects: update` either ignore non-writable
+         keys or return 400 if the key does not match the current value. In
+         the testbench we simply always ignore them, to make life easier.
+
+         :param metadata:dict a dictionary representing a patch or
+             update to the metadata.
+         :return metadata but with only any non-writable keys removed.
+         :rtype: dict
+         """
+        writeable_keys = {
+            "acl",
+            "cacheControl",
+            "contentDisposition",
+            "contentEncoding",
+            "contentLanguage",
+            "contentType",
+            "eventBasedHold",
+            "metadata",
+            "temporaryHold",
+            "storageClass",
+            "customTime",
+        }
+        # Cannot change `metadata` while we are iterating over it, so we make
+        # a copy
+        keys = [key for key in metadata.keys()]
+        for key in keys:
+            if key not in writeable_keys:
+                metadata.pop(key, None)
+        return metadata
+
+    def get_revision_by_generation(self, generation):
+        """Get object revision by generation or None if not found.
+
+        :param generation:int
+        :return: the object revision by generation or None.
+        :rtype:GcsObjectRevision
+        """
+        return self.revisions.get(str(generation), None)
+
+    def get_latest(self):
+        return self.revisions.get(self.current_generation, None)
+
+    def check_preconditions_by_value(
+        self,
+        generation_match,
+        generation_not_match,
+        metageneration_match,
+        metageneration_not_match,
+    ):
+        """Verify that the given precondition values are met."""
+        current_generation = self.current_generation or "0"
+        if generation_match is not None and generation_match != current_generation:
+            raise error_response.ErrorResponse("Precondition Failed", status_code=412)
+        # This object does not exist (yet), testing in this case is special.
+        if (
+            generation_not_match is not None
+            and generation_not_match == current_generation
+        ):
+            raise error_response.ErrorResponse("Precondition Failed", status_code=412)
+
+        if self.current_generation is None:
+            if metageneration_match is not None or metageneration_not_match is not None:
+                raise error_response.ErrorResponse(
+                    "Precondition Failed", status_code=412
+                )
+            return
+
+        current = self.revisions.get(current_generation)
+        if current is None:
+            raise error_response.ErrorResponse("Object not found", status_code=404)
+        metageneration = current.metadata.get("metageneration")
+        if (
+            metageneration_not_match is not None
+            and metageneration_not_match == metageneration
+        ):
+            raise error_response.ErrorResponse("Precondition Failed", status_code=412)
+        if metageneration_match is not None and metageneration_match != metageneration:
+            raise error_response.ErrorResponse("Precondition Failed", status_code=412)
+
+    def check_preconditions(
+        self,
+        request,
+        if_generation_match="ifGenerationMatch",
+        if_generation_not_match="ifGenerationNotMatch",
+        if_metageneration_match="ifMetagenerationMatch",
+        if_metageneration_not_match="ifMetagenerationNotMatch",
+    ):
+        """Verify that the preconditions in request are met.
+
+        :param request:flask.Request the http request.
+        :param if_generation_match:str the name of the generation match
+            parameter name, typically 'ifGenerationMatch', but sometimes
+            'ifSourceGenerationMatch'.
+        :param if_generation_not_match:str the name of the generation not-match
+            parameter name, typically 'ifGenerationNotMatch', but sometimes
+            'ifSourceGenerationNotMatch'.
+        :param if_metageneration_match:str the name of the metageneration match
+            parameter name, typically 'ifMetagenerationMatch', but sometimes
+            'ifSourceMetagenerationMatch'.
+        :param if_metageneration_not_match:str the name of the metageneration
+            not-match parameter name, typically 'ifMetagenerationNotMatch', but
+            sometimes 'ifSourceMetagenerationNotMatch'.
+        :rtype:NoneType
+        """
+        generation_match = request.args.get(if_generation_match)
+        generation_not_match = request.args.get(if_generation_not_match)
+        metageneration_match = request.args.get(if_metageneration_match)
+        metageneration_not_match = request.args.get(if_metageneration_not_match)
+        self.check_preconditions_by_value(
+            generation_match,
+            generation_not_match,
+            metageneration_match,
+            metageneration_not_match,
+        )
+
+    def _insert_revision(self, revision):
+        """Insert a new revision that has been initialized and checked.
+
+        :param revision: GcsObjectVersion the new revision to insert.
+        :rtype:NoneType
+        """
+        update = {str(self.generation_generator): revision}
+        bucket = testbench_utils.lookup_bucket(self.bucket_name)
+        if not bucket.versioning_enabled():
+            self.revisions = update
+        else:
+            self.revisions.update(update)
+        self.current_generation = str(self.generation_generator)
+
+    def insert(self, gcs_url, request):
+        """Insert a new revision based on the give flask request.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :return: the newly created object version.
+        :rtype: GcsObjectVersion
+        """
+        media = testbench_utils.extract_media(request)
+        self.generation_generator += 1
+        revision = GcsObjectVersion(
+            gcs_url,
+            self.bucket_name,
+            self.name,
+            self.generation_generator,
+            request,
+            media,
+        )
+        meta = revision.metadata.setdefault("metadata", {})
+        meta["x_testbench_upload"] = "simple"
+        self._insert_revision(revision)
+        return revision
+
+    def insert_multipart(self, gcs_url, request, resource, media_headers, media_body):
+        """Insert a new revision based on the give flask request.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :param resource:dict JSON resource with object metadata.
+        :param media_headers:dict media headers in a multi-part upload.
+        :param media_body:str object data in a multi-part upload.
+        :return: the newly created object version.
+        :rtype: GcsObjectVersion
+        """
+        # There are two ways to specify the content-type, the 'content-type'
+        # header and the resource['contentType'] field. They must be consistent,
+        # and the service generates an error when they are not.
+        if (
+            resource.get("contentType") is not None
+            and media_headers.get("content-type") is not None
+            and resource.get("contentType") != media_headers.get("content-type")
+        ):
+            raise error_response.ErrorResponse(
+                (
+                    "Content-Type specified in the upload (%s) does not match"
+                    + "contentType specified in the metadata (%s)."
+                )
+                % (media_headers.get("content-type"), resource.get("contentType")),
+                status_code=400,
+            )
+        # Set the contentType in the resource from the header. Note that if both
+        # are set they have the same value.
+        resource.setdefault("contentType", media_headers.get("content-type"))
+        self.generation_generator += 1
+        revision = GcsObjectVersion(
+            gcs_url,
+            self.bucket_name,
+            self.name,
+            self.generation_generator,
+            request,
+            media_body,
+        )
+        meta = revision.metadata.setdefault("metadata", {})
+        meta["x_testbench_upload"] = "multipart"
+        if "md5Hash" in resource:
+            # We should return `x_testbench_md5` only when the user enables
+            # `MD5Hash` computations.
+            meta["x_testbench_md5"] = resource.get("md5Hash")
+        meta["x_testbench_crc32c"] = resource.get("crc32c", "")
+        # Apply any overrides from the resource object part.
+        revision.update_from_metadata(resource)
+        self._insert_revision(revision)
+        return revision
+
+    def insert_resumable(self, gcs_url, request, media, resource):
+        """Implement the final insert for a resumable upload.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :param media:str the media for the object.
+        :param resource:dict the metadata for the object.
+        :return: the newly created object version.
+        :rtype: GcsObjectVersion
+        """
+        self.generation_generator += 1
+        revision = GcsObjectVersion(
+            gcs_url,
+            self.bucket_name,
+            self.name,
+            self.generation_generator,
+            request,
+            media,
+        )
+        meta = revision.metadata.setdefault("metadata", {})
+        meta["x_testbench_upload"] = "resumable"
+        meta["x_testbench_md5"] = resource.get("md5Hash", "")
+        meta["x_testbench_crc32c"] = resource.get("crc32c", "")
+        # Apply any overrides from the resource object part.
+        revision.update_from_metadata(resource)
+        self._insert_revision(revision)
+        return revision
+
+    def insert_xml(self, gcs_url, request):
+        """Implement the insert operation using the XML API.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :return: the newly created object version.
+        :rtype: GcsObjectVersion
+        """
+        media = testbench_utils.extract_media(request)
+        self.generation_generator += 1
+        goog_hash = request.headers.get("x-goog-hash")
+        md5hash = None
+        crc32c = None
+        if goog_hash is not None:
+            for hash in goog_hash.split(","):
+                if hash.startswith("md5="):
+                    md5hash = hash[4:]
+                if hash.startswith("crc32c="):
+                    crc32c = hash[7:]
+        revision = GcsObjectVersion(
+            gcs_url,
+            self.bucket_name,
+            self.name,
+            self.generation_generator,
+            request,
+            media,
+        )
+        meta = revision.metadata.setdefault("metadata", {})
+        meta["x_testbench_upload"] = "xml"
+        if md5hash is not None:
+            meta["x_testbench_md5"] = md5hash
+            revision.update_from_metadata({"md5Hash": md5hash})
+        if crc32c is not None:
+            meta["x_testbench_crc32c"] = crc32c
+            revision.update_from_metadata({"crc32c": crc32c})
+        self._insert_revision(revision)
+        return revision
+
+    def copy_from(self, gcs_url, request, source_revision):
+        """Insert a new revision based on the give flask request.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :param source_revision:GcsObjectVersion the source object version to
+            copy from.
+        :return: the newly created object version.
+        :rtype: GcsObjectVersion
+        """
+        self.generation_generator += 1
+        source_revision.validate_encryption_for_read(request)
+        revision = GcsObjectVersion(
+            gcs_url,
+            self.bucket_name,
+            self.name,
+            self.generation_generator,
+            request,
+            source_revision.media,
+        )
+        metadata = json.loads(request.data)
+        revision.update_from_metadata(metadata)
+        self._insert_revision(revision)
+        return revision
+
+    def compose_from(self, gcs_url, request, composed_media):
+        """Compose a new revision based on the give flask request.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :param composed_media:str contents of the composed object
+        :return: the newly created object version.
+        :rtype: GcsObjectVersion
+        """
+        self.generation_generator += 1
+        revision = GcsObjectVersion(
+            gcs_url,
+            self.bucket_name,
+            self.name,
+            self.generation_generator,
+            request,
+            composed_media,
+        )
+        payload = json.loads(request.data)
+        if payload.get("destination") is not None:
+            revision.update_from_metadata(payload.get("destination"))
+        # The server often discards the MD5 Hash when composing objects, we can
+        # easily maintain them in the testbench, but dropping them helps us
+        # detect bugs sooner.
+        revision.metadata.pop("md5Hash")
+        self._insert_revision(revision)
+        return revision
+
+    @classmethod
+    def rewrite_fixed_args(cls):
+        """The arguments that should not change between requests for the same
+        rewrite operation."""
+        return [
+            "destinationKmsKeyName",
+            "destinationPredefinedAcl",
+            "ifGenerationMatch",
+            "ifGenerationNotMatch",
+            "ifMetagenerationMatch",
+            "ifMetagenerationNotMatch",
+            "ifSourceGenerationMatch",
+            "ifSourceGenerationNotMatch",
+            "ifSourceMetagenerationMatch",
+            "ifSourceMetagenerationNotMatch",
+            "maxBytesRewrittenPerCall",
+            "projection",
+            "sourceGeneration",
+            "userProject",
+        ]
+
+    @classmethod
+    def capture_rewrite_operation_arguments(
+        cls, request, destination_bucket, destination_object
+    ):
+        """Captures the arguments used to validate related rewrite calls.
+
+        :rtype:dict
+        """
+        original_arguments = {}
+        for arg in GcsObject.rewrite_fixed_args():
+            original_arguments[arg] = request.args.get(arg)
+        original_arguments.update(
+            {
+                "destination_bucket": destination_bucket,
+                "destination_object": destination_object,
+            }
+        )
+        return original_arguments
+
+    @classmethod
+    def make_rewrite_token(
+        cls, operation, destination_bucket, destination_object, generation
+    ):
+        """Create a new rewrite token for the given operation."""
+        return base64.b64encode(
+            bytearray(
+                "/".join(
+                    [
+                        str(operation.get("id")),
+                        destination_bucket,
+                        destination_object,
+                        str(generation),
+                        str(operation.get("bytes_rewritten")),
+                    ]
+                ),
+                "utf-8",
+            )
+        ).decode("utf-8")
+
+    def make_rewrite_operation(self, request, destination_bucket, destination_object):
+        """Create a new rewrite token for `Objects: rewrite`."""
+        generation = request.args.get("sourceGeneration")
+        if generation is None:
+            generation = str(self.generation_generator)
+        else:
+            generation = generation
+
+        self.rewrite_token_generator = self.rewrite_token_generator + 1
+        body = json.loads(request.data)
+        original_arguments = self.capture_rewrite_operation_arguments(
+            request, destination_object, destination_object
+        )
+        operation = {
+            "id": self.rewrite_token_generator,
+            "original_arguments": original_arguments,
+            "actual_generation": generation,
+            "bytes_rewritten": 0,
+            "body": body,
+        }
+        token = GcsObject.make_rewrite_token(
+            operation, destination_bucket, destination_object, generation
+        )
+        return token, operation
+
+    def rewrite_finish(self, gcs_url, request, body, source):
+        """Complete a rewrite from `source` into this object.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :param body:dict the HTTP payload, parsed via json.loads()
+        :param source:GcsObjectVersion the source object version.
+        :return: the newly created object version.
+        :rtype: GcsObjectVersion
+        """
+        media = source.media
+        self.check_preconditions(request)
+        self.generation_generator += 1
+        revision = GcsObjectVersion(
+            gcs_url,
+            self.bucket_name,
+            self.name,
+            self.generation_generator,
+            request,
+            media,
+        )
+        revision.update_from_metadata(body)
+        self._insert_revision(revision)
+        return revision
+
+    def rewrite_step(self, gcs_url, request, destination_bucket, destination_object):
+        """Execute an iteration of `Objects: rewrite.
+
+        Objects: rewrite may need to be called multiple times before it
+        succeeds. Only objects in the same location, with the same encryption,
+        are guaranteed to complete in a single request.
+
+        The implementation simulates some, but not all, the behaviors of the
+        server, in particular, only rewrites within the same bucket and smaller
+        than 1MiB complete immediately.
+
+        :param gcs_url:str the root URL for the fake GCS service.
+        :param request:flask.Request the contents of the HTTP request.
+        :param destination_bucket:str where will the object be placed after the
+            rewrite operation completes.
+        :param destination_object:str the name of the object when the rewrite
+            operation completes.
+        :return: a dictionary prepared for JSON encoding of a
+            `Objects: rewrite` response.
+        :rtype:dict
+        """
+        body = json.loads(request.data)
+        rewrite_token = request.args.get("rewriteToken")
+        if rewrite_token is not None and rewrite_token != "":
+            # Note that we remove the rewrite operation, not just look it up.
+            # That way if the operation completes in this call, and/or fails,
+            # it is already removed. We need to insert it with a new token
+            # anyway, so this makes sense.
+            rewrite = self.rewrite_operations.pop(rewrite_token, None)
+            if rewrite is None:
+                raise error_response.ErrorResponse(
+                    "Invalid or expired token in rewrite", status_code=410
+                )
+        else:
+            rewrite_token, rewrite = self.make_rewrite_operation(
+                request, destination_bucket, destination_bucket
+            )
+
+        # Compare the difference to the original arguments, on the first call
+        # this is a waste, but the code is easier to follow.
+        current_arguments = self.capture_rewrite_operation_arguments(
+            request, destination_bucket, destination_object
+        )
+        diff = set(current_arguments) ^ set(rewrite.get("original_arguments"))
+        if len(diff) != 0:
+            raise error_response.ErrorResponse(
+                "Mismatched arguments to rewrite", status_code=412
+            )
+
+        # This will raise if the version is deleted while the operation is in
+        # progress.
+        source = self.get_revision_by_generation(rewrite.get("actual_generation"))
+        source.validate_encryption_for_read(
+            request, prefix="x-goog-copy-source-encryption"
+        )
+        bytes_rewritten = rewrite.get("bytes_rewritten")
+        bytes_rewritten += 1024 * 1024
+        result = {"kind": "storage#rewriteResponse", "objectSize": len(source.media)}
+        if bytes_rewritten >= len(source.media):
+            bytes_rewritten = len(source.media)
+            rewrite["bytes_rewritten"] = bytes_rewritten
+            # Success, the operation completed. Return the new object:
+            object_path, destination = testbench_utils.get_object(
+                destination_bucket,
+                destination_object,
+                GcsObject(destination_bucket, destination_object),
+            )
+            revision = destination.rewrite_finish(gcs_url, request, body, source)
+            testbench_utils.insert_object(object_path, destination)
+            result["done"] = True
+            result["resource"] = revision.metadata
+            rewrite_token = ""
+        else:
+            rewrite["bytes_rewritten"] = bytes_rewritten
+            rewrite_token = GcsObject.make_rewrite_token(
+                rewrite, destination_bucket, destination_object, source.generation
+            )
+            self.rewrite_operations[rewrite_token] = rewrite
+            result["done"] = False
+
+        result.update(
+            {"totalBytesRewritten": bytes_rewritten, "rewriteToken": rewrite_token}
+        )
+        return result

--- a/tests/test_gcloud/testbench/requirements.txt
+++ b/tests/test_gcloud/testbench/requirements.txt
@@ -1,0 +1,5 @@
+crc32c==2.1
+flask==1.1.2
+greenlet==0.4.17
+gevent==20.9.0
+gunicorn==20.0.4

--- a/tests/test_gcloud/testbench/testbench.py
+++ b/tests/test_gcloud/testbench/testbench.py
@@ -1,0 +1,599 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A test bench for the Google Cloud Storage C++ Client Library."""
+
+import argparse
+import error_response
+import flask
+import gcs_bucket
+import gcs_object
+import json
+import os
+import re
+import testbench_utils
+import time
+import sys
+from werkzeug import serving
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+
+
+root = flask.Flask(__name__, subdomain_matching=True)
+root.debug = True
+
+
+@root.route("/")
+def index():
+    """Default handler for the test bench."""
+    return "OK"
+
+
+@root.route("/<path:object_name>", subdomain="<bucket_name>")
+def root_get_object(bucket_name, object_name):
+    return xml_get_object(bucket_name, object_name)
+
+
+@root.route("/<bucket_name>/<path:object_name>", subdomain="")
+def root_get_object_with_bucket(bucket_name, object_name):
+    return xml_get_object(bucket_name, object_name)
+
+
+@root.route("/<path:object_name>", subdomain="<bucket_name>", methods=["PUT"])
+def root_put_object(bucket_name, object_name):
+    return xml_put_object(flask.request.host_url, bucket_name, object_name)
+
+
+@root.route("/<bucket_name>/<path:object_name>", subdomain="", methods=["PUT"])
+def root_put_object_with_bucket(bucket_name, object_name):
+    return xml_put_object(flask.request.host_url, bucket_name, object_name)
+
+
+@root.errorhandler(error_response.ErrorResponse)
+def root_error(error):
+    return error.as_response()
+
+
+# Define the WSGI application to handle bucket requests.
+GCS_HANDLER_PATH = "/storage/v1"
+gcs = flask.Flask(__name__)
+gcs.debug = True
+
+
+def insert_magic_bucket(base_url):
+    if len(testbench_utils.all_buckets()) == 0:
+        bucket_name = os.environ.get(
+            "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME", "test-bucket"
+        )
+        bucket = gcs_bucket.GcsBucket(base_url, bucket_name)
+        testbench_utils.insert_bucket(bucket_name, bucket)
+
+
+@gcs.route("/")
+def gcs_index():
+    """The default handler for GCS requests."""
+    return "OK"
+
+
+@gcs.errorhandler(error_response.ErrorResponse)
+def gcs_error(error):
+    return error.as_response()
+
+
+@gcs.route("/b")
+def buckets_list():
+    """Implement the 'Buckets: list' API: return the Buckets in a project."""
+    base_url = flask.url_for("gcs_index", _external=True)
+    project = flask.request.args.get("project")
+    if project is None or project.endswith("-"):
+        raise error_response.ErrorResponse(
+            "Invalid or missing project id in `Buckets: list`"
+        )
+    insert_magic_bucket(base_url)
+    result = {"next_page_token": "", "items": []}
+    for name, b in testbench_utils.all_buckets():
+        result["items"].append(b.metadata)
+    return testbench_utils.filtered_response(flask.request, result)
+
+
+@gcs.route("/b", methods=["POST"])
+def buckets_insert():
+    """Implement the 'Buckets: insert' API: create a new Bucket."""
+    base_url = flask.url_for("gcs_index", _external=True)
+    insert_magic_bucket(base_url)
+    payload = json.loads(flask.request.data)
+    bucket_name = payload.get("name")
+    if bucket_name is None:
+        raise error_response.ErrorResponse(
+            "Missing bucket name in `Buckets: insert`", status_code=412
+        )
+    if testbench_utils.has_bucket(bucket_name):
+        raise error_response.ErrorResponse(
+            "Bucket %s already exists" % bucket_name, status_code=400
+        )
+    bucket = gcs_bucket.GcsBucket(base_url, bucket_name)
+    testbench_utils.insert_bucket(bucket_name, bucket)
+    return testbench_utils.filtered_response(flask.request, bucket.metadata)
+
+
+@gcs.route("/b/<bucket_name>")
+def buckets_get(bucket_name):
+    """Implement the 'Buckets: get' API: return the metadata for a bucket."""
+    base_url = flask.url_for("gcs_index", _external=True)
+    insert_magic_bucket(base_url)
+    bucket = testbench_utils.lookup_bucket(bucket_name)
+    bucket.check_preconditions(flask.request)
+    return testbench_utils.filtered_response(flask.request, bucket.metadata)
+
+
+@gcs.route("/b/<bucket_name>", methods=["DELETE"])
+def buckets_delete(bucket_name):
+    """Implement the 'Buckets: delete' API."""
+    bucket = testbench_utils.lookup_bucket(bucket_name)
+    bucket.check_preconditions(flask.request)
+    testbench_utils.delete_bucket(bucket_name)
+    return testbench_utils.filtered_response(flask.request, {})
+
+
+@gcs.route("/b/<bucket_name>/o")
+def objects_list(bucket_name):
+    """Implement the 'Objects: list' API: return the objects in a bucket."""
+    # Lookup the bucket, if this fails the bucket does not exist, and this
+    # function should return an error.
+    base_url = flask.url_for("gcs_index", _external=True)
+    insert_magic_bucket(base_url)
+    _ = testbench_utils.lookup_bucket(bucket_name)
+    result = {"next_page_token": "", "items": [], "prefixes:": []}
+    versions_parameter = flask.request.args.get("versions")
+    all_versions = versions_parameter is not None and bool(versions_parameter)
+    prefixes = set()
+    prefix = flask.request.args.get("prefix", "", type(""))
+    delimiter = flask.request.args.get("delimiter", "", type(""))
+    start_offset = flask.request.args.get("startOffset", "", type(""))
+    end_offset = flask.request.args.get("endOffset", "", type(""))
+    bucket_link = bucket_name + "/o/"
+    for name, o in testbench_utils.all_objects():
+        if name.find(bucket_link + prefix) != 0:
+            continue
+        if o.get_latest() is None:
+            continue
+        # We assume `delimiter` has only one character.
+        if name[len(bucket_link) :] < start_offset:
+            continue
+        if end_offset != "" and name[len(bucket_link) :] >= end_offset:
+            continue
+        delimiter_index = name.find(delimiter, len(bucket_link + prefix))
+        if delimiter != "" and delimiter_index > 0:
+            # We don't want to include `bucket_link` in the returned prefix.
+            prefixes.add(name[len(bucket_link) : delimiter_index + 1])
+            continue
+        if all_versions:
+            for object_version in o.revisions.values():
+                result["items"].append(object_version.metadata)
+        else:
+            result["items"].append(o.get_latest().metadata)
+    result["prefixes"] = list(prefixes)
+    return testbench_utils.filtered_response(flask.request, result)
+
+
+@gcs.route(
+    "/b/<source_bucket>/o/<path:source_object>/copyTo/b/<destination_bucket>/o/<path:destination_object>",
+    methods=["POST"],
+)
+def objects_copy(source_bucket, source_object, destination_bucket, destination_object):
+    """Implement the 'Objects: copy' API, copy an object."""
+    object_path, blob = testbench_utils.lookup_object(source_bucket, source_object)
+    blob.check_preconditions(
+        flask.request,
+        if_generation_match="ifSourceGenerationMatch",
+        if_generation_not_match="ifSourceGenerationNotMatch",
+        if_metageneration_match="ifSourceMetagenerationMatch",
+        if_metageneration_not_match="ifSourceMetagenerationNotMatch",
+    )
+    source_revision = blob.get_revision(flask.request, "sourceGeneration")
+    if source_revision is None:
+        raise error_response.ErrorResponse(
+            "Revision not found %s" % object_path, status_code=404
+        )
+
+    destination_path, destination = testbench_utils.get_object(
+        destination_bucket,
+        destination_object,
+        gcs_object.GcsObject(destination_bucket, destination_object),
+    )
+    base_url = flask.url_for("gcs_index", _external=True)
+    current_version = destination.copy_from(base_url, flask.request, source_revision)
+    testbench_utils.insert_object(destination_path, destination)
+    return testbench_utils.filtered_response(flask.request, current_version.metadata)
+
+
+@gcs.route(
+    "/b/<source_bucket>/o/<path:source_object>/rewriteTo/b/<destination_bucket>/o/<path:destination_object>",
+    methods=["POST"],
+)
+def objects_rewrite(
+    source_bucket, source_object, destination_bucket, destination_object
+):
+    """Implement the 'Objects: rewrite' API."""
+    base_url = flask.url_for("gcs_index", _external=True)
+    insert_magic_bucket(base_url)
+    object_path, blob = testbench_utils.lookup_object(source_bucket, source_object)
+    blob.check_preconditions(
+        flask.request,
+        if_generation_match="ifSourceGenerationMatch",
+        if_generation_not_match="ifSourceGenerationNotMatch",
+        if_metageneration_match="ifSourceMetagenerationMatch",
+        if_metageneration_not_match="ifSourceMetagenerationNotMatch",
+    )
+    response = blob.rewrite_step(
+        base_url, flask.request, destination_bucket, destination_object
+    )
+    return testbench_utils.filtered_response(flask.request, response)
+
+
+def objects_get_common(bucket_name, object_name, revision):
+    # Respect the Range: header, if present.
+    range_header = flask.request.headers.get("range")
+    response_payload = revision.media
+    begin = 0
+    end = len(response_payload)
+    if range_header is not None:
+        m = re.match("bytes=([0-9]+)-([0-9]+)", range_header)
+        if m:
+            begin = int(m.group(1))
+            end = int(m.group(2))
+            response_payload = response_payload[begin : end + 1]
+        m = re.match("bytes=([0-9]+)-$", range_header)
+        if m:
+            begin = int(m.group(1))
+            response_payload = response_payload[begin:]
+        m = re.match("bytes=-([0-9]+)$", range_header)
+        if m:
+            last = int(m.group(1))
+            response_payload = response_payload[-last:]
+    # Process custom headers to test error conditions.
+    instructions = flask.request.headers.get("x-goog-testbench-instructions")
+    if instructions == "return-broken-stream":
+
+        def streamer():
+            chunk_size = 64 * 1024
+            for r in range(0, len(response_payload), chunk_size):
+                if r > 1024 * 1024:
+                    print("\n\n###### EXIT to simulate crash\n")
+                    sys.exit(1)
+                time.sleep(0.1)
+                chunk_end = min(r + chunk_size, len(response_payload))
+                yield response_payload[r:chunk_end]
+
+        length = len(response_payload)
+        content_range = "bytes %d-%d/%d" % (begin, end - 1, length)
+        headers = {
+            "Content-Range": content_range,
+            "Content-Length": length,
+            "x-goog-hash": revision.x_goog_hash_header(),
+            "x-goog-generation": revision.generation,
+        }
+        return flask.Response(streamer(), status=200, headers=headers)
+
+    if instructions == "return-corrupted-data":
+        response_payload = testbench_utils.corrupt_media(response_payload)
+
+    if instructions is not None and instructions.startswith("stall-always"):
+        length = len(response_payload)
+        content_range = "bytes %d-%d/%d" % (begin, end - 1, length)
+
+        def streamer():
+            chunk_size = 16 * 1024
+            for r in range(begin, end, chunk_size):
+                chunk_end = min(r + chunk_size, end)
+                if r == begin:
+                    time.sleep(10)
+                yield response_payload[r:chunk_end]
+
+        headers = {
+            "Content-Range": content_range,
+            "x-goog-hash": revision.x_goog_hash_header(),
+            "x-goog-generation": revision.generation,
+        }
+        return flask.Response(streamer(), status=200, headers=headers)
+
+    if instructions == "stall-at-256KiB" and begin == 0:
+        length = len(response_payload)
+        content_range = "bytes %d-%d/%d" % (begin, end - 1, length)
+
+        def streamer():
+            chunk_size = 16 * 1024
+            for r in range(begin, end, chunk_size):
+                chunk_end = min(r + chunk_size, end)
+                if r == 256 * 1024:
+                    time.sleep(10)
+                yield response_payload[r:chunk_end]
+
+        headers = {
+            "Content-Range": content_range,
+            "x-goog-hash": revision.x_goog_hash_header(),
+            "x-goog-generation": revision.generation,
+        }
+        return flask.Response(streamer(), status=200, headers=headers)
+
+    if instructions is not None and instructions.startswith("return-503-after-256K"):
+        length = len(response_payload)
+        headers = {
+            "Content-Range": "bytes %d-%d/%d" % (begin, end - 1, length),
+            "x-goog-hash": revision.x_goog_hash_header(),
+            "x-goog-generation": revision.generation,
+        }
+        if begin == 0:
+
+            def streamer():
+                chunk_size = 4 * 1024
+                for r in range(0, len(response_payload), chunk_size):
+                    if r >= 256 * 1024:
+                        print("\n\n###### EXIT to simulate crash\n")
+                        sys.exit(1)
+                    time.sleep(0.01)
+                    chunk_end = min(r + chunk_size, len(response_payload))
+                    yield response_payload[r:chunk_end]
+
+            return flask.Response(streamer(), status=200, headers=headers)
+        if instructions.endswith("/retry-1"):
+            print("## Return error for retry 1")
+            return flask.Response("Service Unavailable", status=503)
+        if instructions.endswith("/retry-2"):
+            print("## Return error for retry 2")
+            return flask.Response("Service Unavailable", status=503)
+        print("## Return success for %s" % instructions)
+        return flask.Response(response_payload, status=200, headers=headers)
+
+    response = flask.make_response(response_payload)
+    length = len(response_payload)
+    content_range = "bytes %d-%d/%d" % (begin, end - 1, length)
+    response.headers["Content-Range"] = content_range
+    response.headers["x-goog-hash"] = revision.x_goog_hash_header()
+    response.headers["x-goog-generation"] = revision.generation
+    return response
+
+
+@gcs.route("/b/<bucket_name>/o/<path:object_name>", methods=["DELETE"])
+def objects_delete(bucket_name, object_name):
+    """Implement the 'Objects: delete' API.  Delete objects."""
+    object_path, blob = testbench_utils.lookup_object(bucket_name, object_name)
+    blob.check_preconditions(flask.request)
+    remove = blob.del_revision(flask.request)
+    if remove:
+        testbench_utils.delete_object(object_path)
+    return testbench_utils.filtered_response(flask.request, {})
+
+
+@gcs.route("/b/<bucket_name>/o/<path:object_name>/compose", methods=["POST"])
+def objects_compose(bucket_name, object_name):
+    """Implement the 'Objects: compose' API: concatenate Objects."""
+    payload = json.loads(flask.request.data)
+    source_objects = payload["sourceObjects"]
+    if source_objects is None:
+        raise error_response.ErrorResponse(
+            "You must provide at least one source component.", status_code=400
+        )
+    if len(source_objects) > 32:
+        raise error_response.ErrorResponse(
+            "The number of source components provided"
+            " (%d) exceeds the maximum (32)" % len(source_objects),
+            status_code=400,
+        )
+    composed_media = b""
+    for source_object in source_objects:
+        source_object_name = source_object.get("name")
+        if source_object_name is None:
+            raise error_response.ErrorResponse("Required.", status_code=400)
+        source_object_path, source_blob = testbench_utils.lookup_object(
+            bucket_name, source_object_name
+        )
+        source_revision = source_blob.get_latest()
+        generation = source_object.get("generation")
+        if generation is not None:
+            source_revision = source_blob.get_revision_by_generation(generation)
+            if source_revision is None:
+                raise error_response.ErrorResponse(
+                    "No such object: %s" % source_object_path, status_code=404
+                )
+        object_preconditions = source_object.get("objectPreconditions")
+        if object_preconditions is not None:
+            if_generation_match = object_preconditions.get("ifGenerationMatch")
+            source_blob.check_preconditions_by_value(
+                if_generation_match, None, None, None
+            )
+        composed_media += source_revision.media
+    composed_object_path, composed_object = testbench_utils.get_object(
+        bucket_name, object_name, gcs_object.GcsObject(bucket_name, object_name)
+    )
+    composed_object.check_preconditions(flask.request)
+    base_url = flask.url_for("gcs_index", _external=True)
+    current_version = composed_object.compose_from(
+        base_url, flask.request, composed_media
+    )
+    testbench_utils.insert_object(composed_object_path, composed_object)
+    return testbench_utils.filtered_response(flask.request, current_version.metadata)
+
+
+# Define the WSGI application to handle bucket requests.
+DOWNLOAD_HANDLER_PATH = "/download/storage/v1"
+download = flask.Flask(__name__)
+download.debug = True
+
+
+@download.errorhandler(error_response.ErrorResponse)
+def download_error(error):
+    return error.as_response()
+
+
+@gcs.route("/b/<bucket_name>/o/<path:object_name>")
+@download.route("/b/<bucket_name>/o/<path:object_name>")
+def objects_get(bucket_name, object_name):
+    """Implement the 'Objects: get' API.  Read objects or their metadata."""
+    _, blob = testbench_utils.lookup_object(bucket_name, object_name)
+    blob.check_preconditions(flask.request)
+    revision = blob.get_revision(flask.request)
+
+    media = flask.request.args.get("alt", None)
+    if media is None or media == "json":
+        return testbench_utils.filtered_response(flask.request, revision.metadata)
+    if media != "media":
+        raise error_response.ErrorResponse("Invalid alt=%s parameter" % media)
+    revision.validate_encryption_for_read(flask.request)
+    return objects_get_common(bucket_name, object_name, revision)
+
+
+# Define the WSGI application to handle bucket requests.
+UPLOAD_HANDLER_PATH = "/upload/storage/v1"
+upload = flask.Flask(__name__)
+upload.debug = True
+
+
+@upload.errorhandler(error_response.ErrorResponse)
+def upload_error(error):
+    return error.as_response()
+
+
+@upload.route("/b/<bucket_name>/o", methods=["POST"])
+def objects_insert(bucket_name):
+    """Implement the 'Objects: insert' API.  Insert a new GCS Object."""
+    gcs_url = flask.url_for(
+        "objects_insert", bucket_name=bucket_name, _external=True
+    ).replace("/upload/", "/")
+    insert_magic_bucket(gcs_url)
+
+    upload_type = flask.request.args.get("uploadType")
+    if upload_type is None:
+        raise error_response.ErrorResponse(
+            "uploadType not set in Objects: insert", status_code=400
+        )
+    if upload_type not in {"multipart", "media", "resumable"}:
+        raise error_response.ErrorResponse(
+            "testbench does not support %s uploadType" % upload_type, status_code=400
+        )
+
+    if upload_type == "resumable":
+        bucket = testbench_utils.lookup_bucket(bucket_name)
+        upload_url = flask.url_for(
+            "objects_insert", bucket_name=bucket_name, _external=True
+        )
+        return bucket.create_resumable_upload(upload_url, flask.request)
+
+    object_path = None
+    blob = None
+    current_version = None
+    if upload_type == "media":
+        object_name = flask.request.args.get("name", None)
+        if object_name is None:
+            raise error_response.ErrorResponse(
+                "name not set in Objects: insert", status_code=412
+            )
+        object_path, blob = testbench_utils.get_object(
+            bucket_name, object_name, gcs_object.GcsObject(bucket_name, object_name)
+        )
+        blob.check_preconditions(flask.request)
+        current_version = blob.insert(gcs_url, flask.request)
+    else:
+        resource, media_headers, media_body = testbench_utils.parse_multi_part(
+            flask.request
+        )
+        object_name = flask.request.args.get("name", resource.get("name", None))
+        if object_name is None:
+            raise error_response.ErrorResponse(
+                "name not set in Objects: insert", status_code=412
+            )
+        object_path, blob = testbench_utils.get_object(
+            bucket_name, object_name, gcs_object.GcsObject(bucket_name, object_name)
+        )
+        blob.check_preconditions(flask.request)
+        current_version = blob.insert_multipart(
+            gcs_url, flask.request, resource, media_headers, media_body
+        )
+    testbench_utils.insert_object(object_path, blob)
+    return testbench_utils.filtered_response(flask.request, current_version.metadata)
+
+
+@upload.route("/b/<bucket_name>/o", methods=["PUT"])
+def resumable_upload_chunk(bucket_name):
+    """Receive a chunk for a resumable upload."""
+    gcs_url = flask.url_for(
+        "objects_insert", bucket_name=bucket_name, _external=True
+    ).replace("/upload/", "/")
+    bucket = testbench_utils.lookup_bucket(bucket_name)
+    return bucket.receive_upload_chunk(gcs_url, flask.request)
+
+
+@upload.route("/b/<bucket_name>/o", methods=["DELETE"])
+def delete_resumable_upload(bucket_name):
+    upload_type = flask.request.args.get("uploadType")
+    if upload_type != "resumable":
+        raise error_response.ErrorResponse(
+            "testbench can delete resumable uploadType only", status_code=400
+        )
+    upload_id = flask.request.args.get("upload_id")
+    if upload_id is None:
+        raise error_response.ErrorResponse(
+            "missing upload_id in delete_resumable_upload", status_code=400
+        )
+    bucket = testbench_utils.lookup_bucket(bucket_name)
+    if upload_id not in bucket.resumable_uploads:
+        raise error_response.ErrorResponse("upload_id does not exist", status_code=404)
+    bucket.resumable_uploads.pop(upload_id)
+    return testbench_utils.filtered_response(flask.request, {})
+
+
+def xml_put_object(gcs_url, bucket_name, object_name):
+    """Implement PUT for the XML API."""
+    insert_magic_bucket(gcs_url)
+    object_path, blob = testbench_utils.get_object(
+        bucket_name, object_name, gcs_object.GcsObject(bucket_name, object_name)
+    )
+    generation_match = flask.request.headers.get("x-goog-if-generation-match")
+    metageneration_match = flask.request.headers.get("x-goog-if-metageneration-match")
+    blob.check_preconditions_by_value(
+        generation_match, None, metageneration_match, None
+    )
+    revision = blob.insert_xml(gcs_url, flask.request)
+    testbench_utils.insert_object(object_path, blob)
+    response = flask.make_response("")
+    response.headers["x-goog-hash"] = revision.x_goog_hash_header()
+    return response
+
+
+def xml_get_object(bucket_name, object_name):
+    """Implement the 'Objects: insert' API.  Insert a new GCS Object."""
+    object_path, blob = testbench_utils.lookup_object(bucket_name, object_name)
+    if flask.request.args.get("acl") is not None:
+        raise error_response.ErrorResponse(
+            "ACL query not supported in XML API", status_code=500
+        )
+    if flask.request.args.get("encryption") is not None:
+        raise error_response.ErrorResponse(
+            "Encryption query not supported in XML API", status_code=500
+        )
+    generation_match = flask.request.headers.get("if-generation-match")
+    metageneration_match = flask.request.headers.get("if-metageneration-match")
+    blob.check_preconditions_by_value(
+        generation_match, None, metageneration_match, None
+    )
+    revision = blob.get_revision(flask.request)
+    return objects_get_common(bucket_name, object_name, revision)
+
+
+application = DispatcherMiddleware(
+    root,
+    {
+        GCS_HANDLER_PATH: gcs,
+        UPLOAD_HANDLER_PATH: upload,
+        DOWNLOAD_HANDLER_PATH: download,
+    },
+)

--- a/tests/test_gcloud/testbench/testbench_utils.py
+++ b/tests/test_gcloud/testbench/testbench_utils.py
@@ -1,0 +1,324 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Standalone helpers for the Google Cloud Storage test bench."""
+
+import base64
+import error_response
+import hashlib
+import json
+import random
+
+
+def filter_fields_from_response(fields, response):
+    """Format the response as a JSON string, using any filtering included in
+    the request.
+
+    :param fields:str the value of the `fields` parameter in the original
+        request.
+    :param response:dict a dictionary to be formatted as a JSON string.
+    :return: the response formatted as a string.
+    :rtype:str
+    """
+    if fields is None:
+        return json.dumps(response)
+    tmp = {}
+    for key in fields.split(","):
+        key.replace(" ", "")
+        parentheses_idx = key.find("(")
+        if parentheses_idx != -1:
+            main_key = key[:parentheses_idx]
+            child_key = key[parentheses_idx + 1 : -1]
+            if main_key in response:
+                children = response[main_key]
+                if isinstance(children, list):
+                    tmp_list = []
+                    for value in children:
+                        tmp_list.append(value[child_key])
+                    tmp[main_key] = tmp_list
+                elif isinstance(children, dict):
+                    tmp[main_key] = children[child_key]
+        elif key in response:
+            tmp[key] = response[key]
+    return json.dumps(tmp)
+
+
+def filtered_response(request, response):
+    """Format the response as a JSON string, using any filtering included in
+    the request.
+
+    :param request:flask.Request the original HTTP request.
+    :param response:dict a dictionary to be formatted as a JSON string.
+    :return: the response formatted as a string.
+    :rtype:str
+    """
+    fields = request.args.get("fields")
+    return filter_fields_from_response(fields, response)
+
+
+def raise_csek_error(code=400):
+    msg = "Missing a SHA256 hash of the encryption key, or it is not"
+    msg += " base64 encoded, or it does not match the encryption key."
+    link = "https://cloud.google.com/storage/docs/encryption#customer-supplied_encryption_keys"
+    error = {
+        "error": {
+            "errors": [
+                {
+                    "domain": "global",
+                    "reason": "customerEncryptionKeySha256IsInvalid",
+                    "message": msg,
+                    "extendedHelp": link,
+                }
+            ],
+            "code": code,
+            "message": msg,
+        }
+    }
+    raise error_response.ErrorResponse(json.dumps(error), status_code=code)
+
+
+def validate_customer_encryption_headers(
+    key_header_value, hash_header_value, algo_header_value
+):
+    """Verify that the encryption headers are internally consistent.
+
+    :param key_header_value: str the value of the x-goog-*-key header
+    :param hash_header_value: str the value of the x-goog-*-key-sha256 header
+    :param algo_header_value: str the value of the x-goog-*-key-algorithm header
+    :rtype: NoneType
+    """
+    try:
+        if algo_header_value is None or algo_header_value != "AES256":
+            raise error_response.ErrorResponse(
+                "Invalid or missing algorithm %s for CSEK" % algo_header_value,
+                status_code=400,
+            )
+
+        key = base64.standard_b64decode(key_header_value)
+        if key is None or len(key) != 256 / 8:
+            raise_csek_error()
+
+        h = hashlib.sha256()
+        h.update(key)
+        expected = base64.standard_b64encode(h.digest()).decode("utf-8")
+        if hash_header_value is None or expected != hash_header_value:
+            raise_csek_error()
+    except error_response.ErrorResponse:
+        # error_response.ErrorResponse indicates that the request was invalid, just pass
+        # that exception through.
+        raise
+    except Exception:
+        # Many of the functions above may raise, convert those to an
+        # error_response.ErrorResponse with the right format.
+        raise_csek_error()
+
+
+def extract_media(request):
+    """Extract the media from a flask Request.
+
+    To avoid race conditions when using greenlets we cannot perform I/O in the
+    constructor of GcsObjectVersion, or in any of the operations that modify
+    the state of the service.  Because sometimes the media is uploaded with
+    chunked encoding, we need to do I/O before finishing the GcsObjectVersion
+    creation. If we do this I/O after the GcsObjectVersion creation started,
+    the the state of the application may change due to other I/O.
+
+    :param request:flask.Request the HTTP request.
+    :return: the full media of the request.
+    :rtype: str
+    """
+    if request.environ.get("HTTP_TRANSFER_ENCODING", "") == "chunked":
+        return request.environ.get("wsgi.input").read()
+    return request.data
+
+
+def corrupt_media(media):
+    """Return a randomly modified version of a string.
+
+    :param media:bytes a string (typically some object media) to be modified.
+    :return: a string that is slightly different than media.
+    :rtype: str
+    """
+    # Deal with the boundary condition.
+    if not media:
+        return bytearray(random.sample("abcdefghijklmnopqrstuvwxyz", 1), "utf-8")
+    return b"B" + media[1:] if media[0:1] == b"A" else b"A" + media[1:]
+
+
+# Define the collection of Buckets indexed by <bucket_name>
+GCS_BUCKETS = dict()
+
+
+def lookup_bucket(bucket_name):
+    """Lookup a bucket by name in the global collection.
+
+    :param bucket_name:str the name of the Bucket.
+    :return: the bucket matching the name.
+    :rtype:GcsBucket
+    :raises:ErrorResponse if the bucket is not found.
+    """
+    bucket = GCS_BUCKETS.get(bucket_name)
+    if bucket is None:
+        raise error_response.ErrorResponse(
+            "Bucket %s not found" % bucket_name, status_code=404
+        )
+    return bucket
+
+
+def has_bucket(bucket_name):
+    """Return True if the bucket already exists in the global collection."""
+    return GCS_BUCKETS.get(bucket_name) is not None
+
+
+def insert_bucket(bucket_name, bucket):
+    """Insert (or replace) a new bucket into the global collection.
+
+    :param bucket_name:str the name of the bucket.
+    :param bucket:GcsBucket the bucket to insert.
+    """
+    GCS_BUCKETS[bucket_name] = bucket
+
+
+def delete_bucket(bucket_name):
+    """Delete a bucket from the global collection."""
+    GCS_BUCKETS.pop(bucket_name)
+
+
+def all_buckets():
+    """Return a key,value iterator for all the buckets in the global collection.
+
+    :rtype:dict[str, GcsBucket]
+    """
+    return GCS_BUCKETS.items()
+
+
+# Define the collection of GcsObjects indexed by <bucket_name>/o/<object_name>
+GCS_OBJECTS = dict()
+
+
+def lookup_object(bucket_name, object_name):
+    """Lookup an object by name in the global collection.
+
+    :param bucket_name:str the name of the Bucket that contains the object.
+    :param object_name:str the name of the Object.
+    :return: tuple the object path and the object.
+    :rtype: (str,GcsObject)
+    :raises:ErrorResponse if the object is not found.
+    """
+    object_path, gcs_object = get_object(bucket_name, object_name, None)
+    if gcs_object is None:
+        raise error_response.ErrorResponse(
+            "Object {} in {} not found".format(object_name, bucket_name),
+            status_code=404,
+        )
+    return object_path, gcs_object
+
+
+def get_object(bucket_name, object_name, default_value):
+    """Find an object in the global collection, return a default value if not
+    found.
+
+    :param bucket_name:str the name of the Bucket that contains the object.
+    :param object_name:str the name of the Object.
+    :param default_value:GcsObject the default value returned if the object is
+        not found.
+    :return: tuple the object path and the object.
+    :rtype: (str,GcsObject)
+    """
+    object_path = bucket_name + "/o/" + object_name
+    return object_path, GCS_OBJECTS.get(object_path, default_value)
+
+
+def insert_object(object_path, value):
+    """Insert an object to the global collection."""
+    GCS_OBJECTS[object_path] = value
+
+
+def delete_object(object_path):
+    """Delete an object from the global collection."""
+    GCS_OBJECTS.pop(object_path)
+
+
+def all_objects():
+    """Return a key,value iterator for all the objects in the global collection.
+
+    :rtype:dict[str, GcsBucket]
+    """
+    return GCS_OBJECTS.items()
+
+
+def parse_multi_part(request):
+    """Parse a multi-part request
+
+    :param request:flask.Request multipart request.
+    :return: a tuple with the resource, media_headers and the media_body.
+    :rtype: (dict, dict, str)
+    """
+    content_type = request.headers.get("content-type")
+    if content_type is None or not content_type.startswith("multipart/related"):
+        raise error_response.ErrorResponse(
+            "Missing or invalid content-type header in multipart upload"
+        )
+    _, _, boundary = content_type.partition("boundary=")
+    boundary = boundary.strip('"')
+    if boundary is None:
+        raise error_response.ErrorResponse(
+            "Missing or invalid boundary in content-type header in multipart upload"
+        )
+
+    def parse_metadata(part):
+        result = part.split(b"\r\n")
+        if result[0] != b"" and result[-1] != b"":
+            raise error_response.ErrorResponse(
+                "Missing or invalid multipart %s" % str(part)
+            )
+        result = list(filter(None, result))
+        headers = {}
+        if len(result) < 2:
+            result.append(b"")
+        for header in result[:-1]:
+            key, value = header.split(b": ")
+            headers[key.decode("utf-8").lower()] = value.decode("utf-8")
+        return result[-1]
+
+    def parse_body(part):
+        if part[0:2] != b"\r\n" or part[-2:] != b"\r\n":
+            raise error_response.ErrorResponse(
+                "Missing or invalid multipart %s" % str(part)
+            )
+        part = part[2:-2]
+        part.lstrip(b"\r\n")
+        content_type_index = part.find(b"\r\n")
+        if content_type_index == -1:
+            raise error_response.ErrorResponse(
+                "Missing or invalid multipart %s" % str(part)
+            )
+        content_type = part[:content_type_index]
+        _, value = content_type.decode("utf-8").split(": ")
+        media = part[content_type_index + 2 :]
+        if media[:2] == b"\r\n":
+            # It is either `\r\n` or `\r\n\r\n`, we should remove at most 4 characters.
+            media = media[2:]
+        return {"content-type": value}, media
+
+    boundary = boundary.encode("utf-8")
+    body = extract_media(request)
+    parts = body.split(b"--" + boundary)
+    if parts[-1] != b"--\r\n" and parts[-1] != b"--":
+        raise error_response.ErrorResponse(
+            "Missing end marker (--%s--) in media body" % boundary
+        )
+    resource = parse_metadata(parts[1])
+    metadata = json.loads(resource)
+    content_type, media = parse_body(parts[2])
+    return metadata, content_type, media

--- a/tests/test_gcs_eager.py
+++ b/tests/test_gcs_eager.py
@@ -43,19 +43,18 @@ def test_read_file():
 
     body = b"1234567"
 
-    # Setup the S3 bucket and key
+    # Setup the GCS bucket and key
     key_name = "TEST"
-    bucket_name = "s3e{}e".format(int(time.time()))
-
+    bucket_name = "gse{}e".format(int(time.time()))
     bucket = client.create_bucket(bucket_name)
-    print("Project number: {}".format(bucket.project_number))
 
     blob = bucket.blob(key_name)
     blob.upload_from_string(body)
 
-    response = blob.download_as_string()
-    print("RESPONSE: ", response)
+    response = blob.download_as_bytes()
     assert response == body
 
-    # content = tf.io.read_file("gs://{}/{}".format(bucket_name, key_name))
-    # assert content == body
+    os.environ["CLOUD_STORAGE_TESTBENCH_ENDPOINT"] = "http://localhost:9099"
+
+    content = tf.io.read_file("gse://{}/{}".format(bucket_name, key_name))
+    assert content == body

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -14,7 +14,9 @@ cc_library(
         "lib/vtls/*.h",
         "lib/vauth/*.h",
         "lib/vauth/*.c",
-    ]),
+    ]) + [
+        "lib/vssh/ssh.h",
+    ],
     hdrs = glob([
         "include/curl/*.h",
     ]) + [


### PR DESCRIPTION
In this PR:

- Bump com_github_googleapis_google_cloud_cpp to `1.21.0`. Because there is a change in the xml endpoint of `google-cloud-cpp` https://github.com/googleapis/google-cloud-cpp/pull/5097

- Copy testbench from `google-cloud-cpp 1.19.0`. Note that this is the old emulator. I prefer it over the new emulator because it is much simpler. The new emulator is more complicated and supports `gRPC` API, which we don't need. In addition, I delete many functions releated to `acl` and keep only data operation ( upload, download, compose, ... ).

- Bump `libcurl` to `7.69.1` to fix `EasyPause() - CURL error [43]=A libcurl function was given a bad argument`