### PR TITLE
Use `-p 9000:9000` (and hide 8088) when launch hadoop

### DIFF
--- a/tests/test_hdfs/hdfs_test.sh
+++ b/tests/test_hdfs/hdfs_test.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 HADOOP_VERSION=2.7.0
 docker pull sequenceiq/hadoop-docker:$HADOOP_VERSION
-docker run -d --rm --net=host --name=tensorflow-io-hdfs sequenceiq/hadoop-docker:$HADOOP_VERSION
+docker run -d --rm -p 9000:9000 --name=tensorflow-io-hdfs sequenceiq/hadoop-docker:$HADOOP_VERSION
 echo "Waiting for 30 secs until hadoop is up and running"
 sleep 30
 docker logs tensorflow-io-hdfs


### PR DESCRIPTION
This PR will try to resolve the issue related to:
```
Vulnerability Description
Hadoop Yarn Unauthenticated ResourceManager API
Hadoop Yarn ResourceManager controls the computation and storage resources of a Hadoop cluster.
Exposing the ResourceManager API without authentication allows any remote user to create and execute arbitrary applications on the host.
Affected asset(s):
<ip>:8088 VM Instance kokoro-gcp-ubuntu-prod-<number> in GCP project kokoro project_number: <number>
```


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>