### PR TITLE
Update to use https for http file system test also registers https file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import tensorflow as tf
 import tensorflow_io as tfio
 
 # Read the MNIST data into the IODataset.
-dataset_url = "http://storage.googleapis.com/cvdf-datasets/mnist/"
+dataset_url = "https://storage.googleapis.com/cvdf-datasets/mnist/"
 d_train = tfio.IODataset.from_mnist(
     dataset_url + "train-images-idx3-ubyte.gz",
     dataset_url + "train-labels-idx1-ubyte.gz",
@@ -60,7 +60,7 @@ model.fit(d_train, epochs=5, steps_per_epoch=200)
 
 In the above [MNIST](http://yann.lecun.com/exdb/mnist/) example, the URL's
 to access the dataset files are passed directly to the `tfio.IODataset.from_mnist` API call.
-This is due to the inherent support that `tensorflow-io` provides for the `HTTP` file system,
+This is due to the inherent support that `tensorflow-io` provides for `HTTP`/`HTTPS` file system,
 thus eliminating the need for downloading and saving datasets on a local directory.
 
 NOTE: Since `tensorflow-io` is able to detect and uncompress the MNIST dataset automatically if needed,

--- a/tensorflow_io/core/plugins/file_system_plugins.cc
+++ b/tensorflow_io/core/plugins/file_system_plugins.cc
@@ -23,24 +23,25 @@ void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
 
   info->plugin_memory_allocate = tensorflow::io::plugin_memory_allocate;
   info->plugin_memory_free = tensorflow::io::plugin_memory_free;
-  info->num_schemes = 7;
+  info->num_schemes = 8;
   info->ops = static_cast<TF_FilesystemPluginOps*>(
       tensorflow::io::plugin_memory_allocate(info->num_schemes *
                                              sizeof(info->ops[0])));
   tensorflow::io::az::ProvideFilesystemSupportFor(&info->ops[0], "az");
   tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[1], "http");
+  tensorflow::io::http::ProvideFilesystemSupportFor(&info->ops[2], "https");
   // Load plugins only when the environment variable is set
   if (load_plugin == "true" || load_plugin == "1") {
-    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfs");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfs");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "har");
-    tensorflow::io::gs::ProvideFilesystemSupportFor(&info->ops[6], "gs");
+    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[3], "s3");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "hdfs");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "viewfs");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[6], "har");
+    tensorflow::io::gs::ProvideFilesystemSupportFor(&info->ops[7], "gs");
   } else {
-    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[2], "s3e");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[3], "hdfse");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "viewfse");
-    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "hare");
-    tensorflow::io::gs::ProvideFilesystemSupportFor(&info->ops[6], "gse");
+    tensorflow::io::s3::ProvideFilesystemSupportFor(&info->ops[3], "s3e");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[4], "hdfse");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[5], "viewfse");
+    tensorflow::io::hdfs::ProvideFilesystemSupportFor(&info->ops[6], "hare");
+    tensorflow::io::gs::ProvideFilesystemSupportFor(&info->ops[7], "gse");
   }
 }

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -28,7 +28,7 @@ class HTTPFSTest(tf.test.TestCase):
         self.local_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "test_http", "LICENSE-2.0.txt"
         )
-        self.remote_filename = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        self.remote_filename = "https://www.apache.org/licenses/LICENSE-2.0.txt"
         super().__init__(methodName)
 
     def setUp(self):  # pylint: disable=invalid-name


### PR DESCRIPTION
The http test is failing as apache switched to use https for license page.

This PR makes adjustment to fix the issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>