### PR TITLE
Move options to `bazelrc` and use job container for linux

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -7,9 +7,6 @@ on:
   schedule:
     - cron: "0 12 * * *"
 
-env:
-  BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
-
 jobs:
 
   macos:

--- a/.github/workflows/build.bazel.sh
+++ b/.github/workflows/build.bazel.sh
@@ -18,6 +18,7 @@ set -e -x
 export TENSORFLOW_INSTALL="$(python3 setup.py --install-require)"
 
 export BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
+export BAZEL_VERSION=$(cat .bazelversion)
 curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
 bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
 bazel version
@@ -35,17 +36,17 @@ python3 tools/build/configure.py
 cat .bazelrc
 
 bazel build \
-  --crosstool_top=//third_party/toolchains/gcc7_manylinux2010:toolchain \
   ${BAZEL_OPTIMIZATION} \
-  --noshow_progress \
-  --noshow_loading_progress \
-  --verbose_failures \
-  --test_output=errors \
   -- //tensorflow_io/...  //tensorflow_io_gcs_filesystem/...
 
 rm -rf build && mkdir -p build
 
 cp -r bazel-bin/tensorflow_io  build/tensorflow_io
 cp -r bazel-bin/tensorflow_io_gcs_filesystem  build/tensorflow_io_gcs_filesystem
+
+chown -R $(id -nu):$(id -ng) build/tensorflow_io/
+chown -R $(id -nu):$(id -ng) build/tensorflow_io_gcs_filesystem/
+find build/tensorflow_io -name '*runfiles*' | xargs rm -rf
+find build/tensorflow_io_gcs_filesystem -name '*runfiles*' | xargs rm -rf
 
 exit 0

--- a/.github/workflows/build.gpu.sh
+++ b/.github/workflows/build.gpu.sh
@@ -76,7 +76,7 @@ cat .bazelrc
 
 bazel build -s --verbose_failures -c opt -k \
      --jobs=${N_JOBS} \
-     --crosstool_top=//third_party/toolchains/gcc7_manylinux2010-nvcc-cuda10.1:toolchain \
+     --config=linux_ci_gpu \
      //tensorflow_io/core:python/ops/libtensorflow_io.so
 
 exit $?

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
 env:
   REPO_NAME: ${{ github.repository }}
   EVENT_NAME: ${{ github.event_name }}
-  BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt
 
 jobs:
   lint:
@@ -59,10 +58,9 @@ jobs:
       - name: macOS
         run: |
           set -x -e
+          export BAZEL_OPTIMIZATION="--config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
-          else
-            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
+            export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
           echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
           export PATH=/usr/bin:$PATH
@@ -86,10 +84,9 @@ jobs:
       - name: Ubuntu 20.04
         run: |
           set -x -e
+          export BAZEL_OPTIMIZATION="--config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
-          else
-            export BAZEL_OPTIMIZATION="--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
+            export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
           bash -x -e .github/workflows/build.space.sh
           python3 .github/workflows/build.instruction.py docs/development.md "##### Ubuntu 20.04" > source.sh
@@ -111,32 +108,13 @@ jobs:
       - name: Bazel on macOS
         run: |
           set -x -e
+          export BAZEL_OPTIMIZATION="--config=ci --config=mac_ci --config=output_ci --config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
-          else
-            export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
+            export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
           echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
           export PATH=/usr/bin:$PATH
-          python3 --version
-          python3 -c 'import site; print(site.getsitepackages())'
-          BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-          BAZEL_VERSION=$(cat .bazelversion)
-          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          sudo python3 -m pip install $(python3 setup.py --install-require)
-          python3 tools/build/configure.py
-          bazel build \
-            ${BAZEL_OPTIMIZATION} \
-            --copt -Wunguarded-availability \
-            --noshow_progress \
-            --noshow_loading_progress \
-            --verbose_failures \
-            --test_output=errors \
-            //tensorflow_io/...  //tensorflow_io_gcs_filesystem/...
-          mkdir build
-          cp -r bazel-bin/tensorflow_io build
-          cp -r bazel-bin/tensorflow_io_gcs_filesystem build
+          sudo -E bash -e .github/workflows/build.bazel.sh
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-bazel-bin
@@ -235,21 +213,14 @@ jobs:
       - name: Bazel on Linux
         run: |
           set -x -e
