### PR TITLE
Revert "switch to `Aws::S3::Model::ListObjectsV2Request` (#1384)"

### DIFF
--- a/tensorflow_io/core/plugins/s3/BUILD
+++ b/tensorflow_io/core/plugins/s3/BUILD
@@ -10,6 +10,8 @@ load(
 cc_library(
     name = "s3",
     srcs = [
+        "aws_crypto.cc",
+        "aws_crypto.h",
         "aws_logging.cc",
         "aws_logging.h",
         "s3_filesystem.cc",

--- a/tensorflow_io/core/plugins/s3/aws_crypto.cc
+++ b/tensorflow_io/core/plugins/s3/aws_crypto.cc
@@ -1,0 +1,142 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow_io/core/plugins/s3/aws_crypto.h"
+
+#include <aws/core/utils/crypto/HashResult.h>
+#include <aws/s3/S3Client.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+
+namespace tensorflow {
+namespace io {
+namespace s3 {
+namespace tf_s3_filesystem {
+
+namespace {
+class AWSSha256HMACOpenSSLImpl : public Aws::Utils::Crypto::HMAC {
+ public:
+  AWSSha256HMACOpenSSLImpl() {}
+
+  virtual ~AWSSha256HMACOpenSSLImpl() = default;
+
+  Aws::Utils::Crypto::HashResult Calculate(
+      const Aws::Utils::ByteBuffer& toSign,
+      const Aws::Utils::ByteBuffer& secret) override {
+    unsigned int length = SHA256_DIGEST_LENGTH;
+    Aws::Utils::ByteBuffer digest(length);
+    memset(digest.GetUnderlyingData(), 0, length);
+
+    HMAC_CTX ctx;
+    HMAC_CTX_init(&ctx);
+
+    HMAC_Init_ex(&ctx, secret.GetUnderlyingData(),
+                 static_cast<int>(secret.GetLength()), EVP_sha256(), NULL);
+    HMAC_Update(&ctx, toSign.GetUnderlyingData(), toSign.GetLength());
+    HMAC_Final(&ctx, digest.GetUnderlyingData(), &length);
+    HMAC_CTX_cleanup(&ctx);
+
+    return Aws::Utils::Crypto::HashResult(std::move(digest));
+  }
+};
+
+class AWSSha256OpenSSLImpl : public Aws::Utils::Crypto::Hash {
+ public:
+  AWSSha256OpenSSLImpl() {}
+
+  virtual ~AWSSha256OpenSSLImpl() = default;
+
+  Aws::Utils::Crypto::HashResult Calculate(const Aws::String& str) override {
+    SHA256_CTX sha256;
+    SHA256_Init(&sha256);
+    SHA256_Update(&sha256, str.data(), str.size());
+
+    Aws::Utils::ByteBuffer hash(SHA256_DIGEST_LENGTH);
+    SHA256_Final(hash.GetUnderlyingData(), &sha256);
+
+    return Aws::Utils::Crypto::HashResult(std::move(hash));
+  }
+
+  Aws::Utils::Crypto::HashResult Calculate(Aws::IStream& stream) override {
+    SHA256_CTX sha256;
+    SHA256_Init(&sha256);
+
+    auto currentPos = stream.tellg();
+    if (currentPos == std::streampos(std::streamoff(-1))) {
+      currentPos = 0;
+      stream.clear();
+    }
+
+    stream.seekg(0, stream.beg);
+
+    char streamBuffer
+        [Aws::Utils::Crypto::Hash::INTERNAL_HASH_STREAM_BUFFER_SIZE];
+    while (stream.good()) {
+      stream.read(streamBuffer,
+                  Aws::Utils::Crypto::Hash::INTERNAL_HASH_STREAM_BUFFER_SIZE);
+      auto bytesRead = stream.gcount();
+
+      if (bytesRead > 0) {
+        SHA256_Update(&sha256, streamBuffer, static_cast<size_t>(bytesRead));
+      }
+    }
+
+    stream.clear();
+    stream.seekg(currentPos, stream.beg);
+
+    Aws::Utils::ByteBuffer hash(SHA256_DIGEST_LENGTH);
+    SHA256_Final(hash.GetUnderlyingData(), &sha256);
+
+    return Aws::Utils::Crypto::HashResult(std::move(hash));
+  }
+};
+
+class AWSSecureRandomBytesImpl : public Aws::Utils::Crypto::SecureRandomBytes {
+ public:
+  AWSSecureRandomBytesImpl() {}
+  virtual ~AWSSecureRandomBytesImpl() = default;
+  void GetBytes(unsigned char* buffer, size_t bufferSize) override {
+    assert(buffer);
+    int success = RAND_bytes(buffer, static_cast<int>(bufferSize));
+    if (success != 1) {
+      m_failure = true;
+    }
+  }
+
+ private:
+  bool m_failure;
+};
+
+}  // namespace
+
+std::shared_ptr<Aws::Utils::Crypto::Hash>
+AWSSHA256Factory::CreateImplementation() const {
+  return Aws::MakeShared<AWSSha256OpenSSLImpl>(AWSCryptoAllocationTag);
+}
+
+std::shared_ptr<Aws::Utils::Crypto::HMAC>
+AWSSHA256HmacFactory::CreateImplementation() const {
+  return Aws::MakeShared<AWSSha256HMACOpenSSLImpl>(AWSCryptoAllocationTag);
+}
+
+std::shared_ptr<Aws::Utils::Crypto::SecureRandomBytes>
+AWSSecureRandomFactory::CreateImplementation() const {
+  return Aws::MakeShared<AWSSecureRandomBytesImpl>(AWSCryptoAllocationTag);
+}
+
+}  // namespace tf_s3_filesystem
+}  // namespace s3
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow_io/core/plugins/s3/aws_crypto.h
+++ b/tensorflow_io/core/plugins/s3/aws_crypto.h
@@ -1,0 +1,53 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_AWS_CRYPTO_H_
+#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_AWS_CRYPTO_H_
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/crypto/Factories.h>
+#include <aws/core/utils/crypto/HMAC.h>
+#include <aws/core/utils/crypto/Hash.h>
+#include <aws/core/utils/crypto/SecureRandom.h>
+
+namespace tensorflow {
+namespace io {
+namespace s3 {
+namespace tf_s3_filesystem {
+constexpr char AWSCryptoAllocationTag[] = "AWSCryptoAllocation";
+
+class AWSSHA256Factory : public Aws::Utils::Crypto::HashFactory {
+ public:
+  std::shared_ptr<Aws::Utils::Crypto::Hash> CreateImplementation()
+      const override;
+};
+
+class AWSSHA256HmacFactory : public Aws::Utils::Crypto::HMACFactory {
+ public:
+  std::shared_ptr<Aws::Utils::Crypto::HMAC> CreateImplementation()
+      const override;
+};
+
+class AWSSecureRandomFactory : public Aws::Utils::Crypto::SecureRandomFactory {
+ public:
+  std::shared_ptr<Aws::Utils::Crypto::SecureRandomBytes> CreateImplementation()
+      const override;
+};
+
+}  // namespace tf_s3_filesystem
+}  // namespace s3
+}  // namespace io
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_AWS_CRYPTO_H_

--- a/tensorflow_io/core/plugins/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/plugins/s3/s3_filesystem.cc
@@ -39,6 +39,7 @@ limitations under the License.
 #include "tensorflow/c/logging.h"
 #include "tensorflow/c/tf_status.h"
 #include "tensorflow_io/core/plugins/file_system_plugins.h"
+#include "tensorflow_io/core/plugins/s3/aws_crypto.h"
 #include "tensorflow_io/core/plugins/s3/aws_logging.h"
 
 namespace tensorflow {
@@ -192,6 +193,18 @@ static void GetS3Client(tf_s3_filesystem::S3File* s3_file) {
     tf_s3_filesystem::AWSLogSystem::InitializeAWSLogging();
 
     Aws::SDKOptions options;
+    options.cryptoOptions.sha256Factory_create_fn = []() {
+      return Aws::MakeShared<tf_s3_filesystem::AWSSHA256Factory>(
+          tf_s3_filesystem::AWSCryptoAllocationTag);
+    };
+    options.cryptoOptions.sha256HMACFactory_create_fn = []() {
+      return Aws::MakeShared<tf_s3_filesystem::AWSSHA256HmacFactory>(
+          tf_s3_filesystem::AWSCryptoAllocationTag);
+    };
+    options.cryptoOptions.secureRandomFactory_create_fn = []() {
+      return Aws::MakeShared<tf_s3_filesystem::AWSSecureRandomFactory>(
+          tf_s3_filesystem::AWSCryptoAllocationTag);
+    };
     Aws::InitAPI(options);
 
     // The creation of S3Client disables virtual addressing:
@@ -205,7 +218,7 @@ static void GetS3Client(tf_s3_filesystem::S3File* s3_file) {
         Aws::New<Aws::S3::S3Client>(
             kS3ClientAllocationTag, GetDefaultClientConfig(),
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false),
-        [options](Aws::S3::S3Client* s3_client) {
+        [&options](Aws::S3::S3Client* s3_client) {
           if (s3_client != nullptr) {
             Aws::Delete(s3_client);
             Aws::ShutdownAPI(options);

--- a/tensorflow_io/core/plugins/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/plugins/s3/s3_filesystem.cc
@@ -28,7 +28,7 @@ limitations under the License.
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/HeadBucketRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
-#include <aws/s3/model/ListObjectsV2Request.h>
+#include <aws/s3/model/ListObjectsRequest.h>
 #include <aws/s3/model/UploadPartCopyRequest.h>
 #include <stdlib.h>
 #include <string.h>
@@ -665,12 +665,12 @@ void Stat(const TF_Filesystem* filesystem, const char* path,
   if (prefix.back() != '/') {
     prefix.push_back('/');
   }
-  Aws::S3::Model::ListObjectsV2Request list_objects_request;
+  Aws::S3::Model::ListObjectsRequest list_objects_request;
   list_objects_request.WithBucket(bucket).WithPrefix(prefix).WithMaxKeys(1);
   list_objects_request.SetResponseStreamFactory(
       []() { return Aws::New<Aws::StringStream>(kS3FileSystemAllocationTag); });
   auto list_objects_outcome =
-      s3_file->s3_client->ListObjectsV2(list_objects_request);
+      s3_file->s3_client->ListObjects(list_objects_request);
   if (list_objects_outcome.IsSuccess()) {
     auto objects = list_objects_outcome.GetResult().GetContents();
     if (objects.size() > 0) {
@@ -1061,12 +1061,12 @@ void DeleteDir(const TF_Filesystem* filesystem, const char* path,
   GetS3Client(s3_file);
 
   if (object.back() != '/') object.push_back('/');
-  Aws::S3::Model::ListObjectsV2Request list_objects_request;
+  Aws::S3::Model::ListObjectsRequest list_objects_request;
   list_objects_request.WithBucket(bucket).WithPrefix(object).WithMaxKeys(2);
   list_objects_request.SetResponseStreamFactory(
       []() { return Aws::New<Aws::StringStream>(kS3FileSystemAllocationTag); });
   auto list_objects_outcome =
-      s3_file->s3_client->ListObjectsV2(list_objects_request);
+      s3_file->s3_client->ListObjects(list_objects_request);
   if (list_objects_outcome.IsSuccess()) {
     auto contents = list_objects_outcome.GetResult().GetContents();
     if (contents.size() > 1 ||
@@ -1112,17 +1112,17 @@ void RenameFile(const TF_Filesystem* filesystem, const char* src,
   }
 
   Aws::S3::Model::DeleteObjectRequest delete_object_request;
-  Aws::S3::Model::ListObjectsV2Request list_objects_request;
+  Aws::S3::Model::ListObjectsRequest list_objects_request;
   list_objects_request.WithBucket(bucket_src)
       .WithPrefix(object_src)
       .WithMaxKeys(kS3GetChildrenMaxKeys);
   list_objects_request.SetResponseStreamFactory(
       []() { return Aws::New<Aws::StringStream>(kS3FileSystemAllocationTag); });
 
-  Aws::S3::Model::ListObjectsV2Result list_objects_result;
+  Aws::S3::Model::ListObjectsResult list_objects_result;
   do {
     auto list_objects_outcome =
-        s3_file->s3_client->ListObjectsV2(list_objects_request);
+        s3_file->s3_client->ListObjects(list_objects_request);
     if (!list_objects_outcome.IsSuccess())
       return TF_SetStatusFromAWSError(list_objects_outcome.GetError(), status);
 
@@ -1142,8 +1142,7 @@ void RenameFile(const TF_Filesystem* filesystem, const char* src,
         return TF_SetStatusFromAWSError(delete_object_outcome.GetError(),
                                         status);
     }
-    list_objects_request.SetContinuationToken(
-        list_objects_result.GetNextContinuationToken());
+    list_objects_request.SetMarker(list_objects_result.GetNextMarker());
   } while (list_objects_result.GetIsTruncated());
   TF_SetStatus(status, TF_OK, "");
 }
@@ -1159,7 +1158,7 @@ int GetChildren(const TF_Filesystem* filesystem, const char* path,
   auto s3_file = static_cast<S3File*>(filesystem->plugin_filesystem);
   GetS3Client(s3_file);
 
-  Aws::S3::Model::ListObjectsV2Request list_objects_request;
+  Aws::S3::Model::ListObjectsRequest list_objects_request;
   list_objects_request.WithBucket(bucket)
       .WithPrefix(prefix)
       .WithMaxKeys(kS3GetChildrenMaxKeys)
@@ -1167,11 +1166,11 @@ int GetChildren(const TF_Filesystem* filesystem, const char* path,
   list_objects_request.SetResponseStreamFactory(
       []() { return Aws::New<Aws::StringStream>(kS3FileSystemAllocationTag); });
 
-  Aws::S3::Model::ListObjectsV2Result list_objects_result;
+  Aws::S3::Model::ListObjectsResult list_objects_result;
   std::vector<Aws::String> result;
   do {
     auto list_objects_outcome =
-        s3_file->s3_client->ListObjectsV2(list_objects_request);
+        s3_file->s3_client->ListObjects(list_objects_request);
     if (!list_objects_outcome.IsSuccess()) {
       TF_SetStatusFromAWSError(list_objects_outcome.GetError(), status);
       return -1;
@@ -1193,8 +1192,7 @@ int GetChildren(const TF_Filesystem* filesystem, const char* path,
         result.push_back(entry);
       }
     }
-    list_objects_request.SetContinuationToken(
-        list_objects_result.GetNextContinuationToken());
+    list_objects_result.SetMarker(list_objects_result.GetNextMarker());
   } while (list_objects_result.GetIsTruncated());
 
   int num_entries = result.size();


### PR DESCRIPTION
We have been seeing CI failures where segmentation faults are being thrown out randomly. Several attempts have been made to resolve the issue though as the seg fault does not happen all the time, it has been hard to track down to which commit was the issue.

I have been trying to bisect the past commits, and run GitHub Actions multiple times for the past couple of days on my repo. (See branch build with name `fix`|`fix2`...`fix6`|`fix8`):
https://github.com/yongtang/io/actions


The issue points to d08b554f1d4ab5cebd93829b5431383670774c75 (or in combination of 63259e7b5ee7e3f935a7ad6852e7ab8897271821).

Not exactly sure why this is causing the issue. Though I think we want to revert the commit first as TF 2.5.0 (and our tensorflow-io 0.18.0 release is imminent).

In order to avoid false negative, I will trigger CI build multiple times to make sure this is the true fix.

This PR reverts the commit.
/cc @vnvo2409 FYI

This reverts commit d08b554f1d4ab5cebd93829b5431383670774c75.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>