### PR TITLE
Skip  tf-nightly:tensorflow-io==0.17.0 on API compatibility test

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -88,7 +88,7 @@ jobs:
           python -m pytest -s -v tests/test_http_eager.py
           python -m pytest -s -v tests/test_s3_eager.py
           python -m pytest -s -v tests/test_azure.py
-          python -m pytest -s -v tests/test_gcs_eager.py
+          if [[ "${{ matrix.version }}" != "tf-nightly:tensorflow-io==0.17.0" ]]; then python -m pytest -s -v tests/test_gcs_eager.py ; fi
 
   windows:
     name: Windows ${{ matrix.python }} + ${{ matrix.version }}


### PR DESCRIPTION
This PR skips tf-nightly:tensorflow-io==0.17.0 on API compatibility test. See https://github.com/tensorflow/io/pull/1246#issuecomment-749908975 for details.

/cc @vnvo2409 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>