### PR TITLE
[s3] add support for testing on macOS

### DIFF
--- a/tests/test_aws/aws_test.sh
+++ b/tests/test_aws/aws_test.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 export LOCALSTACK_VERSION=0.12.2
 cd tests/test_aws
-docker-compose up -d
+TMPDIR=/private$TMPDIR docker-compose up -d
 cd -
 echo "Waiting for 20 secs until localstack is up and running"
 sleep 20

--- a/tests/test_aws/aws_test.sh
+++ b/tests/test_aws/aws_test.sh
@@ -17,10 +17,11 @@
 set -e
 set -o pipefail
 
-LOCALSTACK_VERSION=0.12.2
-docker pull localstack/localstack:$LOCALSTACK_VERSION
-docker run -d --rm --net=host --name=tensorflow-io-aws localstack/localstack:$LOCALSTACK_VERSION
-echo "Waiting for 10 secs until localstack is up and running"
-sleep 10
+export LOCALSTACK_VERSION=0.12.2
+cd tests/test_aws
+docker-compose up -d
+cd -
+echo "Waiting for 20 secs until localstack is up and running"
+sleep 20
 echo "Localstack up"
 exit 0

--- a/tests/test_aws/docker-compose.yml
+++ b/tests/test_aws/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2.1'
+services:
+  localstack:
+    image: "localstack/localstack:${LOCALSTACK_VERSION}"
+    container_name: tensorflow-io-aws
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=${SERVICES- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"

--- a/tests/test_s3_eager.py
+++ b/tests/test_s3_eager.py
@@ -24,8 +24,8 @@ import pytest
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32", "darwin"),
-    reason="TODO Localstack not setup properly on macOS/Windows yet",
+    sys.platform in ("win32"),
+    reason="TODO Localstack not setup properly on Windows yet",
 )
 def test_read_file():
     """Test case for reading S3"""


### PR DESCRIPTION
This PR addresses #1183 by modifying the`localstack` docker setup using a docker-compose file and modifying the `$TMPDIR` mount. 

I was able to run the `tests/test_s3_eager.py` tests on my mac after this change.

Reference: https://hub.docker.com/r/localstack/localstack (see `using docker-compose` section)