### PR TITLE
reset mongo cursor after reaching end of collection

### DIFF
--- a/tensorflow_io/python/experimental/mongodb_dataset_ops.py
+++ b/tensorflow_io/python/experimental/mongodb_dataset_ops.py
@@ -29,7 +29,6 @@ class _MongoDBHandler:
         self.uri = uri
         self.database = database
         self.collection = collection
-        self.get_healthy_resource()
 
     def get_healthy_resource(self):
         """Retrieve the resource which is connected to a healthy node"""

--- a/tests/test_mongodb/mongodb_test.sh
+++ b/tests/test_mongodb/mongodb_test.sh
@@ -39,7 +39,7 @@ sleep 60
 
 elif [ "$action" == "stop" ]; then
 echo ""
-echo "Removing the tfio elasticsearch container..."
+echo "Removing the tfio mongodb container..."
 echo ""
 docker rm -f tfio-mongodb
 


### PR DESCRIPTION
This PR resets the mongo cursor after it has reached the end of the collection. This is necessary to restart the fetching process for each epoch in the training process.

Additionally:
- Remove the hard-coded `appname` to allow the users to set an `appname` from the URI itself.
- The BSON to JSON conversion has been modified to simplify parsing each dataset record into a json.