### PR TITLE
refactor filesystem plugins directory layout

### DIFF
--- a/tensorflow_io/BUILD
+++ b/tensorflow_io/BUILD
@@ -50,7 +50,7 @@ cc_binary(
         ],
     }) + select({
         "//tensorflow_io/core:static_build_on": [
-            "//tensorflow_io/core/plugins:plugins",
+            "//tensorflow_io/core/filesystems:filesystem_plugins",
         ],
         "//conditions:default": [],
     }),
@@ -63,7 +63,7 @@ cc_binary(
     deps = select({
         "//tensorflow_io/core:static_build_on": [],
         "//conditions:default": [
-            "//tensorflow_io/core/plugins:plugins",
+            "//tensorflow_io/core/filesystems:filesystem_plugins",
         ],
     }),
 )

--- a/tensorflow_io/core/filesystems/BUILD
+++ b/tensorflow_io/core/filesystems/BUILD
@@ -8,9 +8,9 @@ load(
 )
 
 cc_library(
-    name = "plugins_header",
+    name = "filesystem_plugins_header",
     srcs = [
-        "file_system_plugins.h",
+        "filesystem_plugins.h",
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "@local_config_tf//:stub/libtensorflow_framework.lib",
@@ -28,17 +28,17 @@ cc_library(
 )
 
 cc_library(
-    name = "plugins",
+    name = "filesystem_plugins",
     srcs = [
-        "file_system_plugins.cc",
+        "filesystem_plugins.cc",
     ],
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [
-        "//tensorflow_io/core/plugins/az",
-        "//tensorflow_io/core/plugins/hdfs",
-        "//tensorflow_io/core/plugins/http",
-        "//tensorflow_io/core/plugins/s3",
+        "//tensorflow_io/core/filesystems/az",
+        "//tensorflow_io/core/filesystems/hdfs",
+        "//tensorflow_io/core/filesystems/http",
+        "//tensorflow_io/core/filesystems/s3",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/filesystems/az/BUILD
+++ b/tensorflow_io/core/filesystems/az/BUILD
@@ -8,21 +8,16 @@ load(
 )
 
 cc_library(
-    name = "s3",
+    name = "az",
     srcs = [
-        "aws_logging.cc",
-        "aws_logging.h",
-        "s3_filesystem.cc",
-        "s3_filesystem.h",
+        "az_filesystem.cc",
     ],
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [
-        "//tensorflow_io/core/plugins:plugins_header",
-        "@aws-sdk-cpp//:s3",
-        "@aws-sdk-cpp//:transfer",
+        "//tensorflow_io/core/filesystems:filesystem_plugins_header",
+        "@com_github_azure_azure_storage_cpplite//:azure",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/filesystems/az/az_filesystem.cc
+++ b/tensorflow_io/core/filesystems/az/az_filesystem.cc
@@ -34,7 +34,7 @@ limitations under the License.
 #include "storage_errno.h"
 #include "tensorflow/c/logging.h"
 #include "tensorflow/c/tf_status.h"
-#include "tensorflow_io/core/plugins/file_system_plugins.h"
+#include "tensorflow_io/core/filesystems/filesystem_plugins.h"
 
 namespace tensorflow {
 namespace io {

--- a/tensorflow_io/core/filesystems/filesystem_plugins.cc
+++ b/tensorflow_io/core/filesystems/filesystem_plugins.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow_io/core/plugins/file_system_plugins.h"
+#include "tensorflow_io/core/filesystems/filesystem_plugins.h"
 
 #include "absl/strings/ascii.h"
 

--- a/tensorflow_io/core/filesystems/filesystem_plugins.h
+++ b/tensorflow_io/core/filesystems/filesystem_plugins.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TENSORFLOW_IO_CORE_PLUGINS_FILE_SYSTEM_PLUGINS_H
-#define TENSORFLOW_IO_CORE_PLUGINS_FILE_SYSTEM_PLUGINS_H
+#ifndef TENSORFLOW_IO_CORE_FILESYSTEMS_FILESYSTEM_PLUGINS_H
+#define TENSORFLOW_IO_CORE_FILESYSTEMS_FILESYSTEM_PLUGINS_H
 
 #include <stdlib.h>
 
@@ -53,4 +53,4 @@ void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops, const char* uri);
 }  // namespace io
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_IO_CORE_PLUGINS_FILE_SYSTEM_PLUGINS_H
+#endif  // TENSORFLOW_IO_CORE_FILESYSTEMS_FILESYSTEM_PLUGINS_H

--- a/tensorflow_io/core/filesystems/hdfs/BUILD
+++ b/tensorflow_io/core/filesystems/hdfs/BUILD
@@ -8,16 +8,17 @@ load(
 )
 
 cc_library(
-    name = "az",
+    name = "hdfs",
     srcs = [
-        "az_file_system.cc",
+        "hadoop_filesystem.cc",
     ],
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [
-        "//tensorflow_io/core/plugins:plugins_header",
-        "@com_github_azure_azure_storage_cpplite//:azure",
+        "//tensorflow_io/core/filesystems:filesystem_plugins_header",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@hadoop",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/filesystems/hdfs/hadoop_filesystem.cc
+++ b/tensorflow_io/core/filesystems/hdfs/hadoop_filesystem.cc
@@ -33,7 +33,7 @@ limitations under the License.
 #include "hdfs/hdfs.h"
 #include "tensorflow/c/logging.h"
 #include "tensorflow/c/tf_status.h"
-#include "tensorflow_io/core/plugins/file_system_plugins.h"
+#include "tensorflow_io/core/filesystems/filesystem_plugins.h"
 
 namespace tensorflow {
 namespace io {

--- a/tensorflow_io/core/filesystems/http/BUILD
+++ b/tensorflow_io/core/filesystems/http/BUILD
@@ -10,12 +10,12 @@ load(
 cc_library(
     name = "http",
     srcs = [
-        "http_file_system.cc",
+        "http_filesystem.cc",
     ],
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [
-        "//tensorflow_io/core/plugins:plugins_header",
+        "//tensorflow_io/core/filesystems:filesystem_plugins_header",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",

--- a/tensorflow_io/core/filesystems/http/http_filesystem.cc
+++ b/tensorflow_io/core/filesystems/http/http_filesystem.cc
@@ -24,7 +24,7 @@ limitations under the License.
 #include "absl/synchronization/mutex.h"
 #include "tensorflow/c/logging.h"
 #include "tensorflow/c/tf_status.h"
-#include "tensorflow_io/core/plugins/file_system_plugins.h"
+#include "tensorflow_io/core/filesystems/filesystem_plugins.h"
 
 namespace tensorflow {
 namespace io {

--- a/tensorflow_io/core/filesystems/s3/BUILD
+++ b/tensorflow_io/core/filesystems/s3/BUILD
@@ -8,17 +8,21 @@ load(
 )
 
 cc_library(
-    name = "hdfs",
+    name = "s3",
     srcs = [
-        "hadoop_filesystem.cc",
+        "aws_logging.cc",
+        "aws_logging.h",
+        "s3_filesystem.cc",
+        "s3_filesystem.h",
     ],
     copts = tf_io_copts(),
     linkstatic = True,
     deps = [
-        "//tensorflow_io/core/plugins:plugins_header",
+        "//tensorflow_io/core/filesystems:filesystem_plugins_header",
+        "@aws-sdk-cpp//:s3",
+        "@aws-sdk-cpp//:transfer",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
-        "@hadoop",
     ],
     alwayslink = 1,
 )

--- a/tensorflow_io/core/filesystems/s3/aws_logging.cc
+++ b/tensorflow_io/core/filesystems/s3/aws_logging.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include "tensorflow_io/core/plugins/s3/aws_logging.h"
+#include "tensorflow_io/core/filesystems/s3/aws_logging.h"
 
 #include <aws/core/Aws.h>
 #include <aws/core/utils/logging/AWSLogging.h>

--- a/tensorflow_io/core/filesystems/s3/aws_logging.h
+++ b/tensorflow_io/core/filesystems/s3/aws_logging.h
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_AWS_LOGGING_H_
-#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_AWS_LOGGING_H_
+#ifndef TENSORFLOW_IO_CORE_FILESYSTEMS_S3_AWS_LOGGING_H_
+#define TENSORFLOW_IO_CORE_FILESYSTEMS_S3_AWS_LOGGING_H_
 
 #include <aws/core/utils/logging/LogLevel.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
@@ -67,4 +67,4 @@ class AWSLogSystem : public Aws::Utils::Logging::LogSystemInterface {
 }  // namespace io
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_AWS_LOGGING_H_
+#endif  // TENSORFLOW_IO_CORE_FILESYSTEMS_S3_AWS_LOGGING_H_

--- a/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include "tensorflow_io/core/plugins/s3/s3_filesystem.h"
+#include "tensorflow_io/core/filesystems/s3/s3_filesystem.h"
 
 #include <aws/core/client/AsyncCallerContext.h>
 #include <aws/core/config/AWSProfileConfigLoader.h>
@@ -38,8 +38,8 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "tensorflow/c/logging.h"
 #include "tensorflow/c/tf_status.h"
-#include "tensorflow_io/core/plugins/file_system_plugins.h"
-#include "tensorflow_io/core/plugins/s3/aws_logging.h"
+#include "tensorflow_io/core/filesystems/filesystem_plugins.h"
+#include "tensorflow_io/core/filesystems/s3/aws_logging.h"
 
 namespace tensorflow {
 namespace io {

--- a/tensorflow_io/core/filesystems/s3/s3_filesystem.h
+++ b/tensorflow_io/core/filesystems/s3/s3_filesystem.h
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_S3_FILESYSTEM_H_
-#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_S3_FILESYSTEM_H_
+#ifndef TENSORFLOW_IO_CORE_FILESYSTEMS_S3_S3_FILESYSTEM_H_
+#define TENSORFLOW_IO_CORE_FILESYSTEMS_S3_S3_FILESYSTEM_H_
 
 #include <aws/core/Aws.h>
 #include <aws/core/utils/StringUtils.h>
@@ -106,4 +106,4 @@ void RenameFile(const TF_Filesystem* filesystem, const char* src,
 }  // namespace io
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_S3_FILESYSTEM_H_
+#endif  // TENSORFLOW_IO_CORE_FILESYSTEMS_S3_S3_FILESYSTEM_H_


### PR DESCRIPTION
This PR addresses #1440 by renaming the `core/plugins` directory to `core/filesystems` and modifying the bazel targets as required.

cc: @yongtang @vnvo2409 