### PR TITLE
[audio] cleanup vorbis file after usage

### DIFF
--- a/tensorflow_io/core/kernels/audio_video_ogg_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_video_ogg_kernels.cc
@@ -142,8 +142,8 @@ class OggVorbisReadableResource : public AudioReadableResourceBase {
 
     long samples_read = 0;
     long samples_to_read = value->shape().dim_size(0);
+    float** buffer;
     while (samples_read < samples_to_read) {
-      float** buffer;
       int bitstream = 0;
       long chunk = ov_read_float(&ogg_vorbis_file_, &buffer,
                                  samples_to_read - samples_read, &bitstream);
@@ -160,6 +160,9 @@ class OggVorbisReadableResource : public AudioReadableResourceBase {
       }
       samples_read += chunk;
     }
+    // Cleanup the vorbis file
+    ov_clear(&ogg_vorbis_file_);
+
     return Status::OK();
   }
   string DebugString() const override { return "OggVorbisReadableResource"; }

--- a/tensorflow_io/core/kernels/audio_video_ogg_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_video_ogg_kernels.cc
@@ -83,7 +83,10 @@ static ov_callbacks OggVorbisCallbacks = {
 class OggVorbisReadableResource : public AudioReadableResourceBase {
  public:
   OggVorbisReadableResource(Env* env) : env_(env) {}
-  ~OggVorbisReadableResource() {}
+  ~OggVorbisReadableResource() {
+    // Cleanup the vorbis file
+    ov_clear(&ogg_vorbis_file_);
+  }
 
   Status Init(const string& filename, const void* optional_memory,
               const size_t optional_length) override {
@@ -160,8 +163,6 @@ class OggVorbisReadableResource : public AudioReadableResourceBase {
       }
       samples_read += chunk;
     }
-    // Cleanup the vorbis file
-    ov_clear(&ogg_vorbis_file_);
 
     return Status::OK();
   }


### PR DESCRIPTION
This PR aims to address the issue: https://github.com/tensorflow/io/issues/1245 by cleaning up the `ogg_vorbis_file_` pointer after decoding the content. Also, it initializes the output buffer only once, instead of reinitializing it in a loop.

Reference: https://xiph.org/vorbis/doc/vorbisfile/ov_clear.html

@yongtang not sure if this is the root cause of the mem leak. I didn't find any other obvious places where the leak might be possible. However, since the cleanup was missing, I hope this helps in a minor way at least.