### PR TITLE
[docker] segregate docker nightly pushes from stable pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -513,8 +513,6 @@ jobs:
           TFIO_VERSION=$(python setup.py --version)
           docker tag tfsigio/tfio:latest tfsigio/tfio:${TFIO_VERSION}
           docker push tfsigio/tfio:${TFIO_VERSION}
-          bash -x -e tools/docker/tests/dockerfile_nightly_test.sh
-          docker push tfsigio/tfio:nightly
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh
           docker push tfsigio/tfio:latest-devel
 
@@ -723,3 +721,20 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.github_tensorflow_io_nightly }}
+
+  docker-nightly:
+    name: Docker Nightly
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [linux-nightly, macos-nightly, windows-nightly]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - run: |
+          set -e -x
+          docker login --username tfsigio --password ${{ secrets.DOCKER_PASSWORD }}
+          python --version
+          bash -x -e tools/docker/tests/dockerfile_nightly_test.sh
+          docker push tfsigio/tfio:nightly


### PR DESCRIPTION
This PR separates the nightly docker image push process from the general release process. As a result, the nightly image is updated even if the CI actions fail due to flaky tests.

NOTE: Since the docker push occurs only when the PR is merged, the reasons for test failures must be addressed in the PR itself.

Addresses https://github.com/tensorflow/io/issues/1337#issuecomment-813399850 as well