### PR TITLE
add tf-c-header rule

### DIFF
--- a/tensorflow_io/core/plugins/BUILD
+++ b/tensorflow_io/core/plugins/BUILD
@@ -16,7 +16,7 @@ cc_library(
     linkstatic = True,
     deps = [
         "@local_config_tf//:libtensorflow_framework",
-        "@local_config_tf//:tf_header_lib",
+        "@local_config_tf//:tf_c_header_lib",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/plugins/hdfs/BUILD
+++ b/tensorflow_io/core/plugins/hdfs/BUILD
@@ -16,6 +16,8 @@ cc_library(
     linkstatic = True,
     deps = [
         "//tensorflow_io/core/plugins:plugins_header",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
         "@hadoop",
     ],
     alwayslink = 1,

--- a/third_party/toolchains/tf/BUILD.tpl
+++ b/third_party/toolchains/tf/BUILD.tpl
@@ -8,6 +8,14 @@ cc_library(
 )
 
 cc_library(
+    name = "tf_c_header_lib",
+    hdrs = [":tf_c_header_include"],
+    include_prefix = "tensorflow/c",
+    strip_include_prefix = "include_c",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "libtensorflow_framework",
     srcs = [":libtensorflow_framework.so"],
     #data = ["lib/libtensorflow_framework.so"],
@@ -15,4 +23,5 @@ cc_library(
 )
 
 %{TF_HEADER_GENRULE}
+%{TF_C_HEADER_GENRULE}
 %{TF_SHARED_LIBRARY_GENRULE}

--- a/third_party/toolchains/tf/tf_configure.bzl
+++ b/third_party/toolchains/tf/tf_configure.bzl
@@ -176,6 +176,12 @@ def _tf_pip_impl(repository_ctx):
         "tf_header_include",
         tf_pip_dir_rename_pair = ["tensorflow_core", "tensorflow"],
     )
+    tf_c_header_rule = _symlink_genrule_for_dir(
+        repository_ctx,
+        tf_header_dir + "/tensorflow/c/",
+        "include_c",
+        "tf_c_header_include",
+    )
 
     tf_shared_library_dir = repository_ctx.os.environ[_TF_SHARED_LIBRARY_DIR]
     tf_shared_library_name = repository_ctx.os.environ[_TF_SHARED_LIBRARY_NAME]
@@ -192,6 +198,7 @@ def _tf_pip_impl(repository_ctx):
 
     _tpl(repository_ctx, "BUILD", {
         "%{TF_HEADER_GENRULE}": tf_header_rule,
+        "%{TF_C_HEADER_GENRULE}": tf_c_header_rule,
         "%{TF_SHARED_LIBRARY_GENRULE}": tf_shared_library_rule,
     })
 


### PR DESCRIPTION
Related to https://github.com/tensorflow/io/pull/1241#issuecomment-749376381

@yongtang This is my approach for dividing the header from TensorFlow into smaller rules. Using the same approach, we could effectively have `tf_core_header_lib` and `tf_cc_header_lib` and remove all the `third_party` and `external` headers from TensorFlow which cause a lot of problems.

There is a lot of `#include "tensorflow/core/..."` in the codebase right now. I believe introducing `tf_core_header_lib` and removing `tf_header_lib` could help us to prevent a lot of problem related to symbol leak.