### PR TITLE
Use cat > service_account_creds.json << EOF on GitHub Actions Windows  build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
       - master
 
 env:
-  GCP_CREDS: ${{ secrets.GCP_CREDS }}
   REPO_NAME: ${{ github.repository }}
   EVENT_NAME: ${{ github.event_name }}
   BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
@@ -52,14 +51,19 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
+      - name: GCP
+        run: |
+          cat > service_account_creds.json << EOF
+          ${{ secrets.GCP_CREDS }}
+          EOF
+      - name: macOS
+        run: |
+          set -x -e
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           else
             export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
           fi
-          set -x -e
           echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
           export PATH=/usr/bin:$PATH
           echo $PATH
@@ -74,15 +78,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: GCP
+        run: |
+          cat > service_account_creds.json << EOF
+          ${{ secrets.GCP_CREDS }}
+          EOF
       - name: Ubuntu 20.04
         run: |
+          set -x -e
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           else
             export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
           fi
-          set -x -e
           bash -x -e .github/workflows/build.space.sh
           python3 .github/workflows/build.instruction.py docs/development.md "##### Ubuntu 20.04" > source.sh
           cat source.sh
@@ -95,15 +103,19 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: GCP
+        run: |
+          cat > service_account_creds.json << EOF
+          ${{ secrets.GCP_CREDS }}
+          EOF
       - name: Bazel on macOS
         run: |
+          set -x -e
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           else
             export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
           fi
-          set -x -e
           echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
           export PATH=/usr/bin:$PATH
           python3 --version
@@ -215,15 +227,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: GCP
+        run: |
+          cat > service_account_creds.json << EOF
+          ${{ secrets.GCP_CREDS }}
+          EOF
       - name: Bazel on Linux
         run: |
+          set -x -e
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            printf '%s\n' "${GCP_CREDS}" >service_account_creds.json
             export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           else
             export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
           fi
-          set -x -e
           bash -x -e .github/workflows/build.space.sh
           BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
           BAZEL_VERSION=$(cat .bazelversion)
@@ -319,14 +335,20 @@ jobs:
       - uses: egor-tensin/vs-shell@v2
         with:
           arch: x64
+      - name: GCP
+        shell: bash
+        run: |
+          cat > service_account_creds.json << EOF
+          ${{ secrets.GCP_CREDS }}
+          EOF
       - name: Bazel on Windows
         env:
           BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
         shell: cmd
         run: |
+          @echo on
           if "%EVENT_NAME%" == "push" (
             if "%REPO_NAME%" == "tensorflow/io" (
-              printenv GCP_CREDS > service_account_creds.json
               set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
             ) else (
               echo %REPO_NAME%
@@ -336,7 +358,6 @@ jobs:
             echo %EVENT_NAME%
             set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
           )
-          @echo on
           set /P BAZEL_VERSION=< .bazelversion
           curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
           bazel version


### PR DESCRIPTION
On GitHub Actions, we need to dump GCP_CREDS to a file. We used to
use printenv GCP_CREDS and this works on Windows (as GitHub
Actions setup the bash already).

However, some recent change (in order to get the Visual Studio shell)
caused the printenv not to work directly on Windows.

See https://github.com/tensorflow/io/actions/runs/848142638 for Windows build failures.

This PR use `cat > service_account_creds.json << EOF` so that this works again.

This PR also standarize the GCP setup on all jobs.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>