### PR TITLE
Add linkstatic=True to several library Bazel config

### DIFF
--- a/tensorflow_io/core/kernels/avro/utils/BUILD
+++ b/tensorflow_io/core/kernels/avro/utils/BUILD
@@ -19,6 +19,7 @@ cc_library(
         "prefix_tree.h",
         "value_buffer.h",
     ],
+    linkstatic = True,
     deps = [
         "//tensorflow_io/core:dataset_ops",
         "@com_googlesource_code_re2//:re2",
@@ -36,6 +37,7 @@ cc_library(
         "prefix_tree.cc",
         "value_buffer.cc",
     ],
+    linkstatic = True,
     deps = [
         ":avro_utils_api",
         "@avro",

--- a/tensorflow_io/core/kernels/gsmemcachedfs/BUILD
+++ b/tensorflow_io/core/kernels/gsmemcachedfs/BUILD
@@ -11,6 +11,7 @@ cc_library(
         "memcached_dao_interface.h",
     ],
     copts = tf_io_copts(),
+    linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [
         "@libmemcached",
@@ -22,6 +23,7 @@ cc_library(
     srcs = ["memcached_file_block_cache.cc"],
     hdrs = ["memcached_file_block_cache.h"],
     copts = tf_io_copts(),
+    linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [
         ":memcached_dao_interfaces",
@@ -41,6 +43,7 @@ cc_library(
         "gce_memcached_server_list_provider.h",
     ],
     copts = tf_io_copts(),
+    linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/memory",
@@ -54,6 +57,7 @@ cc_library(
     srcs = ["memcached_file_system.cc"],
     hdrs = ["memcached_file_system.h"],
     copts = tf_io_copts(),
+    linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [
         ":gce_memcached_server_list_provider",


### PR DESCRIPTION
While checking the content of the tensorflow-io wheel, noticed that
there are several redundant .so files included:
```
  inflating: tensorflow_io/core/kernels/gsmemcachedfs/libmemcached_file_block_cache.so
  inflating: tensorflow_io/core/kernels/gsmemcachedfs/libgce_memcached_server_list_provider.so
  inflating: tensorflow_io/core/kernels/gsmemcachedfs/libmemcached_file_system.so
  inflating: tensorflow_io/core/kernels/avro/utils/libavro_utils.so
```

The reason was that linkstatic=True was not passed in bazel which caused
extra .so being built.

This PR removes those unneeded .so (they are compiled as static library instead).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>