### PR TITLE
Enable Pulsar test on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,7 @@ jobs:
         run: |
           set -x -e
           bash -x -e .github/workflows/build.space.sh
+          bash -x -e tests/test_pulsar/pulsar_test.sh
           bash -x -e tests/test_kafka/kafka_test.sh
           bash -x -e tests/test_aws/aws_test.sh
           bash -x -e tests/test_gcloud/test_pubsub_bigtable.sh
@@ -290,7 +291,6 @@ jobs:
           bash -x -e tests/test_sql/sql_test.sh
           bash -x -e tests/test_gcloud/test_gcs.sh gcs-emulator
           bash -x -e tests/test_hdfs/hdfs_test.sh
-          echo bash -x -e tests/test_pulsar/pulsar_test.sh
       - name: Test Linux
         run: |
           set -x -e

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -25,7 +25,7 @@ default_pulsar_timeout = 5000
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32", "linux"),
+    sys.platform in ("win32",),
     reason="TODO Pulsar not setup properly on Windows/Linux yet",
 )
 def test_pulsar_simple_messages():
@@ -47,7 +47,7 @@ def test_pulsar_simple_messages():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32", "linux"),
+    sys.platform in ("win32",),
     reason="TODO Pulsar not setup properly on Windows/Linux yet",
 )
 def test_pulsar_keyed_messages():
@@ -73,7 +73,7 @@ def test_pulsar_keyed_messages():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32", "linux"),
+    sys.platform in ("win32",),
     reason="TODO Pulsar not setup properly on Windows/Linux yet",
 )
 def test_pulsar_resubscribe():
@@ -120,7 +120,7 @@ def test_pulsar_resubscribe():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32", "linux"),
+    sys.platform in ("win32",),
     reason="TODO Pulsar not setup properly on Windows/Linux yet",
 )
 def test_pulsar_invalid_arguments():
@@ -178,7 +178,7 @@ def test_pulsar_invalid_arguments():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32", "linux"),
+    sys.platform in ("win32",),
     reason="TODO Pulsar not setup properly on Windows/Linux yet",
 )
 def test_pulsar_write_simple_messages():
@@ -208,7 +208,7 @@ def test_pulsar_write_simple_messages():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32", "linux"),
+    sys.platform in ("win32",),
     reason="TODO Pulsar not setup properly on Windows/Linux yet",
 )
 def test_pulsar_write_keyed_messages():

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -25,8 +25,7 @@ default_pulsar_timeout = 5000
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows yet",
+    sys.platform in ("win32",), reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_simple_messages():
     """Test consuming simple messages from a Pulsar topic with PulsarIODataset. 
@@ -47,8 +46,7 @@ def test_pulsar_simple_messages():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows yet",
+    sys.platform in ("win32",), reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_keyed_messages():
     """Test consuming keyed messages from a Pulsar topic with PulsarIODataset
@@ -73,8 +71,7 @@ def test_pulsar_keyed_messages():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows yet",
+    sys.platform in ("win32",), reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_resubscribe():
     """Test resubscribing the same topic.
@@ -120,8 +117,7 @@ def test_pulsar_resubscribe():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows yet",
+    sys.platform in ("win32",), reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_invalid_arguments():
     """Test the invalid arguments when a PulsarIODataset is created
