### PR TITLE
Enable python 3.9 build on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -184,7 +184,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -453,6 +453,10 @@ jobs:
           path: macOS-3.8-wheel
       - uses: actions/download-artifact@v1
         with:
+          name: macOS-3.9-wheel
+          path: macOS-3.9-wheel
+      - uses: actions/download-artifact@v1
+        with:
           name: Linux-3.6-wheel
           path: Linux-3.6-wheel
       - uses: actions/download-artifact@v1
@@ -489,6 +493,7 @@ jobs:
           cp macOS-3.6-wheel/*.whl wheelhouse/
           cp macOS-3.7-wheel/*.whl wheelhouse/
           cp macOS-3.8-wheel/*.whl wheelhouse/
+          cp macOS-3.9-wheel/*.whl wheelhouse/
           cp Linux-3.6-wheel/*.whl wheelhouse/
           cp Linux-3.7-wheel/*.whl wheelhouse/
           cp Linux-3.8-wheel/*.whl wheelhouse/
@@ -549,7 +554,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8']
+        python: ['3.6', '3.7', '3.8', '3.9']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -678,6 +683,10 @@ jobs:
           path: macOS-3.8-nightly
       - uses: actions/download-artifact@v1
         with:
+          name: macOS-3.9-nightly
+          path: macOS-3.9-nightly
+      - uses: actions/download-artifact@v1
+        with:
           name: Linux-3.6-nightly
           path: Linux-3.6-nightly
       - uses: actions/download-artifact@v1
@@ -714,6 +723,7 @@ jobs:
           cp macOS-3.6-nightly/*.whl dist/
           cp macOS-3.7-nightly/*.whl dist/
           cp macOS-3.8-nightly/*.whl dist/
+          cp macOS-3.9-nightly/*.whl dist/
           cp Linux-3.6-nightly/*.whl dist/
           cp Linux-3.7-nightly/*.whl dist/
           cp Linux-3.8-nightly/*.whl dist/


### PR DESCRIPTION
This PR enables python 3.9 build on macOS, as tf-nightly
is available with macOS now.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>