### PR TITLE
fix gcs compose mode

### DIFF
--- a/tensorflow_io_gcs_filesystem/core/gcs_filesystem.cc
+++ b/tensorflow_io_gcs_filesystem/core/gcs_filesystem.cc
@@ -487,7 +487,7 @@ GCSFileSystemImplementation::GCSFileSystemImplementation(
     google::cloud::storage::Client&& gcs_client)
     : gcs_client(gcs_client), block_cache_lock() {
   const char* append_mode = std::getenv(kAppendMode);
-  compose = (append_mode != nullptr) && (!strcmp(kAppendMode, append_mode));
+  compose = (append_mode != nullptr) && (!strcmp(kComposeAppend, append_mode));
 
   uint64_t value;
   block_size = kDefaultBlockSize;


### PR DESCRIPTION
This fix a small typo in the `gcs` plugin. `kAppendMode` is the name of the env, while `kComposeAppend` is the value of the compose mode. However, we will need some more reworks in order to match the implementation of `gcs` filesystem.

---

One more question, as I understand, we only need to build a shared object and exposed some C functions. It also means that we could pass arbitrary `copts` and `cxxopts` when builiding these objects. I would like to build the plugins with C++ 17 supports and `-Wall` and maybe some other options. WDYT @yongtang ?