### PR TITLE
raise a proper exception when a dir path is passed to ParquetIODataset

### DIFF
--- a/tensorflow_io/python/ops/parquet_dataset_ops.py
+++ b/tensorflow_io/python/ops/parquet_dataset_ops.py
@@ -27,6 +27,11 @@ class ParquetIODataset(tf.data.Dataset):
         """ParquetIODataset."""
         assert internal
         with tf.name_scope("ParquetIODataset"):
+            if tf.io.gfile.isdir(filename):
+                raise ValueError(
+                    "passing a directory path to 'filename' is not supported. "
+                    "Use 'tf.data.Dataset.list_files()' with a map() operation instead."
+                )
             components, shapes, dtypes = core_ops.io_parquet_readable_info(
                 filename, shared=filename, container="ParquetIODataset"
             )


### PR DESCRIPTION
This PR addresses issue: https://github.com/tensorflow/io/issues/1468 by raising a proper exception when a directory path is passed to `ParquetIODataset`. Thus, preventing inadvertent segfaults.

cc: @GuyPozner 