### PR TITLE
Use stub .so/.dylib for FFmpeg linkage and re-enable macOS FFmpeg test

### DIFF
--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -44,7 +44,6 @@ if [[ $(uname) == "Linux" ]]; then
   export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
   export
 elif [[ $(uname) == "Darwin" ]]; then
-  echo "TODO: !!!pytest-xdist!!!"
-  echo brew install ffmpeg
+  brew install ffmpeg
 fi
 run_test $PYTHON_VERSION

--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -14,62 +14,30 @@
 # ==============================================================================
 """Dataset."""
 
-import ctypes
-import _ctypes
-import sys
+import warnings
 
 from tensorflow_io.core.python.ops import _load_library
 
 
-def _load_dependency_and_library(p):
+def _load_libraries(p):
     """load_dependency_and_library"""
     for library in p:
-        # First try load all dependencies with RTLD_LOCAL
-        entries = []
-        for dependency in p[library]:
-            try:
-                entries.append(ctypes.CDLL(dependency))
-            except OSError:
-                pass
-        if len(entries) == len(p[library]):
-            # Dependencies has been satisfied, load dependencies again with RTLD_GLOBAL, no error is expected
-            for dependency in p[library]:
-                ctypes.CDLL(dependency, mode=ctypes.RTLD_GLOBAL)
-            # Load video_op
+        try:
             v = _load_library(library)
-            l = _load_library(library, "dependency")
-            return v, l
-        # Otherwise we dlclose and retry
-        entries.reverse()
-        for entry in entries:
-            _ctypes.dlclose(entry._handle)  # pylint: disable=protected-access
+            if v is not None:
+                return v
+        except NotImplementedError as e:
+            warnings.warn("could not load {}: {}".format(p, e))
+        NotImplementedError
     raise NotImplementedError("could not find ffmpeg after search through ", p)
 
 
