### PR TITLE
Bump abseil-cpp to 6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,21 +88,6 @@ jobs:
           docker run -i --rm -v $PWD:/v -w /v --net=host \
             -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
             ubuntu:20.04 bash -x -e source.sh
-      - name: CentOS 7
-        run: |
-          if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
-            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
-          else
-            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
-          fi
-          set -x -e
-          bash -x -e .github/workflows/build.space.sh
-          python3 .github/workflows/build.instruction.py docs/development.md "##### CentOS 7" > source.sh
-          cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host \
-            -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
-            centos:7 bash -x -e source.sh
 
   macos-bazel:
     name: Bazel macOS

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -400,11 +400,11 @@ http_archive(
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "f368a8476f4e2e0eccf8a7318b98dafbe30b2600f4e3cf52636e5eb145aba06a",
-    strip_prefix = "abseil-cpp-df3ea785d8c30a9503321a3d35ee7d35808f190d",
+    sha256 = "62c27e7a633e965a2f40ff16b487c3b778eae440bab64cad83b34ef1cbe3aa93",
+    strip_prefix = "abseil-cpp-6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
-        "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c.tar.gz",
+        "https://github.com/abseil/abseil-cpp/archive/6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This PR bumps abseil-cpp to 6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c
to fix the build issue.

See related changes in  tensorflow/tensorflow@1c9eeb9

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>