### PR TITLE
Expose environment variable from the command line, before python process start

### DIFF
--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -1,6 +1,7 @@
 set -e
 
 export TF_AZURE_USE_DEV_STORAGE=1
+export TF_USE_MODULAR_FILESYSTEM=1
 
 run_test() {
   entry=$1

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -15,10 +15,6 @@
 """Tests for GCS file system"""
 
 import os
-
-# Use modular file system plugins from tfio instead of the legacy implementation
-# from tensorflow.
-os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 import sys
 import time
 import requests

--- a/tests/test_hdfs.py
+++ b/tests/test_hdfs.py
@@ -15,10 +15,6 @@
 """Tests for HDFS file system"""
 
 import os
-
-# Use modular file system plugins from tfio instead of the legacy implementation
-# from tensorflow.
-os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 import sys
 import socket
 import time

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -15,10 +15,6 @@
 """Tests for S3 file system"""
 
 import os
-
-# Use modular file system plugins from tfio instead of the legacy implementation
-# from tensorflow.
-os.environ["TF_USE_MODULAR_FILESYSTEM"] = "true"
 import sys
 import time
 import tempfile


### PR DESCRIPTION
The reason is that, pytest may not really populate the env before tensorflow is loaded and this is causing CI failures.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>