### PR TITLE
trigger benchmarks workflow only on commits

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,11 +4,8 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "0 12 * * *"
 
 jobs:
-
   macos:
     name: macOS ${{ matrix.python }} + ${{ matrix.version }}
     runs-on: macos-latest


### PR DESCRIPTION
The scheduled benchmarks workflow is failing with the following error:

```
Error: No commit information is found in payload: {
  "schedule": "0 12 * * *"
}
```

This PR removes the scheduler so that the workflow is triggered only when commits are made to master branch.