### PR TITLE
Update Kafka tutorial to work with Apache Kafka

### DIFF
--- a/docs/tutorials/kafka.ipynb
+++ b/docs/tutorials/kafka.ipynb
@@ -70,11 +70,13 @@
       "source": [
         "## Overview\n",
         "\n",
-        "This tutorial focuses on streaming data from a [Kafka](https://docs.confluent.io/current/getting-started.html) cluster into a `tf.data.Dataset` which is then used in conjunction with `tf.keras` for training and inference.\n",
+        "This tutorial focuses on streaming data from a [Kafka](https://kafka.apache.org/quickstart) cluster into a `tf.data.Dataset` which is then used in conjunction with `tf.keras` for training and inference.\n",
         "\n",
         "Kafka is primarily a distributed event-streaming platform which provides scalable and fault-tolerant streaming data across data pipelines. It is an essential technical component of a plethora of major enterprises where mission-critical data delivery is a primary requirement.\n",
         "\n",
-        "**NOTE:** A basic understanding of the [kafka components](https://docs.confluent.io/current/kafka/introduction.html) will help you in following the tutorial with ease."
+        "**NOTE:** A basic understanding of the [kafka components](https://kafka.apache.org/documentation/#intro_concepts_and_terms) will help you in following the tutorial with ease.",
+        "\n",
+        "**NOTE:** A Java runtime environment is required to run this tutorial."
       ]
     },
     {
@@ -104,7 +106,9 @@
       "outputs": [],
       "source": [
         "!pip install tensorflow-io\n",
-        "!pip install kafka-python"
+        "!pip install kafka-python\n",
+        "!pip install sklearn\n",
+        "!pip install pandas"
       ]
     },
     {
@@ -180,8 +184,8 @@
       },
       "outputs": [],
       "source": [
-        "!curl -sSOL http://packages.confluent.io/archive/5.4/confluent-community-5.4.1-2.12.tar.gz\n",
-        "!tar -xzf confluent-community-5.4.1-2.12.tar.gz"
+        "!curl -sSOL https://downloads.apache.org/kafka/2.7.0/kafka_2.13-2.7.0.tgz\n",
+        "!tar -xzf kafka_2.13-2.7.0.tgz"
       ]
     },
     {
@@ -190,7 +194,7 @@
         "id": "vAzfu_WiEs4F"
       },
       "source": [
-        "Using the default configurations (provided by the confluent package) for spinning up the instances."
+        "Using the default configurations (provided by Apache Kafka) for spinning up the instances."
       ]
     },
     {
@@ -201,8 +205,8 @@
       },
       "outputs": [],
       "source": [
-        "!cd confluent-5.4.1 && bin/zookeeper-server-start -daemon etc/kafka/zookeeper.properties\n",
-        "!cd confluent-5.4.1 && bin/kafka-server-start -daemon etc/kafka/server.properties\n",
+        "!./kafka_2.13-2.7.0/bin/zookeeper-server-start.sh -daemon ./kafka_2.13-2.7.0/config/zookeeper.properties\n",
+        "!./kafka_2.13-2.7.0/bin/kafka-server-start.sh -daemon ./kafka_2.13-2.7.0/config/server.properties\n",
         "!echo \"Waiting for 10 secs until kafka and zookeeper services are up and running\"\n",
         "!sleep 10\n"
       ]
@@ -247,8 +251,8 @@
       },
       "outputs": [],
       "source": [
-        "!confluent-5.4.1/bin/kafka-topics --create --zookeeper 127.0.0.1:2181 --replication-factor 1 --partitions 1 --topic susy-train\n",
-        "!confluent-5.4.1/bin/kafka-topics --create --zookeeper 127.0.0.1:2181 --replication-factor 1 --partitions 2 --topic susy-test\n"
+        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --create --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 1 --topic susy-train\n",
+        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --create --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 2 --topic susy-test\n"
       ]
     },
     {
@@ -268,8 +272,8 @@
       },
       "outputs": [],
       "source": [
-        "!confluent-5.4.1/bin/kafka-topics --bootstrap-server 127.0.0.1:9092 --describe --topic susy-train\n",
-        "!confluent-5.4.1/bin/kafka-topics --bootstrap-server 127.0.0.1:9092 --describe --topic susy-test\n"
+        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --describe --bootstrap-server 127.0.0.1:9092 --topic susy-train\n",
+        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --describe --bootstrap-server 127.0.0.1:9092 --topic susy-test\n"
       ]
     },
     {
@@ -720,7 +724,7 @@
       },
       "outputs": [],
       "source": [
-        "!confluent-5.4.1/bin/kafka-consumer-groups --bootstrap-server 127.0.0.1:9092 --describe --group testcg\n"
+        "!./kafka_2.13-2.7.0/bin/kafka-consumer-groups.sh --bootstrap-server 127.0.0.1:9092 --describe --group testcg\n"
       ]
     },
     {

--- a/docs/tutorials/kafka.ipynb
+++ b/docs/tutorials/kafka.ipynb
@@ -106,9 +106,7 @@
       "outputs": [],
       "source": [
         "!pip install tensorflow-io\n",
-        "!pip install kafka-python\n",
-        "!pip install sklearn\n",
-        "!pip install pandas"
+        "!pip install kafka-python"
       ]
     },
     {


### PR DESCRIPTION
Minor update to the Kafka tutorial to remove the dependency on
Confluent's distribution of Kafka, and instead work with vanilla
Apache Kafka.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>