### PR TITLE
refine the STYLE_GUIDE content

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 ## Development
 
 The document contains the necessary information for setting up the development environement
-and building the `tensorflow-io` package from source on various platforms.
+and building the `tensorflow-io` package from source on various platforms. Once the setup is completed please refer to the [STYLE_GUIDE](https://github.com/tensorflow/io/blob/master/STYLE_GUIDE.md) for guidelines on adding new ops.
 
 ### IDE Setup
 


### PR DESCRIPTION
This PR refines the `STYLE_GUIDE.md` content and points the `docs/development.md` to this file for guidelines on adding ops after setting up the dev environment. 