+          export BAZEL_OPTIMIZATION="--config=ci --config=linux_ci --config=output_ci --config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
-            export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
-          else
-            export BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION} --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
+            export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
           bash -x -e .github/workflows/build.space.sh
-          BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-          BAZEL_VERSION=$(cat .bazelversion)
           docker run -i --rm -v $PWD:/v -w /v --net=host \
-            -e BAZEL_VERSION=${BAZEL_VERSION} \
             -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
             gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.github/workflows/build.bazel.sh
-          sudo chown -R $(id -nu):$(id -ng) .
-          sudo find build/tensorflow_io -name '*runfiles*' | sudo xargs rm -rf
-          sudo find build/tensorflow_io_gcs_filesystem -name '*runfiles*' | sudo xargs rm -rf
           sudo cp .bazelrc build/tensorflow_io/
       - uses: actions/upload-artifact@v2
         with:
@@ -347,16 +318,11 @@ jobs:
         shell: cmd
         run: |
           @echo on
+          set "BAZEL_OPTIMIZATION=--config=output_ci --config=cache"
           if "%EVENT_NAME%" == "push" (
             if "%REPO_NAME%" == "tensorflow/io" (
-              set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=true --google_credentials=service_account_creds.json"
-            ) else (
-              echo %REPO_NAME%
-              set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
+              set "BAZEL_OPTIMIZATION=%BAZEL_OPTIMIZATION% --remote_upload_local_results=true --google_credentials=service_account_creds.json"
             )
-          ) else (
-            echo %EVENT_NAME%
-            set "BAZEL_OPTIMIZATION=--remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
           )
           set /P BAZEL_VERSION=< .bazelversion
           curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
@@ -367,7 +333,7 @@ jobs:
           python3 setup.py --install-require | xargs python3 -m pip install
           python3 tools/build/configure.py
           cat .bazelrc
-          bazel build -s --verbose_failures --noshow_progress --noshow_loading_progress --experimental_ui_max_stdouterr_bytes=-1 %BAZEL_OPTIMIZATION% //tensorflow_io/core:python/ops/libtensorflow_io.so //tensorflow_io/core:python/ops/libtensorflow_io_plugins.so  //tensorflow_io_gcs_filesystem/...
+          bazel build -s --experimental_ui_max_stdouterr_bytes=-1 %BAZEL_OPTIMIZATION% //tensorflow_io/core:python/ops/libtensorflow_io.so //tensorflow_io/core:python/ops/libtensorflow_io_plugins.so  //tensorflow_io_gcs_filesystem/...
           if %errorlevel% neq 0 exit /b %errorlevel%
           mkdir build
           cp -r bazel-bin/tensorflow_io build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,11 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+      env:
+        REPO_NAME: ${{ env.REPO_NAME }}
+        EVENT_NAME: ${{ env.EVENT_NAME }}
     steps:
       - uses: actions/checkout@v2
       - name: GCP
@@ -82,18 +87,18 @@ jobs:
           ${{ secrets.GCP_CREDS }}
           EOF
       - name: Ubuntu 20.04
+        shell: bash
         run: |
           set -x -e
           export BAZEL_OPTIMIZATION="--config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
-          bash -x -e .github/workflows/build.space.sh
+          apt update
+          apt-get install -y python3
           python3 .github/workflows/build.instruction.py docs/development.md "##### Ubuntu 20.04" > source.sh
           cat source.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host \
-            -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
-            ubuntu:20.04 bash -x -e source.sh
+          bash -x -e source.sh
 
   macos-bazel:
     name: Bazel macOS
@@ -203,6 +208,11 @@ jobs:
   linux-bazel:
     name: Bazel Linux
     runs-on: ubuntu-latest
+    container:
+      image: gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170
+      env:
+        REPO_NAME: ${{ env.REPO_NAME }}
+        EVENT_NAME: ${{ env.EVENT_NAME }}
     steps:
       - uses: actions/checkout@v2
       - name: GCP
@@ -211,16 +221,14 @@ jobs:
           ${{ secrets.GCP_CREDS }}
           EOF
       - name: Bazel on Linux
+        shell: bash
         run: |
           set -x -e
           export BAZEL_OPTIMIZATION="--config=ci --config=linux_ci --config=output_ci --config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
