### PR TITLE
Add bazel cache to speed up build for git push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
       - master
 
 env:
+  GCP_CREDS: ${{ secrets.GCP_CREDS }}
+  EVENT_NAME: ${{ github.event_name }}
   BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
 
 jobs:
@@ -49,6 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
+            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+          fi
           set -x -e
           echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
           export PATH=/usr/bin:$PATH
@@ -65,12 +71,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
+            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+          fi
           set -x -e
           bash -x -e .github/workflows/build.space.sh
           python3 .github/workflows/build.instruction.py docs/development.md "##### Ubuntu 20.04" > source.sh
           cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host ubuntu:20.04 \
-            bash -x -e source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host \
+            -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
+            ubuntu:20.04 bash -x -e source.sh
 
   centos-7:
     name: CentOS 7
@@ -78,12 +89,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
+            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+          fi
           set -x -e
           bash -x -e .github/workflows/build.space.sh
           python3 .github/workflows/build.instruction.py docs/development.md "##### CentOS 7" > source.sh
           cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host centos:7 \
-            bash -x -e source.sh
+          docker run -i --rm -v $PWD:/v -w /v --net=host \
+            -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
+            centos:7 bash -x -e source.sh
 
   macos-bazel:
     name: Bazel macOS
@@ -92,6 +108,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bazel on macOS
         run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
+            export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+          fi
           set -x -e
           echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
           export PATH=/usr/bin:$PATH
@@ -199,6 +219,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bazel on Linux
         run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
+            export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+          fi
           set -x -e
           bash -x -e .github/workflows/build.space.sh
           BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
@@ -302,6 +326,12 @@ jobs:
           BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
         shell: cmd
         run: |
+          if "%EVENT_NAME%" == "push" (
+            printenv GCP_CREDS > service_account_creds.json
+            set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+          ) else (
+            echo %EVENT_NAME%
+          )
           @echo on
           set /P BAZEL_VERSION=< .bazelversion
           curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
@@ -315,7 +345,7 @@ jobs:
           python3 setup.py --package-version | xargs python3 -m pip install
           python3 tools/build/configure.py
           cat .bazelrc
-          bazel build -s --verbose_failures //tensorflow_io/core:python/ops/libtensorflow_io.so //tensorflow_io/core:python/ops/libtensorflow_io_plugins.so
+          bazel build -s --verbose_failures %BAZEL_OPTIMIZATION% //tensorflow_io/core:python/ops/libtensorflow_io.so //tensorflow_io/core:python/ops/libtensorflow_io_plugins.so
       - uses: actions/upload-artifact@v1
         with:
           name: ${{ runner.os }}-bazel-bin

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,8 +77,12 @@ sudo bash -x -e bazel-$(cat .bazelversion)-installer-darwin-x86_64.sh
 # Install tensorflow and configure bazel
 sudo ./configure.sh
 
+# Add any optimization on bazel command, e.g., --compilation_mode=opt,
+#   --copt=-msse4.2, --remote_cache=, etc.
+# export BAZEL_OPTIMIZATION=
+
 # Build shared libraries
-bazel build -s --verbose_failures //tensorflow_io/...
+bazel build -s --verbose_failures $BAZEL_OPTIMIZATION //tensorflow_io/...
 
 # Once build is complete, shared libraries will be available in
 # `bazel-bin/tensorflow_io/core/python/ops/` and it is possible
@@ -132,8 +136,12 @@ sudo python3 -m pip install -U pip
 # Install tensorflow and configure bazel
 sudo ./configure.sh
 
+# Add any optimization on bazel command, e.g., --compilation_mode=opt,
+#   --copt=-msse4.2, --remote_cache=, etc.
+# export BAZEL_OPTIMIZATION=
+
 # Build shared libraries
-bazel build -s --verbose_failures //tensorflow_io/...
+bazel build -s --verbose_failures $BAZEL_OPTIMIZATION //tensorflow_io/...
 
 # Once build is complete, shared libraries will be available in
 # `bazel-bin/tensorflow_io/core/python/ops/` and it is possible
@@ -182,10 +190,14 @@ scl enable rh-python36 devtoolset-9 \
 scl enable rh-python36 devtoolset-9 \
     './configure.sh'
 
+# Add any optimization on bazel command, e.g., --compilation_mode=opt,
+#   --copt=-msse4.2, --remote_cache=, etc.
+# export BAZEL_OPTIMIZATION=
+
 # Build shared libraries, notice the passing of --//tensorflow_io/core:static_build
 BAZEL_LINKOPTS="-static-libstdc++ -static-libgcc" BAZEL_LINKLIBS="-lm -l%:libstdc++.a" \
   scl enable rh-python36 devtoolset-9 \
-    'bazel build -s --verbose_failures --//tensorflow_io/core:static_build //tensorflow_io/...'
+    'bazel build -s --verbose_failures $BAZEL_OPTIMIZATION --//tensorflow_io/core:static_build //tensorflow_io/...'
 
 # Once build is complete, shared libraries will be available in
 # `bazel-bin/tensorflow_io/core/python/ops/` and it is possible


### PR DESCRIPTION
This PR is part of the effort for #1236. It adds bazel cache to speed up build for push. We added a gcs bucket provided by tensorflow team so that the bazel build will point to the cache to gcs bucket.

The speed for Linux build is now 20 min (vs 1 hour 10 min in the past):
https://github.com/tensorflow/io/runs/1787903245?check_suite_focus=true

One limitation for this PR is that the cache is only available for git push, not for forked PRs (by outside contributors). 

To enable speed up for forked PRs, the gcs bucket will need to give read-only access to anonymous users. This will be inline with the way tensorboard team.

We will sync up to see this will be possible for the gcs bucket that was provided. Note tensorboard is done similarly in:

https://github.com/tensorflow/tensorboard/blob/48c0a2d814c755937f5950e251e8071199c99d38/ci/bazelrc#L27-L34

Thanks @angerson for the great help!

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>