### PR TITLE
Enable bazel remote cache for kokoro tests

### DIFF
--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -48,7 +48,7 @@ docker  --version
 export PYTHON_VERSION=3.8
 
 export BAZEL_VERSION=$(cat .bazelversion)
-export BAZEL_OPTIMIZATION="--copt=-msse4.2 --copt=-mavx --compilation_mode=opt"
+export BAZEL_OPTIMIZATION="--copt=-msse4.2 --copt=-mavx --compilation_mode=opt --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
 export BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
 
 docker run -i --rm -v $PWD:/v -w /v --net=host \


### PR DESCRIPTION
Also enable bazel remote cache for kokoro tests

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>