### PR TITLE
improvements for `s3` environements variables

### DIFF
--- a/tensorflow_io/core/plugins/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/plugins/s3/s3_filesystem.cc
@@ -135,8 +135,6 @@ static Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
   absl::MutexLock l(&cfg_lock);
 
   if (!init) {
-    const char* endpoint = getenv("S3_ENDPOINT");
-    if (endpoint) cfg.endpointOverride = Aws::String(endpoint);
     const char* region = getenv("AWS_REGION");
     // TODO (yongtang): `S3_REGION` should be deprecated after 2.0.
     if (!region) region = getenv("S3_REGION");
@@ -241,9 +239,13 @@ static void GetS3Client(tf_s3_filesystem::S3File* s3_file) {
             tf_s3_filesystem::AWSLogSystem::ShutdownAWSLogging();
           }
         });
+
     int temp_value;
     if (absl::SimpleAtoi(getenv("S3_DISABLE_MULTI_PART_DOWNLOAD"), &temp_value))
       s3_file->use_multi_part_download = (temp_value != 1);
+
+    const char* endpoint = getenv("S3_ENDPOINT");
+    if (endpoint) s3_file->s3_client->OverrideEndpoint(endpoint);
   }
 }
 

--- a/tensorflow_io/core/plugins/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/plugins/s3/s3_filesystem.cc
@@ -166,20 +166,6 @@ static Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
           cfg.region = profiles["default"].GetRegion();
       }
     }
-    const char* use_https = getenv("S3_USE_HTTPS");
-    if (use_https) {
-      if (use_https[0] == '0')
-        cfg.scheme = Aws::Http::Scheme::HTTP;
-      else
-        cfg.scheme = Aws::Http::Scheme::HTTPS;
-    }
-    const char* verify_ssl = getenv("S3_VERIFY_SSL");
-    if (verify_ssl) {
-      if (verify_ssl[0] == '0')
-        cfg.verifySSL = false;
-      else
-        cfg.verifySSL = true;
-    }
     // if these timeouts are low, you may see an error when
     // uploading/downloading large files: Unable to connect to endpoint
     int64_t timeout;

--- a/tensorflow_io/core/plugins/s3/s3_filesystem.h
+++ b/tensorflow_io/core/plugins/s3/s3_filesystem.h
@@ -60,11 +60,12 @@ typedef struct S3File {
   std::shared_ptr<Aws::S3::S3Client> s3_client;
   std::shared_ptr<Aws::Utils::Threading::PooledThreadExecutor> executor;
   // We need 2 `TransferManager`, for multipart upload/download.
-  Aws::Map<Aws::Transfer::TransferDirection,
-           std::shared_ptr<Aws::Transfer::TransferManager>>
+  Aws::UnorderedMap<Aws::Transfer::TransferDirection,
+                    std::shared_ptr<Aws::Transfer::TransferManager>>
       transfer_managers;
   // Sizes to split objects during multipart upload/download.
-  Aws::Map<Aws::Transfer::TransferDirection, uint64_t> multi_part_chunk_sizes;
+  Aws::UnorderedMap<Aws::Transfer::TransferDirection, uint64_t>
+      multi_part_chunk_sizes;
   bool use_multi_part_download;
   absl::Mutex initialization_lock;
   S3File();

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -51,9 +51,7 @@ def test_read_file():
     response = client.get_object(Bucket=bucket_name, Key=key_name)
     assert response["Body"].read() == body
 
-    os.environ["S3_ENDPOINT"] = "localhost:4566"
-    os.environ["S3_USE_HTTPS"] = "0"
-    os.environ["S3_VERIFY_SSL"] = "0"
+    os.environ["S3_ENDPOINT"] = "http://localhost:4566"
 
     content = tf.io.read_file("s3://{}/{}".format(bucket_name, key_name))
     assert content == body


### PR DESCRIPTION
116dc39: Now, we have to set 3 envs `S3_DISABLE_MULTI_PART_DOWNLOAD`, `S3_MULTI_PART_UPLOAD_CHUNK_SIZE` and `S3_MULTI_PART_DOWNLOAD_CHUNK_SIZE` before importing `tensorflow-io` if we want to change the default behavior. This PR defers the reading:
- `S3_DISABLE_MULTI_PART_DOWNLOAD` now should be set before the first calling to `s3` filesystem ( read in `GetS3Client` )
- `S3_MULTI_PART_UPLOAD_CHUNK_SIZE` should be set before uploading something to `s3` ( read in `GetTransferManager` in `Aws::Transfer::TransferDirection::UPLOAD` ).
- `S3_MULTI_PART_DOWNLOAD_CHUNK_SIZE ` should be set before reading something from `s3` ( read in `GetTransferManager` in `Aws::Transfer::TransferDirection::DOWNLOAD` ).

6e9e86d: This commit use [`OverrideEndpoint`](https://github.com/aws/aws-sdk-cpp/blob/b343488fc5351d7278c0b9482988321c9b4387bf/aws-cpp-sdk-s3/source/S3Client.cpp#L185-L203) of `s3_client` instead of forcing users to set `S3_ENDPOINT` and `S3_USE_HTTPS`. `OverrideEndpoint` supports both with and without `uri` ( in the latter case it will fallback to `S3_USE_HTTPS`). We could eventually remove `S3_USE_HTTPS` and `S3_VERIFY_SSL` since users might accidentally set `S3_USE_HTTPS=0` in a production environment which is extremely dangerous. ( we could remove those envs in this PR I think )