### PR TITLE
improvements for `test_filesystem.py`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,7 +435,6 @@ jobs:
           python -m pip install google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
           (python -m pytest -s -v test_bigquery.py)
           (python -m pytest -s -v test_dicom.py)
-          (python -m pytest -s -v test_filesystem.py)
 
   release:
     name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,6 +435,7 @@ jobs:
           python -m pip install google-cloud-bigquery-storage==0.7.0 google-cloud-bigquery==1.22.0 fastavro
           (python -m pytest -s -v test_bigquery.py)
           (python -m pytest -s -v test_dicom.py)
+          (python -m pytest -s -v test_filesystem.py)
 
   release:
     name: Release

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -57,7 +57,9 @@ def reload_filesystem():
 
 # Helper to check if we should skip tests for an `uri`.
 def should_skip(uri):
-    if uri == S3_URI and sys.platform in ("win32", "darwin"):
+    if (uri == S3_URI and sys.platform in ("win32", "darwin")) or (
+        uri in (AZ_URI, AZ_DSN_URI) and sys.platform == "win32"
+    ):
         return True
     else:
         return False
@@ -221,8 +223,12 @@ def fs(request, s3_fs, az_fs, az_dsn_fs, https_fs):
             pytest.skip("TODO: `s3` emulator not setup properly on macOS/Windows yet")
         return s3_fs
     elif request.param == AZ_URI:
+        if should_skip(AZ_URI):
+            pytest.skip("TODO: `az` does not work on Windows yet")
         return az_fs
     elif request.param == AZ_DSN_URI:
