### PR TITLE
Add @com_google_absl//absl/strings:cord

### DIFF
--- a/tensorflow_io/core/kernels/text_kernels.cc
+++ b/tensorflow_io/core/kernels/text_kernels.cc
@@ -16,10 +16,11 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/lib/io/buffered_inputstream.h"
 #include "tensorflow_io/core/kernels/io_stream.h"
-
 #if defined(_MSC_VER)
 #include <io.h>
 #define STDIN_FILENO _fileno(stdin)
+#else
+#include <unistd.h>
 #endif
 
 namespace tensorflow {

--- a/tensorflow_io/core/kernels/video_kernels.h
+++ b/tensorflow_io/core/kernels/video_kernels.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 static int xioctl(int fh, int request, void* arg) {
   int r;

--- a/third_party/toolchains/tf/BUILD.tpl
+++ b/third_party/toolchains/tf/BUILD.tpl
@@ -8,6 +8,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:cord",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
     ],


### PR DESCRIPTION
While trying to build tensorflow-io against tf-nightly (not tensorflow package), I noticed there were some additional fixes that will be needed to compile.

Since they are additional includes and will not impact existing build, and we will update to next version of tensorflow soon, it makes sense to have the update.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>