### PR TITLE
use batch.num.messages config in KafkaGroupReadableResource::Next

### DIFF
--- a/tensorflow_io/core/kernels/kafka_kernels.cc
+++ b/tensorflow_io/core/kernels/kafka_kernels.cc
@@ -904,6 +904,19 @@ class KafkaGroupReadableResource : public ResourceBase {
       }
     }
 
+    // set max.poll.records configuration
+    std::string max_poll_records;
+    if ((result = conf->get("max.poll.records", max_poll_records)) !=
+        RdKafka::Conf::CONF_OK) {
+      max_poll_records = "1024";    
+      if ((result = conf->set("max.poll.records", max_poll_records, errstr)) !=
+          RdKafka::Conf::CONF_OK) {
+        return errors::Internal("failed to set max.poll.records [", max_poll_records,
+                                "]:", errstr);
+      }
+    }
+    max_poll_records_ = reinterpret_cast<int64>(max_poll_records.c_str());
+
     // Always set enable.partition.eof=true
     if ((result = conf->set("enable.partition.eof", "true", errstr)) !=
         RdKafka::Conf::CONF_OK) {
@@ -947,16 +960,15 @@ class KafkaGroupReadableResource : public ResourceBase {
 
     // Initialize necessary variables
     int64 num_messages = 0;
-    int64 max_num_messages = 1024;
     max_stream_timeout_polls_ = stream_timeout / message_poll_timeout;
 
     // Allocate memory for message_value and key_value vectors
     std::vector<string> message_value, key_value;
-    message_value.reserve(max_num_messages);
-    key_value.reserve(max_num_messages);
+    message_value.reserve(max_poll_records_);
+    key_value.reserve(max_poll_records_);
 
     std::unique_ptr<RdKafka::Message> message;
-    while (consumer_.get() != nullptr && num_messages < max_num_messages) {
+    while (consumer_.get() != nullptr && num_messages < max_poll_records_) {
       if (!kafka_event_cb_.run()) {
         return errors::Internal(
             "failed to consume messages due to broker issue");
@@ -1022,6 +1034,7 @@ class KafkaGroupReadableResource : public ResourceBase {
   KafkaRebalanceCb kafka_rebalance_cb_ = KafkaRebalanceCb();
   int max_stream_timeout_polls_ = -1;
   int stream_timeout_polls_ = -1;
+  int64 max_poll_records_ = 1024;
 };
 
 class KafkaGroupReadableInitOp

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -449,6 +449,38 @@ def test_kafka_group_io_dataset_stream_timeout_check():
     )
 
 
+def test_kafka_batch_io_dataset_mini_dataset_size():
+    """Test the functionality of batch.num.messages property of
+    KafkaBatchIODataset.
+    """
+    import tensorflow_io.kafka as kafka_io
+
+    # Write new messages to the topic
+    for i in range(10, 10000):
+        message = "{}".format(i)
+        kafka_io.write_kafka(message=message, topic="mini-batch-test")
+
+    BATCH_NUM_MESSAGES = 5000
+    dataset = tfio.experimental.streaming.KafkaBatchIODataset(
+        topics=["mini-batch-test"],
+        group_id="cgminibatchsize",
+        servers=None,
+        stream_timeout=5000,
+        configuration=[
+            "session.timeout.ms=7000",
+            "max.poll.interval.ms=8000",
+            "auto.offset.reset=earliest",
+            "batch.num.messages={}".format(BATCH_NUM_MESSAGES),
+        ],
+    )
+    for mini_d in dataset:
+        count = 0
+        for _ in mini_d:
+            count += 1
+        assert count == BATCH_NUM_MESSAGES
+        break
+
+
 def test_kafka_batch_io_dataset():
     """Test the functionality of the KafkaBatchIODataset by training a model
     directly on the incoming kafka message batch(of type tf.data.Dataset), in an
@@ -460,7 +492,7 @@ def test_kafka_batch_io_dataset():
 
     dataset = tfio.experimental.streaming.KafkaBatchIODataset(
         topics=["mini-batch-test"],
-        group_id="cgminibatch",
+        group_id="cgminibatchtrain",
         servers=None,
         stream_timeout=5000,
         configuration=[

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -449,20 +449,20 @@ def test_kafka_group_io_dataset_stream_timeout_check():
     )
 
 
-def test_kafka_batch_io_dataset_mini_dataset_size():
+def test_kafka_mini_dataset_size():
     """Test the functionality of batch.num.messages property of
-    KafkaBatchIODataset.
+    KafkaBatchIODataset/KafkaGroupIODataset.
     """
     import tensorflow_io.kafka as kafka_io
 
     # Write new messages to the topic
-    for i in range(10, 10000):
-        message = "{}".format(i)
-        kafka_io.write_kafka(message=message, topic="mini-batch-test")
+    for i in range(200, 10000):
+        message = "D{}".format(i)
+        kafka_io.write_kafka(message=message, topic="key-partition-test")
 
     BATCH_NUM_MESSAGES = 5000
     dataset = tfio.experimental.streaming.KafkaBatchIODataset(
-        topics=["mini-batch-test"],
+        topics=["key-partition-test"],
         group_id="cgminibatchsize",
         servers=None,
         stream_timeout=5000,


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/io/issues/1458 by allowing the users to set the number of records fetched from kafka per `next()` on `KafkaGroupIODataset` and `KafkaBatchIODataset`. (Defaults to 1024).