### PR TITLE
add a lightweight API deprecation handler

### DIFF
--- a/tensorflow_io/python/ops/kafka_deprecated_dataset_ops.py
+++ b/tensorflow_io/python/ops/kafka_deprecated_dataset_ops.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 from tensorflow import dtypes
 from tensorflow.compat.v1 import data
 from tensorflow_io.python.ops import core_ops
+from tensorflow_io.python.utils import deprecation
 
 warnings.warn(
     "implementation of existing tensorflow_io.kafka.KafkaDataset is "
@@ -30,6 +31,7 @@ warnings.warn(
 )
 
 
+@deprecation.deprecate("Use tfio.IODataset.from_kafka(...) instead")
 class KafkaDataset(data.Dataset):
     """A Kafka Dataset that consumes the messages."""
 

--- a/tensorflow_io/python/utils/__init__.py
+++ b/tensorflow_io/python/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorflow_io/python/utils/deprecation.py
+++ b/tensorflow_io/python/utils/deprecation.py
@@ -1,0 +1,68 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import warnings
+import functools
+
+
+def deprecate(message):
+    """a decorator to aid in deprecating python api endpoints and
+  suggesting alternatives.
+
+  Args:
+    message: A description of the deprecation activity and an
+      alternative endpoint that can be used (if applicable).
+
+  Example:
+
+  ```
+  from tensorflow_io.python.utils import deprecation
+
+  @deprecation.deprecate("Use new_func instead")
+  def old_func():
+    return 1
+  ```
+  """
+
+    def deprecated_wrapper(func_or_class):
+        """Deprecation wrapper."""
+        if isinstance(func_or_class, type):
+            # If a class is deprecated, you actually want to wrap the constructor.
+            cls = func_or_class
+            if cls.__new__ is object.__new__:
+                func = cls.__init__
+                constructor_name = "__init__"
+            else:
+                # for classes where __new__ has been overwritten
+                func = cls.__new__
+                constructor_name = "__new__"
+        else:
+            cls = None
+            constructor_name = None
+            func = func_or_class
+
+        @functools.wraps(func)
+        def new_func(*args, **kwargs):  # pylint: disable=missing-docstring
+            warnings.warn(message=message)
+            return func(*args, **kwargs)
+
+        if cls is None:
+            return new_func
+        else:
+            # Insert the wrapped function as the constructor
+            setattr(cls, constructor_name, new_func)
+            return cls
+
+    return deprecated_wrapper


### PR DESCRIPTION
This PR adds a lightweight API deprecation handler (decorator) which is similar to the one available in [TensorFlow](https://github.com/tensorflow/tensorflow/blob/322a3dc7bffb449b024702b7234c862b653a2861/tensorflow/python/util/deprecation.py#L281).
Additionally, the `KafkaDataset` is now marked as deprecated.