### PR TITLE
Add -fvisibility=hidden to macOS/Linux build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -80,6 +80,7 @@ http_archive(
     build_file = "//third_party:aws-sdk-cpp.BUILD",
     patch_cmds = [
         """sed -i.bak 's/UUID::RandomUUID/Aws::Utils::UUID::RandomUUID/g' aws-cpp-sdk-core/source/client/AWSClient.cpp""",
+        """sed -i.bak 's/__attribute__((visibility("default")))//g' aws-cpp-sdk-core/include/aws/core/external/tinyxml2/tinyxml2.h """,
     ],
     sha256 = "758174f9788fed6cc1e266bcecb20bf738bd5ef1c3d646131c9ed15c2d6c5720",
     strip_prefix = "aws-sdk-cpp-1.7.336",
@@ -258,7 +259,7 @@ http_archive(
     name = "com_github_azure_azure_storage_cpplite",
     build_file = "//third_party:azure.BUILD",
     patch_cmds = [
-        #"sed -i.bak 's/struct stat/struct_stat/' src/blob/blob_client_wrapper.cpp",
+        """sed -i.bak 's/__attribute__((visibility("default")))//g' include/tinyxml2.h """,
         "echo '' >> include/base64.h",
         "echo '#include <stdexcept>' >> include/base64.h",
         "echo '' >> include/utility.h",

--- a/tensorflow_io/core/kernels/audio_ffmpeg_kernels.cc
+++ b/tensorflow_io/core/kernels/audio_ffmpeg_kernels.cc
@@ -355,14 +355,15 @@ class EncodeAACFunctionState {
 }  // namespace tensorflow
 
 extern "C" {
-void EncodeAACFunctionFiniFFmpeg(void* state) {
+__attribute__((visibility("default"))) void EncodeAACFunctionFiniFFmpeg(
+    void* state) {
   if (state != nullptr) {
     delete static_cast<tensorflow::data::EncodeAACFunctionState*>(state);
   }
 }
 
-void* EncodeAACFunctionInitFFmpeg(const int64_t codec, const int64_t rate,
-                                  const int64_t channels) {
+__attribute__((visibility("default"))) void* EncodeAACFunctionInitFFmpeg(
+    const int64_t codec, const int64_t rate, const int64_t channels) {
   tensorflow::data::FFmpegInit();
   tensorflow::data::EncodeAACFunctionState* state =
       new tensorflow::data::EncodeAACFunctionState(codec, rate, channels);
@@ -374,10 +375,9 @@ void* EncodeAACFunctionInitFFmpeg(const int64_t codec, const int64_t rate,
   }
   return nullptr;
 }
-int64_t EncodeAACFunctionCallFFmpeg(void* state, const float* data_in,
-                                    const int64_t size_in,
-                                    char** data_out_chunk,
-                                    int64_t* size_out_chunk, int64_t* chunk) {
+__attribute__((visibility("default"))) int64_t EncodeAACFunctionCallFFmpeg(
+    void* state, const float* data_in, const int64_t size_in,
+    char** data_out_chunk, int64_t* size_out_chunk, int64_t* chunk) {
   if (state != nullptr) {
     return static_cast<tensorflow::data::EncodeAACFunctionState*>(state)->Call(
         data_in, size_in, data_out_chunk, size_out_chunk, chunk);
@@ -385,14 +385,15 @@ int64_t EncodeAACFunctionCallFFmpeg(void* state, const float* data_in,
   return -1;
 }
 
-void DecodeAACFunctionFiniFFmpeg(void* state) {
+__attribute__((visibility("default"))) void DecodeAACFunctionFiniFFmpeg(
+    void* state) {
   if (state != nullptr) {
     delete static_cast<tensorflow::data::DecodeAACFunctionState*>(state);
   }
 }
 
-void* DecodeAACFunctionInitFFmpeg(const int64_t codec, const int64_t rate,
-                                  const int64_t channels) {
+__attribute__((visibility("default"))) void* DecodeAACFunctionInitFFmpeg(
+    const int64_t codec, const int64_t rate, const int64_t channels) {
   tensorflow::data::FFmpegInit();
 
   tensorflow::data::DecodeAACFunctionState* state =
@@ -406,12 +407,11 @@ void* DecodeAACFunctionInitFFmpeg(const int64_t codec, const int64_t rate,
   return nullptr;
 }
 
-int64_t DecodeAACFunctionCallFFmpeg(void* state, const int64_t codec,
-                                    const int64_t rate, const int64_t channels,
-                                    const void* data_in_chunk,
-                                    const int64_t* size_in_chunk, int64_t chunk,
-                                    int64_t frames, void* data_out,
-                                    int64_t size_out) {
+__attribute__((visibility("default"))) int64_t DecodeAACFunctionCallFFmpeg(
+    void* state, const int64_t codec, const int64_t rate,
+    const int64_t channels, const void* data_in_chunk,
+    const int64_t* size_in_chunk, int64_t chunk, int64_t frames, void* data_out,
+    int64_t size_out) {
   if (state != nullptr) {
     return static_cast<tensorflow::data::DecodeAACFunctionState*>(state)->Call(
         rate, channels, (const char*)data_in_chunk, size_in_chunk, chunk,

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -72,6 +72,7 @@ def write_config():
     try:
 
         with open(".bazelrc", "w") as bazel_rc:
+            bazel_rc.write('build --copt="-fvisibility=hidden"\n')
             for opt in opt_list:
                 bazel_rc.write('build --copt="{}"\n'.format(opt))
             header_dir = include_list[0][2:]


### PR DESCRIPTION
This PR adds `-fvisibility=hidden` to macOS/Linux build, so that local symbols will not be exposed.

This PR patches aws-cpp-sdk and azure lite sdk as both uses tinyxml2 and incorrectly exposes TinyXML API.

The end result is that now libtensorflow_io_plugins.so and libtensorflow_io_gcs_filesystem.so only exposes `TF_InitPlugin` function. (net reduction of almost 1000+ APIs un-exposed).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>