-          bash -x -e .github/workflows/build.space.sh
-          docker run -i --rm -v $PWD:/v -w /v --net=host \
-            -e BAZEL_OPTIMIZATION="${BAZEL_OPTIMIZATION}" \
-            gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170 /v/.github/workflows/build.bazel.sh
+          bash -x -e .github/workflows/build.bazel.sh
           sudo cp .bazelrc build/tensorflow_io/
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Bazel on macOS
         run: |
           set -x -e
-          export BAZEL_OPTIMIZATION="--config=ci --config=mac_ci --config=output_ci --config=cache"
+          export BAZEL_OPTIMIZATION="--config=optimization --config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
@@ -224,7 +224,7 @@ jobs:
         shell: bash
         run: |
           set -x -e
-          export BAZEL_OPTIMIZATION="--config=ci --config=linux_ci --config=output_ci --config=cache"
+          export BAZEL_OPTIMIZATION="--config=optimization --config=linux_ci --config=cache"
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
@@ -326,7 +326,7 @@ jobs:
         shell: cmd
         run: |
           @echo on
-          set "BAZEL_OPTIMIZATION=--config=output_ci --config=cache"
+          set "BAZEL_OPTIMIZATION=--config=cache"
           if "%EVENT_NAME%" == "push" (
             if "%REPO_NAME%" == "tensorflow/io" (
               set "BAZEL_OPTIMIZATION=%BAZEL_OPTIMIZATION% --remote_upload_local_results=true --google_credentials=service_account_creds.json"
@@ -341,7 +341,7 @@ jobs:
           python3 setup.py --install-require | xargs python3 -m pip install
           python3 tools/build/configure.py
           cat .bazelrc
-          bazel build -s --experimental_ui_max_stdouterr_bytes=-1 %BAZEL_OPTIMIZATION% //tensorflow_io/core:python/ops/libtensorflow_io.so //tensorflow_io/core:python/ops/libtensorflow_io_plugins.so  //tensorflow_io_gcs_filesystem/...
+          bazel build -s %BAZEL_OPTIMIZATION% //tensorflow_io/core:python/ops/libtensorflow_io.so //tensorflow_io/core:python/ops/libtensorflow_io_plugins.so  //tensorflow_io_gcs_filesystem/...
           if %errorlevel% neq 0 exit /b %errorlevel%
           mkdir build
           cp -r bazel-bin/tensorflow_io build

--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -48,7 +48,7 @@ docker  --version
 export PYTHON_VERSION=3.8
 
 export BAZEL_VERSION=$(cat .bazelversion)
-export BAZEL_OPTIMIZATION="--copt=-msse4.2 --copt=-mavx --compilation_mode=opt --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io --remote_upload_local_results=false"
+export BAZEL_OPTIMIZATION="--config=ci --config=cache"
 export BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
 
 docker run -i --rm -v $PWD:/v -w /v --net=host \

--- a/.kokorun/io_cpu.sh
+++ b/.kokorun/io_cpu.sh
@@ -48,7 +48,7 @@ docker  --version
 export PYTHON_VERSION=3.8
 
 export BAZEL_VERSION=$(cat .bazelversion)
-export BAZEL_OPTIMIZATION="--config=ci --config=cache"
+export BAZEL_OPTIMIZATION="--config=optimization --config=cache"
 export BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
 
 docker run -i --rm -v $PWD:/v -w /v --net=host \

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -114,9 +114,9 @@ def write_config():
                     bazel_rc.write('build --action_env TF_CUDA_VERSION="10.1"\n')
                     bazel_rc.write('build --action_env TF_CUDNN_VERSION="7"\n')
             # Needed for tf rules
-            bazel_rc.write('build --experimental_repo_remote_exec\n')
+            bazel_rc.write("build --experimental_repo_remote_exec\n")
             # Enable platform specific config
-            bazel_rc.write('build --enable_platform_specific_config\n')
+            bazel_rc.write("build --enable_platform_specific_config\n")
             # Needed for GRPC build
             bazel_rc.write('build:macos --copt="-DGRPC_BAZEL_BUILD"\n')
             # Stay with 10.14 for macOS
@@ -124,6 +124,27 @@ def write_config():
             bazel_rc.write('build:macos --linkopt="-mmacosx-version-min=10.14"\n')
             # MSVC (Windows): Standards-conformant preprocessor mode
             bazel_rc.write('build:windows --copt="/Zc:preprocessor"\n')
+            # Config for CI and release build
+            bazel_rc.write("build:ci --copt=-msse4.2\n")
+            bazel_rc.write("build:ci --copt=-mavx\n")
+            bazel_rc.write("build:ci --compilation_mode=opt\n")
+            bazel_rc.write("build:mac_ci --copt=-Wunguarded-availability\n")
+            bazel_rc.write(
+                "build:linux_ci --crosstool_top=//third_party/toolchains/gcc7_manylinux2010:toolchain\n"
+            )
+            bazel_rc.write(
+                "build:linux_ci_gpu --crosstool_top=//third_party/toolchains/gcc7_manylinux2010-nvcc-cuda10.1:toolchain\n"
+            )
+            bazel_rc.write("build:output_ci --noshow_progress\n")
+            bazel_rc.write("build:output_ci --noshow_loading_progress\n")
+            bazel_rc.write("build:output_ci --verbose_failures\n")
+            bazel_rc.write("build:output_ci --test_output=errors\n")
+            # GCS cache (read-only by default)
+            bazel_rc.write(
+                "build:cache --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io\n"
+            )
+            bazel_rc.write("build:cache --remote_upload_local_results=false\n")
+
             bazel_rc.close()
     except OSError:
         print("ERROR: Writing .bazelrc")

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -122,23 +122,26 @@ def write_config():
             # Stay with 10.14 for macOS
             bazel_rc.write('build:macos --copt="-mmacosx-version-min=10.14"\n')
             bazel_rc.write('build:macos --linkopt="-mmacosx-version-min=10.14"\n')
+            # Warns for unguarded uses of Objective-C APIs
+            bazel_rc.write("build:macos --copt=-Wunguarded-availability\n")
             # MSVC (Windows): Standards-conformant preprocessor mode
             bazel_rc.write('build:windows --copt="/Zc:preprocessor"\n')
             # Config for CI and release build
-            bazel_rc.write("build:ci --copt=-msse4.2\n")
-            bazel_rc.write("build:ci --copt=-mavx\n")
-            bazel_rc.write("build:ci --compilation_mode=opt\n")
-            bazel_rc.write("build:mac_ci --copt=-Wunguarded-availability\n")
+            bazel_rc.write("build:optimization --copt=-msse4.2\n")
+            bazel_rc.write("build:optimization --copt=-mavx\n")
+            bazel_rc.write("build:optimization --compilation_mode=opt\n")
             bazel_rc.write(
                 "build:linux_ci --crosstool_top=//third_party/toolchains/gcc7_manylinux2010:toolchain\n"
             )
             bazel_rc.write(
                 "build:linux_ci_gpu --crosstool_top=//third_party/toolchains/gcc7_manylinux2010-nvcc-cuda10.1:toolchain\n"
             )
-            bazel_rc.write("build:output_ci --noshow_progress\n")
-            bazel_rc.write("build:output_ci --noshow_loading_progress\n")
-            bazel_rc.write("build:output_ci --verbose_failures\n")
-            bazel_rc.write("build:output_ci --test_output=errors\n")
+            # For a cleaner output
+            bazel_rc.write("build --noshow_progress\n")
+            bazel_rc.write("build --noshow_loading_progress\n")
+            bazel_rc.write("build --verbose_failures\n")
+            bazel_rc.write("build --test_output=errors\n")
+            bazel_rc.write("build --experimental_ui_max_stdouterr_bytes=-1\n")
             # GCS cache (read-only by default)
             bazel_rc.write(
                 "build:cache --remote_cache=https://storage.googleapis.com/tensorflow-sigs-io\n"


### PR DESCRIPTION
This PR changes 2 things:
- Move build options to `.bazelrc` instead of `build.yml`. This way, we don't need to repeat `BAZEL_OPTIMIZATION: --copt=-msse4.2 --copt=-mavx --compilation_mode=opt` and it will be eaiser to add another build configs like `asan`, `tsan` and `msan`.
- Use [`jobs.container`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer) for linux build, so we don't have to use `docker` directly and we could eventually share a common script ( see `macos-bazel` and `linux-bazel` ) for both Linux and MacOS build. 

Testing script is harder since we have many things to setup. I am trying to compress everything into a docker container so we could replace this
https://github.com/tensorflow/io/blob/87e2b4d7191ff8569e7a18d6109839b8d2f3156e/.github/workflows/build.yml#L311-L321

with something like `docker-compose up` and contributors ( including me ) will have an easier way to setup the environment for testing locally. WDYT @yongtang ?