### PR TITLE
Update openjpeg to 2.4.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -305,11 +305,11 @@ http_archive(
 http_archive(
     name = "openjpeg",
     build_file = "//third_party:openjpeg.BUILD",
-    sha256 = "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9",
-    strip_prefix = "openjpeg-2.3.1",
+    sha256 = "8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d",
+    strip_prefix = "openjpeg-2.4.0",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
-        "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz",
+        "https://github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This PR updates openjpeg to the latest 2.4.0

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>