### PR TITLE
bump TF to 2.5.0rc3 for api compatibility and benchmark checks

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.5.0rc1:tensorflow-io-nightly', 'tf-nightly:tensorflow-io', 'tf-nightly:tensorflow-io-nightly']
+        version: ['tensorflow==2.5.0rc3:tensorflow-io-nightly', 'tf-nightly:tensorflow-io', 'tf-nightly:tensorflow-io-nightly']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.5.0rc1:tensorflow-io-nightly', 'tf-nightly:tensorflow-io', 'tf-nightly:tensorflow-io-nightly']
+        version: ['tensorflow==2.5.0rc3:tensorflow-io-nightly', 'tf-nightly:tensorflow-io', 'tf-nightly:tensorflow-io-nightly']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.5.0rc1:tensorflow-io-nightly', 'tf-nightly:tensorflow-io', 'tf-nightly:tensorflow-io-nightly']
+        version: ['tensorflow==2.5.0rc3:tensorflow-io-nightly', 'tf-nightly:tensorflow-io', 'tf-nightly:tensorflow-io-nightly']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.5.0rc1:tensorflow-io-nightly', 'tensorflow==2.5.0rc1:tensorflow-io']
+        version: ['tensorflow==2.5.0rc3:tensorflow-io-nightly', 'tensorflow==2.5.0rc3:tensorflow-io']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.8']
-        version: ['tensorflow==2.5.0rc1:tensorflow-io-nightly', 'tensorflow==2.5.0rc1:tensorflow-io']
+        version: ['tensorflow==2.5.0rc3:tensorflow-io-nightly', 'tensorflow==2.5.0rc3:tensorflow-io']
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This PR bumps the TensorFlow version from 2.5.0rc1 to 2.5.0rc3 for API compatibility and benchmarking workflows.