### PR TITLE
Add reference to github-pages benchmarks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ of releases [here](https://github.com/tensorflow/io/releases).
 
 ## Performance Benchmarking
 
-We use [github-pages](https://tensorflow.github.io/io/dev/bench/) to document the results of api performance benchmarks. The benchmarks are triggered on every commit to `master` branch and
+We use [github-pages](https://tensorflow.github.io/io/dev/bench/) to document the results of api performance benchmarks. The benchmark job is triggered on every commit to `master` branch and
 facilitates tracking performance w.r.t commits.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ of releases [here](https://github.com/tensorflow/io/releases).
 | 0.2.0 | 1.12.0 | Jan 29, 2019 |
 | 0.1.0 | 1.12.0 | Dec 16, 2018 |
 
+
+## Performance Benchmarking
+
+We use [github-pages](https://tensorflow.github.io/io/dev/bench/) to document the results of api performance benchmarks. The benchmarks are triggered on every commit to `master` branch and
+facilitates tracking performance w.r.t commits.
+
 ## Contributing
 
 Tensorflow I/O is a community led open source project. As such, the project

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ of releases [here](https://github.com/tensorflow/io/releases).
 
 ## Performance Benchmarking
 
-We use [github-pages](https://tensorflow.github.io/io/dev/bench/) to document the results of api performance benchmarks. The benchmark job is triggered on every commit to `master` branch and
+We use [github-pages](https://tensorflow.github.io/io/dev/bench/) to document the results of API performance benchmarks. The benchmark job is triggered on every commit to `master` branch and
 facilitates tracking performance w.r.t commits.
 
 ## Contributing


### PR DESCRIPTION
This PR updates the README.md file with the performance-benchmarks section, which points to the github-pages deployment.
Addresses https://github.com/tensorflow/io/issues/1265