### PR TITLE
Remove redundant output of dataset.element_spec in PostgreSQL tutorial

### DIFF
--- a/docs/tutorials/postgresql.ipynb
+++ b/docs/tutorials/postgresql.ipynb
@@ -275,14 +275,7 @@
         "id": "8y-VpwcWNYTF"
       },
       "source": [
-        "As you could see from the output of `dataset.element_spec` above, the element of the created `Dataset` is a python dict object with column names of the database table as keys:\n",
-        "```\n",
-        "{\n",
-        "  'co': TensorSpec(shape=(), dtype=tf.float32, name=None),\n",
-        "  'pt08s1': TensorSpec(shape=(), dtype=tf.int32, name=None),\n",
-        "}\n",
-        "```\n",
-        "\n",
+        "As you could see from the output of `dataset.element_spec` above, the element of the created `Dataset` is a python dict object with column names of the database table as keys.\n",
         "It is quite convenient to apply further operations. For example, you could select both `nox` and `no2` field of the `Dataset`, and calculate the difference:"
       ]
     },


### PR DESCRIPTION
The output is already shown as part of the previous code block `print(dataset.element_spec)`.