### PR TITLE
add github workflow for performance benchmarking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,73 @@
+name: API Performance Benchmarks
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+
+  macos:
+    name: macOS ${{ matrix.python }} + ${{ matrix.version }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.8']
+        version: ['tensorflow==2.4.0:tensorflow-io-nightly', 'tensorflow==2.4.0:tensorflow-io']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Setup macOS
+        run: |
+          set -x -e
+          python -m pip install -U wheel setuptools
+          python --version
+      - name: Test macOS
+        run: |
+          set -x -e
+          python --version
+          df -h
+          rm -rf tensorflow_io
+          echo ${{ matrix.version }} | awk -F: '{print $1}' | xargs python -m pip install -U
+          echo ${{ matrix.version }} | awk -F: '{print $2}' | xargs python -m pip install --no-deps -U
+          python -m pip install pytest-benchmark scikit-image
+          python -m pip freeze
+          python -c 'import tensorflow as tf; print(tf.version.VERSION)'
+          python -c 'import tensorflow_io as tfio; print(tfio.version.VERSION)'
+          python -m pytest --benchmark-only -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \))
+
+  linux:
+    name: Linux ${{ matrix.python }} + ${{ matrix.version }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.8']
+        version: ['tensorflow==2.4.0:tensorflow-io-nightly', 'tensorflow==2.4.0:tensorflow-io']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Setup Linux
+        run: |
+          set -x -e
+          bash -x -e .github/workflows/build.space.sh
+      - name: Test Linux
+        run: |
+          set -x -e
+          python --version
+          df -h
+          rm -rf tensorflow_io
+          echo ${{ matrix.version }} | awk -F: '{print $1}' | xargs python -m pip install -U
+          echo ${{ matrix.version }} | awk -F: '{print $2}' | xargs python -m pip install --no-deps -U
+          python -m pip install pytest-benchmark scikit-image
+          python -m pip freeze
+          python -c 'import tensorflow as tf; print(tf.version.VERSION)'
+          python -c 'import tensorflow_io as tfio; print(tfio.version.VERSION)'
+          python -m pytest --benchmark-only -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \))

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -70,4 +70,9 @@ jobs:
           python -m pip freeze
           python -c 'import tensorflow as tf; print(tf.version.VERSION)'
           python -c 'import tensorflow_io as tfio; print(tfio.version.VERSION)'
-          python -m pytest --benchmark-only -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \))
+          python -m pytest --benchmark-only --benchmark-json benchmark.json -v --import-mode=append $(find . -type f \( -iname "test_*_eager.py" ! \( -iname "test_bigquery_eager.py" \) \))
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: benchmark.json


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/io/issues/1265 by adding a github workflow to benchmark API performance.
Benchmarking of additional API's will be taken up in the following PR's.

Additionally, I can add [github-action-benchmark](https://github.com/rhysd/github-action-benchmark/tree/master/examples/pytest) action to our workflow so that we can see the results in gh pages.
Please let me know.
cc: @yongtang @terrytangyuan 