### PR TITLE
Only enable bazel caching writes for tensorflow/io github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   GCP_CREDS: ${{ secrets.GCP_CREDS }}
+  REPO_NAME: ${{ github.repository }}
   EVENT_NAME: ${{ github.event_name }}
   BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
 
@@ -51,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          if [[ "${EVENT_NAME}" == "push" ]]; then
+          if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
@@ -71,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          if [[ "${EVENT_NAME}" == "push" ]]; then
+          if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
@@ -89,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          if [[ "${EVENT_NAME}" == "push" ]]; then
+          if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
@@ -108,7 +109,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bazel on macOS
         run: |
-          if [[ "${EVENT_NAME}" == "push" ]]; then
+          if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
@@ -219,7 +220,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bazel on Linux
         run: |
-          if [[ "${EVENT_NAME}" == "push" ]]; then
+          if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
@@ -327,8 +328,12 @@ jobs:
         shell: cmd
         run: |
           if "%EVENT_NAME%" == "push" (
-            printenv GCP_CREDS > service_account_creds.json
-            set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+            if "%REPO_NAME%" == "tensorflow/io" (
+              printenv GCP_CREDS > service_account_creds.json
+              set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+            ) else (
+              echo %REPO_NAME%
+            )
           ) else (
             echo %EVENT_NAME%
           )


### PR DESCRIPTION
This PR updates so that only GitHub actions run on
tensorflow/io repo will be enabled with bazel cache writes.

Without the updates, a focked repo actions will cause error.

Note once bazel cache read-permissions are enabled from gcs
forked repo will be able to access bazel cache (read-only).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>