### PR TITLE
remove unstable elasticsearch test setup on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,6 @@ jobs:
           bash -x -e tests/test_pubsub/pubsub_test.sh
           bash -x -e tests/test_aws/aws_test.sh
           bash -x -e tests/test_pulsar/pulsar_test.sh
-          bash -x -e tests/test_elasticsearch/elasticsearch_test.sh start
           bash -x -e tests/test_mongodb/mongodb_test.sh start
       - name: Install ${{ matrix.python }} macOS
         run: |


### PR DESCRIPTION
This PR removes the Elasticsearch docker setup on macOS which is causing the test setup to exit even before the tests are run.