### PR TITLE
bump `aws-sdk-cpp` to 1.8.186

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,11 +82,11 @@ http_archive(
         """sed -i.bak 's/UUID::RandomUUID/Aws::Utils::UUID::RandomUUID/g' aws-cpp-sdk-core/source/client/AWSClient.cpp""",
         """sed -i.bak 's/__attribute__((visibility("default")))//g' aws-cpp-sdk-core/include/aws/core/external/tinyxml2/tinyxml2.h """,
     ],
-    sha256 = "758174f9788fed6cc1e266bcecb20bf738bd5ef1c3d646131c9ed15c2d6c5720",
-    strip_prefix = "aws-sdk-cpp-1.7.336",
+    sha256 = "749322a8be4594472512df8a21d9338d7181c643a00e08a0ff12f07e831e3346",
+    strip_prefix = "aws-sdk-cpp-1.8.186",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
-        "https://github.com/aws/aws-sdk-cpp/archive/1.7.336.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/aws/aws-sdk-cpp/archive/1.8.186.tar.gz",
+        "https://github.com/aws/aws-sdk-cpp/archive/1.8.186.tar.gz",
     ],
 )
 

--- a/tensorflow_io/core/plugins/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/plugins/s3/s3_filesystem.cc
@@ -134,37 +134,6 @@ static Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
   absl::MutexLock l(&cfg_lock);
 
   if (!init) {
-    const char* region = getenv("AWS_REGION");
-    // TODO (yongtang): `S3_REGION` should be deprecated after 2.0.
-    if (!region) region = getenv("S3_REGION");
-    if (region) {
-      cfg.region = Aws::String(region);
-    } else {
-      // Load config file (e.g., ~/.aws/config) only if AWS_SDK_LOAD_CONFIG
-      // is set with a truthy value.
-      const char* load_config_env = getenv("AWS_SDK_LOAD_CONFIG");
-      std::string load_config =
-          load_config_env ? absl::AsciiStrToLower(load_config_env) : "";
-      if (load_config == "true" || load_config == "1") {
-        Aws::String config_file;
-        // If AWS_CONFIG_FILE is set then use it, otherwise use ~/.aws/config.
-        const char* config_file_env = getenv("AWS_CONFIG_FILE");
-        if (config_file_env) {
-          config_file = config_file_env;
-        } else {
-          const char* home_env = getenv("HOME");
-          if (home_env) {
-            config_file = home_env;
-            config_file += "/.aws/config";
-          }
-        }
-        Aws::Config::AWSConfigFileProfileConfigLoader loader(config_file);
-        loader.Load();
-        auto profiles = loader.GetProfiles();
-        if (!profiles["default"].GetRegion().empty())
-          cfg.region = profiles["default"].GetRegion();
-      }
-    }
     // if these timeouts are low, you may see an error when
     // uploading/downloading large files: Unable to connect to endpoint
     int64_t timeout;


### PR DESCRIPTION
Since the symbol collision is resolved, I think we could try to bump `aws-sdk-cpp`.