### PR TITLE
bump `absl` to match `tf-2.5-rc1`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -400,11 +400,11 @@ http_archive(
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "62c27e7a633e965a2f40ff16b487c3b778eae440bab64cad83b34ef1cbe3aa93",
-    strip_prefix = "abseil-cpp-6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c",
+    sha256 = "35f22ef5cb286f09954b7cc4c85b5a3f6221c9d4df6b8c4a1e9d399555b366ee",
+    strip_prefix = "abseil-cpp-997aaf3a28308eba1b9156aa35ab7bca9688e9f6",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c.tar.gz",
-        "https://github.com/abseil/abseil-cpp/archive/6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/997aaf3a28308eba1b9156aa35ab7bca9688e9f6.tar.gz",
+        "https://github.com/abseil/abseil-cpp/archive/997aaf3a28308eba1b9156aa35ab7bca9688e9f6.tar.gz",
     ],
 )
 


### PR DESCRIPTION
- Related commit: https://github.com/tensorflow/tensorflow/commit/404f96bfaff94185b65a0a19373022354cf78cd5
- In this `absl` version, there is a `cleanup` library that we could replace some parts of `gcs` code.