### PR TITLE
Re-Update arrow to 4.0.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -272,11 +272,11 @@ http_archive(
         """sed -i.bak 's/type_traits/std::max<int16_t>(sizeof(int16_t), type_traits/g' cpp/src/parquet/column_reader.cc""",
         """sed -i.bak 's/value_byte_size/value_byte_size)/g' cpp/src/parquet/column_reader.cc""",
     ],
-    sha256 = "fc461c4f0a60e7470a7c58b28e9344aa8fb0be5cc982e9658970217e084c3a82",
-    strip_prefix = "arrow-apache-arrow-3.0.0",
+    sha256 = "a27971e2a71c412ae43d998b7b6d06201c7a3da382c804dcdc4a8126ccbabe67",
+    strip_prefix = "arrow-apache-arrow-4.0.0",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/apache/arrow/archive/apache-arrow-3.0.0.tar.gz",
-        "https://github.com/apache/arrow/archive/apache-arrow-3.0.0.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/apache/arrow/archive/apache-arrow-4.0.0.tar.gz",
+        "https://github.com/apache/arrow/archive/apache-arrow-4.0.0.tar.gz",
     ],
 )
 
@@ -1133,5 +1133,15 @@ http_archive(
     strip_prefix = "orc-rel-release-1.6.7",
     urls = [
         "https://github.com/apache/orc/archive/refs/tags/rel/release-1.6.7.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "xsimd",
+    build_file = "//third_party:xsimd.BUILD",
+    sha256 = "45337317c7f238fe0d64bb5d5418d264a427efc53400ddf8e6a964b6bcb31ce9",
+    strip_prefix = "xsimd-7.5.0",
+    urls = [
+        "https://github.com/xtensor-stack/xsimd/archive/refs/tags/7.5.0.tar.gz",
     ],
 )

--- a/tensorflow_io/core/kernels/csv_kernels.cc
+++ b/tensorflow_io/core/kernels/csv_kernels.cc
@@ -45,8 +45,8 @@ class CSVReadable : public IOReadableInterface {
     csv_file_.reset(new ArrowRandomAccessFile(file_.get(), file_size_));
 
     auto result = ::arrow::csv::TableReader::Make(
-        ::arrow::default_memory_pool(), csv_file_,
-        ::arrow::csv::ReadOptions::Defaults(),
+        ::arrow::default_memory_pool(), ::arrow::io::default_io_context(),
+        csv_file_, ::arrow::csv::ReadOptions::Defaults(),
         ::arrow::csv::ParseOptions::Defaults(),
         ::arrow::csv::ConvertOptions::Defaults());
     if (!result.status().ok()) {

--- a/third_party/arrow.BUILD
+++ b/third_party/arrow.BUILD
@@ -120,6 +120,7 @@ cc_library(
         "@rapidjson",
         "@snappy",
         "@thrift",
+        "@xsimd",
         "@zlib",
         "@zstd",
     ],

--- a/third_party/xsimd.BUILD
+++ b/third_party/xsimd.BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD 3-Clause
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "xsimd",
+    srcs = [],
+    hdrs = glob(
+        [
+            "include/xsimd/*.hpp",
+            "include/xsimd/config/*.hpp",
+            "include/xsimd/math/*.hpp",
+            "include/xsimd/memory/*.hpp",
+            "include/xsimd/stl/*.hpp",
+            "include/xsimd/types/*.hpp",
+        ],
+        exclude = [
+        ],
+    ),
+    copts = [],
+    defines = [],
+    includes = [
+        "include",
+    ],
+    linkopts = [],
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)


### PR DESCRIPTION
Arrow was upgraded to 4.0.0 in PR #1397, though it had been reverted in PR #1399. It looks like arrow is not the source of segmentation fault we encountered. So this PR re-update arrow to 4.0.0

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>