### PR TITLE
Remove the CI build for CentOS 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,19 +72,6 @@ jobs:
           docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:20.04 \
             bash -x -e source.sh
 
-  centos-8:
-    name: CentOS 8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py README.md "##### CentOS 8" > source.sh
-          cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host centos:8 \
-            bash -x -e source.sh
-
   centos-7:
     name: CentOS 7
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -277,33 +277,12 @@ TFIO_DATAPATH=bazel-bin python3 -m pytest -s -v tests/test_serialization_eager.p
 
 ##### CentOS 8
 
-CentOS 8 requires gcc/g++, git, and python 3. The following will install dependencies and build
-the shared libraries on CentOS 8:
-```sh
-#!/usr/bin/env bash
-
-# Install gcc/g++, git, unzip/which (for bazel), and python3
-sudo yum install -y python3 python3-devel gcc gcc-c++ git unzip which make
-
-# Install Bazel version specified in .bazelversion
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
-sudo bash -x -e bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
-
-# Upgrade pip
-sudo python3 -m pip install -U pip
-
-# Install tensorflow and configure bazel
-sudo ./configure.sh
-
-# Build shared libraries
-bazel build -s --verbose_failures //tensorflow_io/...
-
-# Once build is complete, shared libraries will be available in
-# `bazel-bin/tensorflow_io/core/python/ops/` and it is possible
-# to run tests with `pytest`, e.g.:
-sudo python3 -m pip install pytest
-TFIO_DATAPATH=bazel-bin python3 -m pytest -s -v tests/test_serialization_eager.py
+The steps to build shared libraries for CentOS 8 is similiar to Ubuntu 20.04 above
+excpet that
 ```
+sudo yum install -y python3 python3-devel gcc gcc-c++ git unzip which make
+```
+should be used instead to install gcc/g++, git, unzip/which (for bazel), and python3.
 
 ##### CentOS 7
 


### PR DESCRIPTION
Building shared libraries on CentOS 8 is pretty much the same as
on Ubuntu 20.04 except `apt` should be changed to `yum`. For that
our CentOS 8 CI test is not adding a lot of value.

Furthermore with the upcoming CentOS 8 change:
https://www.phoronix.com/scan.php?page=news_item&px=CentOS-8-Ending-For-Stream

CentOS 8 is effectively EOLed at 2021.

For that we may want to drop the CentOS 8 build (only leave a comment in README.md)

Note we keep CentOS 7 build for now as there are still many users using
CentOS 7 and CentOS 7 will only be EOLed at 2024. We might drop CentOS 7 build in
the future as well if there is similiar changes to CentOS 7 like CentOS 8.

This PR may also help #1236 a little bit by reducing number of GitHub Action jobs by 1.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>