### PR TITLE
remove docker based mongodb tests from macos based Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,6 @@ jobs:
           bash -x -e tests/test_azure/start_azure.sh
           bash -x -e tests/test_pubsub/pubsub_test.sh
           bash -x -e tests/test_pulsar/pulsar_test.sh
-          bash -x -e tests/test_mongodb/mongodb_test.sh start
       - name: Install ${{ matrix.python }} macOS
         run: |
           set -x -e


### PR DESCRIPTION
This PR removes the mongodb tests in macos env as the docker environment is not yet stable. Follow up of https://github.com/tensorflow/io/pull/1277

Issue : https://github.com/docker-practice/actions-setup-docker/issues/5