+        if should_skip(AZ_DSN_URI):
+            pytest.skip("TODO: `az` does not work on Windows yet")
         return az_dsn_fs
     elif request.param == HTTPS_URI:
         return https_fs

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -203,7 +203,7 @@ def test_io_write_file(fs, patchs, monkeypatch):
     [
         (
             S3_URI,
-            # `use_multi_part_download` does not work with `seakable`.
+            # `use_multi_part_download` does not work with `seekable`.
             lambda monkeypatch: monkeypatch.setattr(
                 tf.io.gfile.GFile, "seekable", lambda _: False
             ),

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -25,11 +25,6 @@ import tensorflow as tf
 import tensorflow_io as tfio  # pylint: disable=unused-import
 from azure.storage.blob import ContainerClient
 
-pytestmark = pytest.mark.skipif(
-    sys.platform in ("win32", "darwin"),
-    reason="TODO emulator not setup properly on macOS/Windows yet",
-)
-
 ROOT_PREFIX = f"tf-io-root-{int(time.time())}/"
 S3_URI = "s3"
 AZ_URI = "az"
@@ -154,6 +149,8 @@ def az_fs():
 @pytest.fixture
 def fs(request, s3_fs, az_fs):
     if request.param == S3_URI:
+        if sys.platform in ("win32", "darwin"):
+            pytest.skip("TODO: `s3` emulator not setup properly on macOS/Windows yet")
         return s3_fs
     elif request.param == AZ_URI:
         return az_fs

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -94,7 +94,7 @@ def s3_fs():
             path += "/"
         write(path, b"")
 
-    yield S3_URI, path_to, read, write, mkdirs, posixpath.join
+    yield S3_URI, path_to, read, write, mkdirs, posixpath.join, (client, bucket_name)
     monkeypatch.undo()
 
 
@@ -142,7 +142,11 @@ def az_fs():
     def mkdirs(_):
         pass
 
-    yield AZ_URI, path_to, read, write, mkdirs, posixpath.join
+    yield AZ_URI, path_to, read, write, mkdirs, posixpath.join, (
+        client,
+        container_name,
+        account,
+    )
     monkeypatch.undo()
 
 
@@ -160,7 +164,7 @@ def fs(request, s3_fs, az_fs):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_init(fs, patchs, monkeypatch):
-    _, path_to, _, _, _, _ = fs
+    _, path_to, _, _, _, _, _ = fs
     mock_patchs(monkeypatch, patchs)
     assert tf.io.gfile.exists(path_to("")) is True
 
@@ -169,7 +173,7 @@ def test_init(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_io_read_file(fs, patchs, monkeypatch):
-    _, path_to, _, write, _, _ = fs
+    _, path_to, _, write, _, _, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     fname = path_to("test_io_read_file")
@@ -183,7 +187,7 @@ def test_io_read_file(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_io_write_file(fs, patchs, monkeypatch):
-    _, path_to, read, _, _, _ = fs
+    _, path_to, read, _, _, _, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     fname = path_to("test_io_write_file")
@@ -210,7 +214,7 @@ def test_io_write_file(fs, patchs, monkeypatch):
     indirect=["fs"],
 )
 def test_gfile_GFile_readable(fs, patchs, monkeypatch):
-    uri, path_to, _, write, _, _ = fs
+    uri, path_to, _, write, _, _, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     fname = path_to("test_gfile_GFile_readable")
@@ -274,7 +278,7 @@ def test_gfile_GFile_readable(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_gfile_GFile_writable(fs, patchs, monkeypatch):
-    uri, path_to, read, _, _, _ = fs
+    uri, path_to, read, _, _, _, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     fname = path_to("test_gfile_GFile_writable")
@@ -303,7 +307,7 @@ def test_gfile_GFile_writable(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_gfile_isdir(fs, patchs, monkeypatch):
-    _, path_to, _, write, mkdirs, join = fs
+    _, path_to, _, write, mkdirs, join, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     root_path = "test_gfile_isdir"
@@ -321,7 +325,7 @@ def test_gfile_isdir(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_gfile_listdir(fs, patchs, monkeypatch):
-    _, path_to, _, write, mkdirs, join = fs
+    _, path_to, _, write, mkdirs, join, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     root_path = "test_gfile_listdir"
@@ -347,7 +351,7 @@ def test_gfile_listdir(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_gfile_makedirs(fs, patchs, monkeypatch):
-    _, path_to, _, write, _, join = fs
+    _, path_to, _, write, _, join, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     root_path = "test_gfile_makedirs/"
@@ -365,7 +369,7 @@ def test_gfile_makedirs(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_gfile_rmtree(fs, patchs, monkeypatch):
-    _, path_to, _, write, mkdirs, join = fs
+    _, path_to, _, write, mkdirs, join, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     num_entries = 3
@@ -387,7 +391,7 @@ def test_gfile_rmtree(fs, patchs, monkeypatch):
 # TODO(vnvo2409): `az` copy operations causes an infinite loop.
 @pytest.mark.parametrize("fs, patchs", [(S3_URI, None)], indirect=["fs"])
 def test_gfile_copy(fs, patchs, monkeypatch):
-    _, path_to, read, write, _, _ = fs
+    _, path_to, read, write, _, _, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     src = path_to("test_gfile_copy_src")
@@ -413,7 +417,7 @@ def test_gfile_copy(fs, patchs, monkeypatch):
     "fs, patchs", [(S3_URI, None), (AZ_URI, None)], indirect=["fs"]
 )
 def test_gfile_glob(fs, patchs, monkeypatch):
-    _, path_to, _, write, _, join = fs
+    _, path_to, _, write, _, join, _ = fs
     mock_patchs(monkeypatch, patchs)
 
     dname = path_to("test_gfile_glob/")


### PR DESCRIPTION
> I remember there might be an issue where az is only available through kernel ops, or through gfile types of APIs but not available to both at the same time.

It is accessible through kernel ops but it didn't work correctly so I disable `az` on `win32` for now. I thought that https://github.com/tensorflow/tensorflow/pull/43594 should solve it, could you check it again ?

398dc7e is an example for showing how flexible these tests could be.

@yongtang could you take a look ?