### PR TITLE
Avoid error if plugins .so module is not available

### DIFF
--- a/tensorflow_io/core/python/ops/__init__.py
+++ b/tensorflow_io/core/python/ops/__init__.py
@@ -18,6 +18,7 @@ import os
 import ctypes
 import sys
 import inspect
+import warnings
 import types
 
 import tensorflow as tf
@@ -95,5 +96,8 @@ try:
     plugin_ops = _load_library("libtensorflow_io_plugins.so", "fs")
 except NotImplementedError as e:
     # Note: load libtensorflow_io.so imperatively in case of statically linking
-    core_ops = _load_library("libtensorflow_io.so")
-    plugin_ops = _load_library("libtensorflow_io.so", "fs")
+    try:
+        core_ops = _load_library("libtensorflow_io.so")
+        plugin_ops = _load_library("libtensorflow_io.so", "fs")
+    except NotImplementedError as e:
+        warnings.warn("file system plugins are not loaded: {}".format(e))


### PR DESCRIPTION
This PR raises a warning instead of an error in case plugins .so module is not available, so that tensorflow-io package can be at least partially used with python-only functions.

This PR is related to #1298

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>