### PR TITLE
update `protobuf` version to `3.11.4` to match tensorflow-nightly

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,11 +12,14 @@ cuda_configure(name = "local_config_cuda")
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "cfcba2df10feec52a84208693937c17a4b5df7775e1635c1e3baffc487b24c9b",
-    strip_prefix = "protobuf-3.9.2",
+    patch_cmds = [
+        """sed -i.bak 's/@six\\/\\/:six/\\/\\/external:six/g' BUILD""",
+    ],
+    sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
+    strip_prefix = "protobuf-3.11.4",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/v3.9.2.zip",
-        "https://github.com/protocolbuffers/protobuf/archive/v3.9.2.zip",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/v3.11.4.zip",
+        "https://github.com/protocolbuffers/protobuf/archive/v3.11.4.zip",
     ],
 )
 


### PR DESCRIPTION
There is a mismatch version of protobuf between `tf-nightly` and `tf-io` ( and there are leaks symbols somewhere I think ). Commit https://github.com/tensorflow/tensorflow/commit/e71367f826ed32e8a7a3e78d5f35aded180c9c72 updated `protobuf` version of Tensorflow to `3.11.4`. This PR does the same things for `tf-io`.