### PR TITLE
Release nightly even if test fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -535,7 +535,7 @@ jobs:
   macos-nightly:
     name: Nightly ${{ matrix.python }} macOS
     if: github.event_name == 'push'
-    needs: [build-number, release]
+    needs: [build-number, macos-wheel]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -578,7 +578,7 @@ jobs:
   linux-nightly:
     name: Nightly ${{ matrix.python }} Linux
     if: github.event_name == 'push'
-    needs: [build-number, release]
+    needs: [build-number, linux-wheel]
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -616,7 +616,7 @@ jobs:
   windows-nightly:
     name: Nightly ${{ matrix.python }} Windows
     if: github.event_name == 'push'
-    needs: [build-number, release]
+    needs: [build-number, windows-wheel]
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
Our tests on some platforms have not been very stable recently. That prevents the nightly releases. For example, PR #1336 may potentially have #1335 addressed as well but we don't have tensorflow-io-nightly due to test failure.

This PR removes the dependency so that tensorflow-io-nightly can be released even if the tests fails. (as tensorflow-io-nightly is supposed to be not the same grade as final release anyway).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>