### PR TITLE
Revert "update `protobuf` version to `3.11.4` to match tensorflow-nightly"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,14 +12,11 @@ cuda_configure(name = "local_config_cuda")
 
 http_archive(
     name = "com_google_protobuf",
-    patch_cmds = [
-        """sed -i.bak 's/@six\\/\\/:six/\\/\\/external:six/g' BUILD""",
-    ],
-    sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
-    strip_prefix = "protobuf-3.11.4",
+    sha256 = "cfcba2df10feec52a84208693937c17a4b5df7775e1635c1e3baffc487b24c9b",
+    strip_prefix = "protobuf-3.9.2",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/v3.11.4.zip",
-        "https://github.com/protocolbuffers/protobuf/archive/v3.11.4.zip",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/v3.9.2.zip",
+        "https://github.com/protocolbuffers/protobuf/archive/v3.9.2.zip",
     ],
 )
 


### PR DESCRIPTION
Reverts tensorflow/io#1320

The commit https://github.com/tensorflow/tensorflow/commit/e71367f826ed32e8a7a3e78d5f35aded180c9c72  in TensorFlow is reverted by https://github.com/tensorflow/tensorflow/commit/bd3e005eb9c8d23992d793d54b28e103e2348866. Please wait for `tf-nightly 2.5.0.dev20210310` before merging this PR.

Could we freeze the `tf-nightly` version @yongtang ?