@@ -178,8 +174,7 @@ def test_pulsar_invalid_arguments():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows yet",
+    sys.platform in ("win32",), reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_write_simple_messages():
     """Test writing simple messages to a Pulsar topic with PulsarWriter
@@ -208,8 +203,7 @@ def test_pulsar_write_simple_messages():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows yet",
+    sys.platform in ("win32",), reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_write_keyed_messages():
     """Test writing keyed messages to a Pulsar topic with PulsarWriter

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -26,7 +26,7 @@ default_pulsar_timeout = 5000
 
 @pytest.mark.skipif(
     sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows/Linux yet",
+    reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_simple_messages():
     """Test consuming simple messages from a Pulsar topic with PulsarIODataset. 
@@ -48,7 +48,7 @@ def test_pulsar_simple_messages():
 
 @pytest.mark.skipif(
     sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows/Linux yet",
+    reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_keyed_messages():
     """Test consuming keyed messages from a Pulsar topic with PulsarIODataset
@@ -74,7 +74,7 @@ def test_pulsar_keyed_messages():
 
 @pytest.mark.skipif(
     sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows/Linux yet",
+    reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_resubscribe():
     """Test resubscribing the same topic.
@@ -121,7 +121,7 @@ def test_pulsar_resubscribe():
 
 @pytest.mark.skipif(
     sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows/Linux yet",
+    reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_invalid_arguments():
     """Test the invalid arguments when a PulsarIODataset is created
@@ -179,7 +179,7 @@ def test_pulsar_invalid_arguments():
 
 @pytest.mark.skipif(
     sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows/Linux yet",
+    reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_write_simple_messages():
     """Test writing simple messages to a Pulsar topic with PulsarWriter
@@ -209,7 +209,7 @@ def test_pulsar_write_simple_messages():
 
 @pytest.mark.skipif(
     sys.platform in ("win32",),
-    reason="TODO Pulsar not setup properly on Windows/Linux yet",
+    reason="TODO Pulsar not setup properly on Windows yet",
 )
 def test_pulsar_write_keyed_messages():
     """Test writing keyed messages to a Pulsar topic with PulsarWriter

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -43,11 +43,12 @@ for i in {1..30}; do
       break
   fi
   echo "[$i] Access namespace public/default failed: $RESPONSE, sleep for 1 second"
-  cat logs/*.log
   sleep 1
 done
 echo "Sleep for 5 seconds more to avoid flaky test"
 sleep 5
+
+cat logs/*.log
 
 echo "Creating and populating 'test' topic with sample non-keyed messages"
 bin/pulsar-client produce -m "D0,D1,D2,D3,D4,D5" test

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -43,6 +43,7 @@ for i in {1..30}; do
       break
   fi
   echo "[$i] Access namespace public/default failed: $RESPONSE, sleep for 1 second"
+  cat logs/*.log
   sleep 1
 done
 echo "Sleep for 5 seconds more to avoid flaky test"

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -32,6 +32,7 @@ echo "Disable deleting inactive topics"
 sed -i.bak 's/zookeeperServers=.*/zookeeperServers=localhost:2182/' conf/standalone.conf
 sed -i.bak "s/brokerDeleteInactiveTopicsFrequencySeconds=.*/brokerDeleteInactiveTopicsFrequencySeconds=86400/" conf/standalone.conf
 sed -i.bak 's/advertisedAddress=.*/advertisedAddress=127.0.0.1/' conf/standalone.conf
+sed -i.bak 's/bindAddress=.*/bindAddress=127.0.0.1/' conf/standalone.conf
 
 bin/pulsar-daemon start standalone
 

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -31,6 +31,7 @@ cd "apache-pulsar-${VERSION}"
 echo "Disable deleting inactive topics"
 sed -i.bak 's/zookeeperServers=.*/zookeeperServers=localhost:2182/' conf/standalone.conf
 sed -i.bak "s/brokerDeleteInactiveTopicsFrequencySeconds=.*/brokerDeleteInactiveTopicsFrequencySeconds=86400/" conf/standalone.conf
+sed -i.bak 's/advertisedAddress=.*/advertisedAddress=127.0.0.1/' conf/standalone.conf
 
 bin/pulsar-daemon start standalone
 

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -51,15 +51,15 @@ sleep 5
 cat logs/*.log
 
 echo "Creating and populating 'test' topic with sample non-keyed messages"
-bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D0,D1,D2,D3,D4,D5" test
+bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D0,D1,D2,D3,D4,D5" test
 
 echo "Creating and populating 'key-test' topic with sample keyed messages"
-bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D0" -k "K0" key-test
-bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D1" -k "K1" key-test
-bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D2" -k "K0" key-test
-bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D3" -k "K1" key-test
-bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D4" -k "K0" key-test
-bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D5" -k "K1" key-test
+bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D0" -k "K0" key-test
+bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D1" -k "K1" key-test
+bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D2" -k "K0" key-test
+bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D3" -k "K1" key-test
+bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D4" -k "K0" key-test
+bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D5" -k "K1" key-test
 
 echo "Pulsar test setup completed"
 exit 0

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -37,7 +37,7 @@ bin/pulsar-daemon start standalone
 
 echo "Waiting for Pulsar service ready or 30 seconds passed"
 for i in {1..30}; do
-  RESPONSE=$(curl --write-out '%{http_code}' --silent -o /dev/null -L http://localhost:8080/admin/v2/persistent/public/default) || true
+  RESPONSE=$(curl --write-out '%{http_code}' --silent -o /dev/null -L http://127.0.0.1:8080/admin/v2/persistent/public/default) || true
   if [[ $RESPONSE == 200 ]]; then
       echo "[$i] Access namespace public/default successfully"
       break
@@ -51,15 +51,15 @@ sleep 5
 cat logs/*.log
 
 echo "Creating and populating 'test' topic with sample non-keyed messages"
-bin/pulsar-client produce -m "D0,D1,D2,D3,D4,D5" test
+bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D0,D1,D2,D3,D4,D5" test
 
 echo "Creating and populating 'key-test' topic with sample keyed messages"
-bin/pulsar-client produce -m "D0" -k "K0" key-test
-bin/pulsar-client produce -m "D1" -k "K1" key-test
-bin/pulsar-client produce -m "D2" -k "K0" key-test
-bin/pulsar-client produce -m "D3" -k "K1" key-test
-bin/pulsar-client produce -m "D4" -k "K0" key-test
-bin/pulsar-client produce -m "D5" -k "K1" key-test
+bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D0" -k "K0" key-test
+bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D1" -k "K1" key-test
+bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D2" -k "K0" key-test
+bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D3" -k "K1" key-test
+bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D4" -k "K0" key-test
+bin/pulsar-client produce --url pulsar://127.0.0.1:6650 -m "D5" -k "K1" key-test
 
 echo "Pulsar test setup completed"
 exit 0

--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -49,8 +49,6 @@ done
 echo "Sleep for 5 seconds more to avoid flaky test"
 sleep 5
 
-cat logs/*.log
-
 echo "Creating and populating 'test' topic with sample non-keyed messages"
 bin/pulsar-client --url pulsar://127.0.0.1:6650 produce -m "D0,D1,D2,D3,D4,D5" test
 


### PR DESCRIPTION
This PR is to expose the pulsar test issue on Linux

/cc @BewareMyPower I tried  configure `advertisedAddress=127.0.0.1` in `conf/standalone.conf` (suggested in https://github.com/tensorflow/io/pull/1370#issuecomment-822151685) though the pulsar still cannot be setup on Github Actions CI. Maybe you can take a look if you get a chance?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>