### PR TITLE
Remove llvm toolchain and add -Wno-error=implicit-function-declaration

### DIFF
--- a/third_party/hdf5.BUILD
+++ b/third_party/hdf5.BUILD
@@ -25,7 +25,9 @@ cc_library(
         "@bazel_tools//src/conditions:windows": [
             "/Zc:preprocessor-",
         ],
-        "//conditions:default": [],
+        "//conditions:default": [
+            "-Wno-error=implicit-function-declaration",
+        ],
     }),
     includes = [
         "c++/src",

--- a/third_party/kafka.BUILD
+++ b/third_party/kafka.BUILD
@@ -50,6 +50,12 @@ cc_library(
         "src/rdxxhash.c",
         "src/rdxxhash.h",
     ],
+    copts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wno-error=implicit-function-declaration",
+        ],
+    }),
     defines = [
         "LIBRDKAFKA_STATICLIB",
         "WIN32_LEAN_AND_MEAN",

--- a/third_party/libmongoc.BUILD
+++ b/third_party/libmongoc.BUILD
@@ -40,7 +40,12 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    copts = [],
+    copts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wno-error=implicit-function-declaration",
+        ],
+    }),
     defines = [
         "MONGOC_COMPILATION",
         "BSON_COMPILATION",

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -114,8 +114,6 @@ def write_config():
                     bazel_rc.write('build --action_env TF_CUDNN_VERSION="7"\n')
             # Enable platform specific config
             bazel_rc.write('build --enable_platform_specific_config\n')
-            # Use llvm toolchain
-            bazel_rc.write('build:macos --crosstool_top=@llvm_toolchain//:toolchain"\n')
             # Needed for GRPC build
             bazel_rc.write('build:macos --copt="-DGRPC_BAZEL_BUILD"\n')
             # Stay with 10.14 for macOS


### PR DESCRIPTION
Since upgrading to XCode 12.5 I had encountered some issues with isysroot path for C++ compile. This PR removes llvm toolchain to allow building the program on macOS.


This PR also add -Wno-error=implicit-function-declaration as XCode now adds -std=c99 by default for C code which caused build failure if not adjusted.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>