### PR TITLE
modify env var for loading modular file systems

### DIFF
--- a/tensorflow_io/core/plugins/file_system_plugins.cc
+++ b/tensorflow_io/core/plugins/file_system_plugins.cc
@@ -29,6 +29,7 @@ void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
                                              sizeof(info->ops[0])));
   tensorflow::io::az::ProvideFilesystemSupportFor(&info->ops[0], "az");
   tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[1], "http");
+  // Load plugins only when the environment variable is set
   if (load_plugin == "true" || load_plugin == "1") {
     tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfs");

--- a/tensorflow_io/core/plugins/file_system_plugins.cc
+++ b/tensorflow_io/core/plugins/file_system_plugins.cc
@@ -18,9 +18,8 @@ limitations under the License.
 #include "absl/strings/ascii.h"
 
 void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
-  const char* enable_legacy_env = getenv("TF_ENABLE_LEGACY_FILESYSTEM");
-  std::string enable_legacy =
-      enable_legacy_env ? absl::AsciiStrToLower(enable_legacy_env) : "";
+  const char* env_value = getenv("TF_USE_MODULAR_FILESYSTEM");
+  std::string load_plugin = env_value ? absl::AsciiStrToLower(env_value) : "";
 
   info->plugin_memory_allocate = tensorflow::io::plugin_memory_allocate;
   info->plugin_memory_free = tensorflow::io::plugin_memory_free;
@@ -30,7 +29,7 @@ void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
                                              sizeof(info->ops[0])));
   tensorflow::io::az::ProvideFilesystemSupportFor(&info->ops[0], "az");
   tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[1], "http");
-  if (enable_legacy == "true" || enable_legacy == "1") {
+  if (load_plugin == "true" || load_plugin == "1") {
     tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfse");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfse");

--- a/tensorflow_io/core/plugins/file_system_plugins.cc
+++ b/tensorflow_io/core/plugins/file_system_plugins.cc
@@ -30,16 +30,16 @@ void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
   tensorflow::io::az::ProvideFilesystemSupportFor(&info->ops[0], "az");
   tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[1], "http");
   if (load_plugin == "true" || load_plugin == "1") {
-    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfse");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfse");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "hare");
-    tensorflow::io::gs::ProvideFilesystemSupportFor(&info->ops[6], "gse");
-  } else {
     tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfs");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfs");
     tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "har");
     tensorflow::io::gs::ProvideFilesystemSupportFor(&info->ops[6], "gs");
+  } else {
+    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfse");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfse");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "hare");
+    tensorflow::io::gs::ProvideFilesystemSupportFor(&info->ops[6], "gse");
   }
 }

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -25,6 +25,9 @@ import pytest
 
 # GCS emulator setup is in tests/test_gcloud/test_gcs.sh
 
+# Use modular file system plugins from tfio instead of the legacy implementation
+# from tensorflow.
+os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -29,6 +29,7 @@ import pytest
 # from tensorflow.
 os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 
+
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),
     reason="TODO GCS emulator not setup properly on macOS/Windows yet",

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -15,6 +15,7 @@
 """Tests for GCS file system"""
 
 import os
+
 # Use modular file system plugins from tfio instead of the legacy implementation
 # from tensorflow.
 os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
@@ -27,6 +28,7 @@ import pytest
 
 
 # GCS emulator setup is in tests/test_gcloud/test_gcs.sh
+
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -15,6 +15,9 @@
 """Tests for GCS file system"""
 
 import os
+# Use modular file system plugins from tfio instead of the legacy implementation
+# from tensorflow.
+os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 import sys
 import time
 import requests
@@ -24,11 +27,6 @@ import pytest
 
 
 # GCS emulator setup is in tests/test_gcloud/test_gcs.sh
-
-# Use modular file system plugins from tfio instead of the legacy implementation
-# from tensorflow.
-os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
-
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_hdfs.py
+++ b/tests/test_hdfs.py
@@ -23,6 +23,10 @@ import tensorflow as tf
 import tensorflow_io as tfio
 import pytest
 
+# Use modular file system plugins from tfio instead of the legacy implementation
+# from tensorflow.
+os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
+
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_hdfs.py
+++ b/tests/test_hdfs.py
@@ -15,6 +15,9 @@
 """Tests for HDFS file system"""
 
 import os
+# Use modular file system plugins from tfio instead of the legacy implementation
+# from tensorflow.
+os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 import sys
 import socket
 import time
@@ -22,11 +25,6 @@ import tempfile
 import tensorflow as tf
 import tensorflow_io as tfio
 import pytest
-
-# Use modular file system plugins from tfio instead of the legacy implementation
-# from tensorflow.
-os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
-
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_hdfs.py
+++ b/tests/test_hdfs.py
@@ -15,6 +15,7 @@
 """Tests for HDFS file system"""
 
 import os
+
 # Use modular file system plugins from tfio instead of the legacy implementation
 # from tensorflow.
 os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
@@ -25,6 +26,7 @@ import tempfile
 import tensorflow as tf
 import tensorflow_io as tfio
 import pytest
+
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -22,6 +22,10 @@ import tensorflow as tf
 import tensorflow_io as tfio
 import pytest
 
+# Use modular file system plugins from tfio instead of the legacy implementation
+# from tensorflow.
+os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
+
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -15,6 +15,7 @@
 """Tests for S3 file system"""
 
 import os
+
 # Use modular file system plugins from tfio instead of the legacy implementation
 # from tensorflow.
 os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
@@ -24,6 +25,7 @@ import tempfile
 import tensorflow as tf
 import tensorflow_io as tfio
 import pytest
+
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -15,17 +15,15 @@
 """Tests for S3 file system"""
 
 import os
+# Use modular file system plugins from tfio instead of the legacy implementation
+# from tensorflow.
+os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 import sys
 import time
 import tempfile
 import tensorflow as tf
 import tensorflow_io as tfio
 import pytest
-
-# Use modular file system plugins from tfio instead of the legacy implementation
-# from tensorflow.
-os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
-
 
 @pytest.mark.skipif(
     sys.platform in ("win32", "darwin"),


### PR DESCRIPTION
This change is a result of https://github.com/tensorflow/tensorflow/commit/aa35d4755409474f6619c68af1bfca168db24518 and https://github.com/tensorflow/tensorflow/commit/f8aee66b8c227da41273a8d3cef558d9dcf431de
The former approach requires the users to install `tensorflow-io` on a priority basis to continue normal operations and set `TF_ENABLE_LEGACY_FILESYSTEM` env var to use TensorFlow's legacy implementation. Thus, to ensure backwards compatibility, we are using a different env var (`TF_USE_MODULAR_FILESYSTEM`) and assume it to be unset by default. This will enable the users to load the tfio modular fs plugins only when the env var `TF_USE_MODULAR_FILESYSTEM` is set.

cc: @mihaimaruseac @yongtang @vnvo2409 