-def _shared_object(name, version):
-    if sys.platform == "darwin":
-        return "lib{}.{}.dylib".format(name, version)
-    return "lib{}.so.{}".format(name, version)
-
-
-_ffmpeg_ops, _decode_ops = _load_dependency_and_library(
-    {
-        "libtensorflow_io_ffmpeg_4.2.so": [
-            _shared_object("avformat", "58"),
-            _shared_object("swscale", "5"),
-        ],
-        "libtensorflow_io_ffmpeg_3.4.so": [
-            _shared_object("avformat", "57"),
-            _shared_object("avutil", "55"),
-            _shared_object("swscale", "4"),
-        ],
-        "libtensorflow_io_ffmpeg_2.8.so": [
-            _shared_object("avformat-ffmpeg", "56"),
-            _shared_object("avcodec-ffmpeg", "56"),
-            _shared_object("avutil-ffmpeg", "54"),
-            _shared_object("swscale-ffmpeg", "3"),
-        ],
-    }
+_ffmpeg_ops = _load_libraries(
+    [
+        "libtensorflow_io_ffmpeg_4.2.so",
+        "libtensorflow_io_ffmpeg_3.4.so",
+        "libtensorflow_io_ffmpeg_2.8.so",
+    ]
 )
 
 io_ffmpeg_readable_init = _ffmpeg_ops.io_ffmpeg_readable_init

--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -27,7 +27,7 @@ def _load_libraries(p):
             if v is not None:
                 return v
         except NotImplementedError as e:
-            warnings.warn("could not load {}: {}".format(p, e))
+            warnings.warn("could not load {}: {}".format(library, e))
         NotImplementedError
     raise NotImplementedError("could not find ffmpeg after search through ", p)
 

--- a/tensorflow_io/core/python/ops/ffmpeg_ops.py
+++ b/tensorflow_io/core/python/ops/ffmpeg_ops.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Dataset."""
 
+import sys
 import warnings
 
 from tensorflow_io.core.python.ops import _load_library
@@ -24,15 +25,27 @@ def _load_libraries(p):
     for library in p:
         try:
             v = _load_library(library)
+            # Only Linux utilize the library for
+            # EncodeAACFunctionFiniFFmpeg
+            # EncodeAACFunctionInitFFmpeg
+            # EncodeAACFunctionCallFFmpeg
+            # DecodeAACFunctionFiniFFmpeg
+            # DecodeAACFunctionInitFFmpeg
+            # DecodeAACFunctionCallFFmpeg
+            l = (
+                _load_library(library, "dependency")
+                if sys.platform == "linux"
+                else None
+            )
             if v is not None:
-                return v
+                return v, l
         except NotImplementedError as e:
             warnings.warn("could not load {}: {}".format(library, e))
         NotImplementedError
     raise NotImplementedError("could not find ffmpeg after search through ", p)
 
 
-_ffmpeg_ops = _load_libraries(
+_ffmpeg_ops, _decode_ops = _load_libraries(
     [
         "libtensorflow_io_ffmpeg_4.2.so",
         "libtensorflow_io_ffmpeg_3.4.so",

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -61,12 +61,7 @@ def fixture_audio_data_24():
     [
         pytest.param(
             lambda f: tfio.IOTensor.from_ffmpeg(f)("a:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!!"
-                ),
-                pytest.mark.xfail(reason="does not support 24 bit yet"),
-            ],
+            marks=[pytest.mark.xfail(reason="does not support 24 bit yet")],
         ),
     ],
     ids=["from_ffmpeg"],
@@ -94,12 +89,7 @@ def test_audio_io_tensor_24(audio_data_24, io_tensor_func):
     [
         pytest.param(
             lambda f: tfio.IODataset.from_ffmpeg(f, "a:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!!"
-                ),
-                pytest.mark.xfail(reason="does not support 24 bit yet"),
-            ],
+            marks=[pytest.mark.xfail(reason="does not support 24 bit yet")],
         ),
     ],
     ids=["from_ffmpeg"],
@@ -133,12 +123,7 @@ def test_audio_io_dataset_24(audio_data_24, io_dataset_func):
     [
         pytest.param(
             lambda f: tfio.IOTensor.from_ffmpeg(f)("a:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!!"
-                ),
-                pytest.mark.xfail(reason="shape does not work correctly yet"),
-            ],
+            marks=[pytest.mark.xfail(reason="shape does not work correctly yet")],
         ),
     ],
     ids=["from_ffmpeg"],
@@ -164,22 +149,8 @@ def test_audio_io_tensor(audio_data, io_tensor_func):
 @pytest.mark.parametrize(
     ("io_dataset_func"),
     [
-        pytest.param(
-            lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!!"
-                ),
-            ],
-        ),
-        pytest.param(
-            lambda f: tfio.IODataset.from_ffmpeg(f, "a:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!!"
-                ),
-            ],
-        ),
+        pytest.param(lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0")),
+        pytest.param(lambda f: tfio.IODataset.from_ffmpeg(f, "a:0")),
     ],
     ids=["from_ffmpeg", "from_ffmpeg(eager)"],
 )
@@ -211,12 +182,7 @@ def test_audio_io_dataset(audio_data, io_dataset_func):
         pytest.param(
             tfio.IOTensor.from_ffmpeg,
             1,
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!!"
-                ),
-                pytest.mark.xfail(reason="does not work in graph yet"),
-            ],
+            marks=[pytest.mark.xfail(reason="does not work in graph yet")],
         ),
     ],
     ids=["from_ffmpeg"],
@@ -256,16 +222,7 @@ def test_audio_io_tensor_with_dataset(audio_data, io_tensor_func, num_parallel_c
 
 @pytest.mark.parametrize(
     ("io_dataset_func"),
-    [
-        pytest.param(
-            lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!!"
-                ),
-            ],
-        ),
-    ],
+    [pytest.param(lambda f: tfio.IODataset.graph(tf.int16).from_ffmpeg(f, "a:0")),],
     ids=["from_ffmpeg"],
 )
 def test_audio_io_dataset_with_dataset(audio_data, io_dataset_func):

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -22,19 +22,22 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_io as tfio
 
-if sys.platform == "darwin":
-    pytest.skip("TODO: !!!pytest-xdist!!!", allow_module_level=True)
 
-video_path = "file://" + os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "test_video", "small.mp4"
-)
-
-audio_path = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "test_audio", "mono_10khz.wav"
-)
+@pytest.fixture(name="video_path", scope="module")
+def fixture_video_path():
+    return "file://" + os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_video", "small.mp4"
+    )
 
 
-def test_ffmpeg_io_tensor_audio():
+@pytest.fixture(name="audio_path", scope="module")
+def fixture_audio_path():
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_audio", "mono_10khz.wav"
+    )
+
+
+def test_ffmpeg_io_tensor_audio(audio_path):
     """test_ffmpeg_io_tensor_audio"""
     audio = tfio.IOTensor.from_audio(audio_path)
     ffmpeg = tfio.IOTensor.from_ffmpeg(audio_path)
@@ -49,7 +52,7 @@ def test_ffmpeg_io_tensor_audio():
 # Disable as the mkv file is large. Run locally
 # by pulling test file while is located in:
 # https://github.com/Matroska-Org/matroska-test-files/blob/master/test_files/test5.mkv
-def _test_ffmpeg_io_tensor_mkv():
+def _test_ffmpeg_io_tensor_mkv(video_path):
     """test_ffmpeg_io_tensor_mkv"""
     mkv_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "test_video", "test5.mkv"
@@ -75,7 +78,7 @@ def _test_ffmpeg_io_tensor_mkv():
     assert video("v:0").to_tensor().shape == [166, 320, 560, 3]
 
 
-def test_ffmpeg_decode_video():
+def test_ffmpeg_decode_video(video_path):
     """test_ffmpeg_decode_video"""
     content = tf.io.read_file(video_path)
     video = tfio.experimental.ffmpeg.decode_video(content, 0)
@@ -83,7 +86,7 @@ def test_ffmpeg_decode_video():
     assert video.dtype == tf.uint8
 
 
-def test_video_predict():
+def test_video_predict(video_path):
     """test_video_predict"""
     model = tf.keras.applications.resnet50.ResNet50(weights="imagenet")
     x = (

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -86,6 +86,7 @@ def test_ffmpeg_decode_video(video_path):
     assert video.dtype == tf.uint8
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="macOS fails now")
 def test_video_predict(video_path):
     """test_video_predict"""
     model = tf.keras.applications.resnet50.ResNet50(weights="imagenet")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -36,8 +36,8 @@ def fixture_video_data():
 @pytest.mark.parametrize(
     ("io_dataset_func"),
     [
-        pytest.param(lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),),
-        pytest.param(lambda f: tfio.IODataset.from_ffmpeg(f, "v:0"),),
+        pytest.param(lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0")),
+        pytest.param(lambda f: tfio.IODataset.from_ffmpeg(f, "v:0")),
     ],
     ids=["from_ffmpeg", "from_ffmpeg(eager)"],
 )
@@ -64,7 +64,7 @@ def test_video_io_dataset(video_data, io_dataset_func):
 
 @pytest.mark.parametrize(
     ("io_dataset_func"),
-    [pytest.param(lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),),],
+    [pytest.param(lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),)],
     ids=["from_ffmpeg"],
 )
 def test_video_io_dataset_with_dataset(video_data, io_dataset_func):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -36,23 +36,8 @@ def fixture_video_data():
 @pytest.mark.parametrize(
     ("io_dataset_func"),
     [
-        pytest.param(
-            lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!! on macOS"
-                ),
-            ],
-        ),
-        pytest.param(
-            lambda f: tfio.IODataset.from_ffmpeg(f, "v:0"),
-            marks=[
-                pytest.mark.skipif(
-                    True,  # sys.platform == "darwin",
-                    reason="macOS does not support FFmpeg",
-                ),
-            ],
-        ),
+        pytest.param(lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),),
+        pytest.param(lambda f: tfio.IODataset.from_ffmpeg(f, "v:0"),),
     ],
     ids=["from_ffmpeg", "from_ffmpeg(eager)"],
 )
@@ -79,16 +64,7 @@ def test_video_io_dataset(video_data, io_dataset_func):
 
 @pytest.mark.parametrize(
     ("io_dataset_func"),
-    [
-        pytest.param(
-            lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),
-            marks=[
-                pytest.mark.skipif(
-                    sys.platform == "darwin", reason="TODO: !!!pytest-xdist!!! on macOS"
-                ),
-            ],
-        ),
-    ],
+    [pytest.param(lambda f: tfio.IODataset.graph(tf.uint8).from_ffmpeg(f, "v:0"),),],
     ids=["from_ffmpeg"],
 )
 def test_video_io_dataset_with_dataset(video_data, io_dataset_func):

--- a/third_party/ffmpeg_2_8.BUILD
+++ b/third_party/ffmpeg_2_8.BUILD
@@ -5,8 +5,14 @@ licenses(["notice"])  # LGPL v2.1+ license
 
 exports_files(["LICENSE.md"])
 
-cc_import(
+cc_library(
     name = "ffmpeg",
+    srcs = [
+        ":stub/libavcodec-ffmpeg.so",
+        ":stub/libavformat-ffmpeg.so",
+        ":stub/libavutil-ffmpeg.so",
+        ":stub/libswscale-ffmpeg.so",
+    ],
     hdrs = [
         "libavcodec/avcodec.h",
         "libavcodec/old_codec_ids.h",
@@ -54,4 +60,69 @@ genrule(
         "#endif /* AVUTIL_AVCONFIG_H */",
         "EOF",
     ]),
+)
+
+cc_binary(
+    name = "stub/libavformat-ffmpeg.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libavformat-ffmpeg.56.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libavformat-ffmpeg.so.56",
+        ],
+    }),
+    linkshared = 1,
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "stub/libavcodec-ffmpeg.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libavcodec-ffmpeg.56.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libavcodec-ffmpeg.so.56",
+        ],
+    }),
+    linkshared = 1,
+)
+
+cc_binary(
+    name = "stub/libavutil-ffmpeg.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libavutil-ffmpeg.54.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libavutil-ffmpeg.so.54",
+        ],
+    }),
+    linkshared = 1,
+)
+
+cc_binary(
+    name = "stub/libswscale-ffmpeg.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libswscale-ffmpeg.3.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libswscale-ffmpeg.so.3",
+        ],
+    }),
+    linkshared = 1,
 )

--- a/third_party/ffmpeg_3_4.BUILD
+++ b/third_party/ffmpeg_3_4.BUILD
@@ -5,8 +5,13 @@ licenses(["notice"])  # LGPL v2.1+ license
 
 exports_files(["LICENSE.md"])
 
-cc_import(
+cc_library(
     name = "ffmpeg",
+    srcs = [
+        ":stub/libavformat.so",
+        ":stub/libavutil.so",
+        ":stub/libswscale.so",
+    ],
     hdrs = [
         "libavcodec/avcodec.h",
         "libavcodec/version.h",
@@ -52,4 +57,52 @@ genrule(
         "#endif /* AVUTIL_AVCONFIG_H */",
         "EOF",
     ]),
+)
+
+cc_binary(
+    name = "stub/libavformat.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libavformat.57.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libavformat.so.57",
+        ],
+    }),
+    linkshared = 1,
+)
+
+cc_binary(
+    name = "stub/libavutil.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libavutil.55.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libavutil.so.55",
+        ],
+    }),
+    linkshared = 1,
+)
+
+cc_binary(
+    name = "stub/libswscale.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libswscale.4.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libswscale.so.4",
+        ],
+    }),
+    linkshared = 1,
 )

--- a/third_party/ffmpeg_4_2.BUILD
+++ b/third_party/ffmpeg_4_2.BUILD
@@ -5,8 +5,12 @@ licenses(["notice"])  # LGPL v2.1+ license
 
 exports_files(["LICENSE.md"])
 
-cc_import(
+cc_library(
     name = "ffmpeg",
+    srcs = [
+        ":stub/libavformat.so",
+        ":stub/libswscale.so",
+    ],
     hdrs = [
         "libavcodec/avcodec.h",
         "libavcodec/version.h",
@@ -53,4 +57,36 @@ genrule(
         "#endif /* AVUTIL_AVCONFIG_H */",
         "EOF",
     ]),
+)
+
+cc_binary(
+    name = "stub/libavformat.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libavformat.58.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libavformat.so.58",
+        ],
+    }),
+    linkshared = 1,
+)
+
+cc_binary(
+    name = "stub/libswscale.so",
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "@bazel_tools//src/conditions:darwin": [
+            "-install_name",
+            "libswscale.5.dylib",
+        ],
+        "//conditions:default": [
+            "-Wl,--disable-new-dtags",
+            "-Wl,-soname,libswscale.so.5",
+        ],
+    }),
+    linkshared = 1,
 )

--- a/tools/build/auditwheel
+++ b/tools/build/auditwheel
@@ -2,7 +2,7 @@ TF_SHARED_LIBRARY_NAME=$(grep -r TF_SHARED_LIBRARY_NAME .bazelrc | awk -F= '{pri
 
 POLICY_JSON=$(find / -name policy.json)
 
-sed -i "s/libresolv.so.2\"/libresolv.so.2\", $TF_SHARED_LIBRARY_NAME/g" $POLICY_JSON
+sed -i "s/libresolv.so.2\"/libresolv.so.2\", $TF_SHARED_LIBRARY_NAME, \"libavformat.so.58\", \"libswscale.so.5\", \"libavformat.so.57\", \"libavutil.so.55\", \"libswscale.so.4\", \"libavformat-ffmpeg.so.56\", \"libavcodec-ffmpeg.so.56\", \"libavutil-ffmpeg.so.54\", \"libswscale-ffmpeg.so.3\"/g" $POLICY_JSON
 
 cat $POLICY_JSON
 


### PR DESCRIPTION
This PR take a similar approaches as we have done for libtensorflow_framework.so linkage:
1. Create stub ffmpeg dependencies (e.g., libavformat.so) without content
2. Change sonata to with version (e.g., libavformat.so.57)
3. Directly depends `libtensorflow_io_ffmpeg_4.2.so`/etc with ffmpeg dependencies (e.g., libavformat.so)

In this way, system will still search for  `libavformat.so.57` which was specified in soname.

This allows us to not globally load all symbols from `libavformat.so.57` (which could be dangerous), but rely on system to resolve the symbols for us.

The end result is the reduction in code complexity (much of the original ffmpeg_ops.py code has been removed).

In addition, this PR also re-enabled all ffmpeg tests on macOS (disabled when we faced some issues earlier).

/cc @kyamagu FYI

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>