### PR TITLE
Modify --plat-name for macosx wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
           set -x -e
           python -m pip install -U wheel setuptools
           python --version
-          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_15_x86_64
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
           set -x -e
@@ -553,7 +553,7 @@ jobs:
           set -x -e
           python -m pip install -U wheel setuptools
           python --version
-          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_13_x86_64 --nightly $BUILD_NUMBER
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_15_x86_64 --nightly $BUILD_NUMBER
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
           set -x -e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
           set -x -e
           python -m pip install -U wheel setuptools
           python --version
-          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_15_x86_64
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_14_x86_64
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
           set -x -e
@@ -553,7 +553,7 @@ jobs:
           set -x -e
           python -m pip install -U wheel setuptools
           python --version
-          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_15_x86_64 --nightly $BUILD_NUMBER
+          python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_14_x86_64 --nightly $BUILD_NUMBER
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
           set -x -e


### PR DESCRIPTION
This PR updates the `--plat-name` from `macosx_10_13_x86_64` to `macosx_10_15_x86_64` while building the tfio wheel as per the github actions env.