### PR TITLE
Add test for `hdfs` filesystem

### DIFF
--- a/tests/test_hdfs/hdfs_test.sh
+++ b/tests/test_hdfs/hdfs_test.sh
@@ -17,11 +17,10 @@
 set -e
 set -o pipefail
 
-HADOOP_VERSION=2.7.0
-docker pull sequenceiq/hadoop-docker:$HADOOP_VERSION
-docker run -d --rm -p 9000:9000 --name=tensorflow-io-hdfs sequenceiq/hadoop-docker:$HADOOP_VERSION
-echo "Waiting for 30 secs until hadoop is up and running"
-sleep 30
-docker logs tensorflow-io-hdfs
+HADOOP_RELEASE_TAG="3.2.1"
+curl -OL https://github.com/big-data-europe/docker-hadoop/archive/refs/tags/$HADOOP_RELEASE_TAG.tar.gz
+tar -xzf $HADOOP_RELEASE_TAG.tar.gz -C /tmp/
+cd /tmp/docker-hadoop-$HADOOP_RELEASE_TAG
+docker-compose up -d
 echo "Hadoop up"
 exit 0


### PR DESCRIPTION
This PR added test for `hdfs`. `har` and `viewfs` requires sepecial setup and I am still thinking how to test it

I also changed the emulator because https://github.com/sequenceiq/hadoop-docker was marked as obsoleted and https://github.com/big-data-europe/docker-hadoop infra is closer to production. Failed tests related to https://github.com/tensorflow/io/pull/1401

---

@kvignesh1420 I want to benchmark the filesystem but they are falling because of missing `gs`. Do you know why ?