### PR TITLE
Remove AWS headers from tensorflow, and use headers from third_party …

### DIFF
--- a/third_party/toolchains/tf/BUILD.tpl
+++ b/third_party/toolchains/tf/BUILD.tpl
@@ -4,6 +4,13 @@ cc_library(
     name = "tf_header_lib",
     hdrs = [":tf_header_include"],
     includes = ["include"],
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_absl//absl/types:span",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/toolchains/tf/tf_configure.bzl
+++ b/third_party/toolchains/tf/tf_configure.bzl
@@ -147,7 +147,7 @@ def _symlink_genrule_for_dir(
     if src_dir != None:
         src_dir = _norm_path(src_dir)
         dest_dir = _norm_path(dest_dir)
-        files = "\n".join(sorted(_read_dir(repository_ctx, src_dir).splitlines()))
+        files = "\n".join(sorted([e for e in _read_dir(repository_ctx, src_dir).splitlines() if ("/external/" not in e) and ("/absl" not in e)]))
 
         # Create a list with the src_dir stripped to use for outputs.
         if tf_pip_dir_rename_pair_len:

--- a/third_party/toolchains/tf/tf_configure.bzl
+++ b/third_party/toolchains/tf/tf_configure.bzl
@@ -147,7 +147,7 @@ def _symlink_genrule_for_dir(
     if src_dir != None:
         src_dir = _norm_path(src_dir)
         dest_dir = _norm_path(dest_dir)
-        files = "\n".join(sorted([e for e in _read_dir(repository_ctx, src_dir).splitlines() if ("/external/" not in e) and ("/absl" not in e)]))
+        files = "\n".join(sorted([e for e in _read_dir(repository_ctx, src_dir).splitlines() if ("/external/" not in e) and ("/absl/" not in e)]))
 
         # Create a list with the src_dir stripped to use for outputs.
         if tf_pip_dir_rename_pair_len:


### PR DESCRIPTION
…in tensorflow-io instead

This PR removes AWS headers from tensorflow and use headers
from third_party packages in tensorflow-io instead

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>