### PR TITLE
S3 Improvements

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -463,7 +463,7 @@ cc_library(
     linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",
-        "@aws-sdk-cpp",
+        "@aws-sdk-cpp//:kinesis",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/plugins/s3/BUILD
+++ b/tensorflow_io/core/plugins/s3/BUILD
@@ -21,7 +21,8 @@ cc_library(
     linkstatic = True,
     deps = [
         "//tensorflow_io/core/plugins:plugins_header",
-        "@aws-sdk-cpp",
+        "@aws-sdk-cpp//:s3",
+        "@aws-sdk-cpp//:transfer",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
     ],

--- a/tensorflow_io/core/plugins/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/plugins/s3/s3_filesystem.cc
@@ -1078,6 +1078,11 @@ void CreateDir(const TF_Filesystem* filesystem, const char* path,
   TF_SetStatus(status, TF_OK, "");
 }
 
+void RecursivelyCreateDir(const TF_Filesystem* filesystem, const char* path,
+                          TF_Status* status) {
+  CreateDir(filesystem, path, status);
+}
+
 void DeleteDir(const TF_Filesystem* filesystem, const char* path,
                TF_Status* status) {
   TF_VLog(1, "DeleteDir: %s\n", path);
@@ -1274,6 +1279,8 @@ void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops, const char* uri) {
   ops->filesystem_ops->new_read_only_memory_region_from_file =
       tf_s3_filesystem::NewReadOnlyMemoryRegionFromFile;
   ops->filesystem_ops->create_dir = tf_s3_filesystem::CreateDir;
+  ops->filesystem_ops->recursively_create_dir =
+      tf_s3_filesystem::RecursivelyCreateDir;
   ops->filesystem_ops->delete_file = tf_s3_filesystem::DeleteFile;
   ops->filesystem_ops->delete_dir = tf_s3_filesystem::DeleteDir;
   ops->filesystem_ops->copy_file = tf_s3_filesystem::CopyFile;

--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -8,51 +8,73 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 cc_library(
-    name = "aws-sdk-cpp",
+    name = "core",
     srcs = glob([
-        "aws-cpp-sdk-core/include/**/*.h",
-        "aws-cpp-sdk-core/source/*.cpp",
-        "aws-cpp-sdk-core/source/auth/**/*.cpp",
-        "aws-cpp-sdk-core/source/client/**/*.cpp",
-        "aws-cpp-sdk-core/source/config/**/*.cpp",
-        "aws-cpp-sdk-core/source/external/**/*.cpp",
-        "aws-cpp-sdk-core/source/http/*.cpp",
-        "aws-cpp-sdk-core/source/http/curl/*.cpp",
-        "aws-cpp-sdk-core/source/http/standard/*.cpp",
-        "aws-cpp-sdk-core/source/internal/**/*.cpp",
-        "aws-cpp-sdk-core/source/monitoring/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/*.cpp",
-        "aws-cpp-sdk-core/source/utils/base64/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/crypto/*.cpp",
-        "aws-cpp-sdk-core/source/utils/crypto/factory/*.cpp",
-        "aws-cpp-sdk-core/source/utils/crypto/openssl/CryptoImpl.cpp",
-        "aws-cpp-sdk-core/source/utils/event/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/json/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/logging/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/memory/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/stream/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/threading/**/*.cpp",
-        "aws-cpp-sdk-core/source/utils/xml/**/*.cpp",
-        "aws-cpp-sdk-kinesis/include/**/*.h",
-        "aws-cpp-sdk-kinesis/source/**/*.cpp",
-        "aws-cpp-sdk-s3/include/**/*.h",
-        "aws-cpp-sdk-s3/source/**/*.cpp",
-        "aws-cpp-sdk-transfer/include/**/*.h",
-        "aws-cpp-sdk-transfer/source/**/*.cpp",
+        "aws-cpp-sdk-core/source/*.cpp",  # AWS_SOURCE
+        "aws-cpp-sdk-core/source/external/tinyxml2/*.cpp",  # AWS_TINYXML2_SOURCE
+        "aws-cpp-sdk-core/source/external/cjson/*.cpp",  # CJSON_SOURCE
+        "aws-cpp-sdk-core/source/auth/*.cpp",  # AWS_AUTH_SOURCE
+        "aws-cpp-sdk-core/source/client/*.cpp",  # AWS_CLIENT_SOURCE
+        "aws-cpp-sdk-core/source/internal/*.cpp",  # AWS_INTERNAL_SOURCE
+        "aws-cpp-sdk-core/source/aws/model/*.cpp",  # AWS_MODEL_SOURCE
+        "aws-cpp-sdk-core/source/http/*.cpp",  # HTTP_SOURCE
+        "aws-cpp-sdk-core/source/http/standard/*.cpp",  # HTTP_STANDARD_SOURCE
+        "aws-cpp-sdk-core/source/config/*.cpp",  # CONFIG_SOURCE
+        "aws-cpp-sdk-core/source/monitoring/*.cpp",  # MONITORING_SOURCE
+        "aws-cpp-sdk-core/source/utils/*.cpp",  # UTILS_SOURCE
+        "aws-cpp-sdk-core/source/utils/event/*.cpp",  # UTILS_EVENT_SOURCE
+        "aws-cpp-sdk-core/source/utils/base64/*.cpp",  # UTILS_BASE64_SOURCE
+        "aws-cpp-sdk-core/source/utils/crypto/*.cpp",  # UTILS_CRYPTO_SOURCE
+        "aws-cpp-sdk-core/source/utils/json/*.cpp",  # UTILS_JSON_SOURCE
+        "aws-cpp-sdk-core/source/utils/threading/*.cpp",  # UTILS_THREADING_SOURCE
+        "aws-cpp-sdk-core/source/utils/xml/*.cpp",  # UTILS_XML_SOURCE
+        "aws-cpp-sdk-core/source/utils/logging/*.cpp",  # UTILS_LOGGING_SOURCE
+        "aws-cpp-sdk-core/source/utils/memory/*.cpp",  # UTILS_MEMORY_SOURCE
+        "aws-cpp-sdk-core/source/utils/memory/stl/*.cpp",  # UTILS_MEMORY_STL_SOURCE
+        "aws-cpp-sdk-core/source/utils/stream/*.cpp",  # UTILS_STREAM_SOURCE
+        "aws-cpp-sdk-core/source/utils/crypto/factory/*.cpp",  # UTILS_CRYPTO_FACTORY_SOURCE
+        "aws-cpp-sdk-core/source/http/curl/*.cpp",  # HTTP_CURL_CLIENT_SOURCE
+        "aws-cpp-sdk-core/source/utils/crypto/openssl/*.cpp",  # UTILS_CRYPTO_OPENSSL_SOURCE
     ]) + select({
         "@bazel_tools//src/conditions:windows": glob([
-            "aws-cpp-sdk-core/source/http/windows/*.cpp",
-            "aws-cpp-sdk-core/source/net/windows/*.cpp",
-            "aws-cpp-sdk-core/source/platform/windows/*.cpp",
+            "aws-cpp-sdk-core/source/net/windows/*.cpp",  # NET_SOURCE
+            "aws-cpp-sdk-core/source/platform/windows/*.cpp",  # PLATFORM_WINDOWS_SOURCE
         ]),
         "//conditions:default": glob([
-            "aws-cpp-sdk-core/source/net/linux-shared/*.cpp",
-            "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
+            "aws-cpp-sdk-core/source/net/linux-shared/*.cpp",  # NET_SOURCE
+            "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",  # PLATFORM_LINUX_SHARED_SOURCE
         ]),
     }),
     hdrs = [
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
-    ],
+    ] + glob([
+        "aws-cpp-sdk-core/include/aws/core/*.h",  # AWS_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/auth/*.h",  # AWS_AUTH_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/client/*.h",  # AWS_CLIENT_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/internal/*.h",  # AWS_INTERNAL_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/net/*.h",  # NET_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/http/*.h",  # HTTP_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/http/standard/*.h",  # HTTP_STANDARD_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/config/*.h",  # CONFIG_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/monitoring/*.h",  # MONITORING_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/platform/*.h",  # PLATFORM_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/*.h",  # UTILS_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/event/*.h",  # UTILS_EVENT_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/base64/*.h",  # UTILS_BASE64_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/crypto/*.h",  # UTILS_CRYPTO_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/json/*.h",  # UTILS_JSON_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/threading/*.h",  # UTILS_THREADING_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/xml/*.h",  # UTILS_XML_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/memory/*.h",  # UTILS_MEMORY_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/memory/stl/*.h",  # UTILS_STL_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/logging/*.h",  # UTILS_LOGGING_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/ratelimiter/*.h",  # UTILS_RATE_LIMITER_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/stream/*.h",  # UTILS_STREAM_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/external/cjson/*.h",  # CJSON_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/external/tinyxml2/*.h",  # TINYXML2_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/http/curl/*.h",  # HTTP_CURL_CLIENT_HEADERS
+        "aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/*.h",  # UTILS_CRYPTO_OPENSSL_HEADERS
+    ]),
     defines = [
         'AWS_SDK_VERSION_STRING=\\"1.7.366\\"',
         "AWS_SDK_VERSION_MAJOR=1",
@@ -72,15 +94,7 @@ cc_library(
     }),
     includes = [
         "aws-cpp-sdk-core/include",
-        "aws-cpp-sdk-kinesis/include",
-        "aws-cpp-sdk-s3/include",
-        "aws-cpp-sdk-transfer/include",
-    ] + select({
-        "@bazel_tools//src/conditions:windows": [
-            "aws-cpp-sdk-core/include/aws/core/platform/refs",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [
             "-DEFAULTLIB:userenv.lib",
@@ -89,11 +103,61 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "@aws-c-common",
         "@aws-c-event-stream",
-        "@aws-checksums",
-        "@boringssl//:crypto",
         "@curl",
+    ],
+)
+
+cc_library(
+    name = "s3",
+    srcs = glob([
+        "aws-cpp-sdk-s3/source/*.cpp",  # AWS_S3_SOURCE
+        "aws-cpp-sdk-s3/source/model/*.cpp",  # AWS_S3_MODEL_SOURCE
+    ]),
+    hdrs = glob([
+        "aws-cpp-sdk-s3/include/aws/s3/*.h",  # AWS_S3_HEADERS
+        "aws-cpp-sdk-s3/include/aws/s3/model/*.h",  # AWS_S3_MODEL_HEADERS
+    ]),
+    includes = [
+        "aws-cpp-sdk-s3/include",
+    ],
+    deps = [
+        ":core",
+    ],
+)
+
+cc_library(
+    name = "transfer",
+    srcs = glob([
+        "aws-cpp-sdk-transfer/source/transfer/*.cpp",  # TRANSFER_SOURCE
+    ]),
+    hdrs = glob([
+        "aws-cpp-sdk-transfer/include/aws/transfer/*.h",  # TRANSFER_HEADERS
+    ]),
+    includes = [
+        "aws-cpp-sdk-transfer/include",
+    ],
+    deps = [
+        ":core",
+        ":s3",
+    ],
+)
+
+cc_library(
+    name = "kinesis",
+    srcs = glob([
+        "aws-cpp-sdk-kinesis/source/*.cpp",  # AWS_KINESIS_SOURCE
+        "aws-cpp-sdk-kinesis/source/model/*.cpp",  # AWS_KINESIS_MODEL_SOURCE
+    ]),
+    hdrs = glob([
+        "aws-cpp-sdk-kinesis/include/aws/kinesis/*.h",  # AWS_KINESIS_HEADERS
+        "aws-cpp-sdk-kinesis/include/aws/kinesis/model/*.h",  # AWS_KINESIS_MODEL_HEADERS
+    ]),
+    includes = [
+        "aws-cpp-sdk-kinesis/include",
+    ],
+    deps = [
+        ":core",
     ],
 )
 

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -112,7 +112,7 @@ genrule(
         "#  define HAVE_SYS_FILIO_H 1",
         "#  define HAVE_SYS_SOCKIO_H 1",
         "#  define OS \"x86_64-apple-darwin15.5.0\"",
-        "#  define USE_DARWINSSL 1",
+        "#  define USE_SECTRANSP 1",
         "#else",
         "#  define CURL_CA_BUNDLE \"/etc/ssl/certs/ca-certificates.crt\"",
         "#  define GETSERVBYPORT_R_ARGS 6",


### PR DESCRIPTION
It seems that there are still some problems with symbol leaks and #1226.

So this PR:
- adds some improvements for `s3` without bumping to newer version.
- fixes a ssl support problem on Mac because USE_DARWINSSL is renamed to USE_SECTRANSP https://github.com/curl/curl/blob/ccbdbe13c43f15a637afdd1ac4bf5df62c25a235/CMakeLists.txt#L365-L367.