### PR TITLE
add missing ---project argument during docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,7 +528,7 @@ jobs:
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           docker push tfsigio/tfio:latest
           python --version
-          TFIO_VERSION=$(python setup.py --project tensorflow-io --version)
+          TFIO_VERSION=$(python setup.py --project tensorflow-io --version | tail -1)
           docker tag tfsigio/tfio:latest tfsigio/tfio:${TFIO_VERSION}
           docker push tfsigio/tfio:${TFIO_VERSION}
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,7 +528,7 @@ jobs:
           bash -x -e tools/docker/tests/dockerfile_cpu_test.sh
           docker push tfsigio/tfio:latest
           python --version
-          TFIO_VERSION=$(python setup.py --version)
+          TFIO_VERSION=$(python setup.py --project tensorflow-io --version)
           docker tag tfsigio/tfio:latest tfsigio/tfio:${TFIO_VERSION}
           docker push tfsigio/tfio:${TFIO_VERSION}
           bash -x -e tools/docker/tests/dockerfile_devel_test.sh


### PR DESCRIPTION
This PR addresses a minor issue with capturing `tfio` version while pushing docker images to github.

```console
# python setup.py --project tensorflow-io --version
Project: tensorflow-io
Exclude: ['tests', 'tests.*', 'tensorflow_io_plugin_gs', 'tensorflow_io_plugin_gs.*']
Install Requires: ['tensorflow==2.5.0rc1', 'tensorflow-io-plugin-gs==0.18.0']
Project Rootpath: tensorflow_io
0.18.0

# python setup.py --project tensorflow-io --version | tail -1
0.18.0
```