### PR TITLE
Switch to modular file system for s3

### DIFF
--- a/tensorflow_io/core/plugins/file_system_plugins.cc
+++ b/tensorflow_io/core/plugins/file_system_plugins.cc
@@ -30,12 +30,25 @@ void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
                                              sizeof(info->ops[0])));
   tensorflow::io::az::ProvideFilesystemSupportFor(&info->ops[0], "az");
   tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[1], "http");
-  tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
   if (enable_legacy == "true" || enable_legacy == "1") {
+// TODO: enable on windows once tf-nightly releases windows build
+// that contains TF_ENABLE_LEGACY_FILESYSTEM.
+#if defined(_MSC_VER)
+    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3");
+#else
+    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
+#endif
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfse");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfse");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "hare");
   } else {
+// TODO: enable on windows once tf-nightly releases windows build
+// that contains TF_ENABLE_LEGACY_FILESYSTEM.
+#if defined(_MSC_VER)
+    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
+#else
+    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3");
+#endif
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfs");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfs");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "har");

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -55,7 +55,5 @@ def test_read_file():
     os.environ["S3_USE_HTTPS"] = "0"
     os.environ["S3_VERIFY_SSL"] = "0"
 
-    # TODO: The following is not working yet, need update to use
-    # s3 implementation with module file system
-    content = tf.io.read_file("s3e://{}/{}".format(bucket_name, key_name))
+    content = tf.io.read_file("s3://{}/{}".format(bucket_name, key_name))
     assert content == body


### PR DESCRIPTION
This PR is part of the effort to switch to modular file system for s3.
When TF_ENABLE_LEGACY_FILESYSTEM=1 is provided, old behavior will
be preserved.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>