### PR TITLE
Remove build temporary folder to avoid adding tfio python files in TFIO - 0.19 backport

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,7 @@ jobs:
           python -m pip install -U wheel setuptools
           python --version
           python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_14_x86_64
+          rm -rf build
           python setup.py --project tensorflow-io-gcs-filesystem --data bazel-bin -q bdist_wheel --plat-name macosx_10_14_x86_64
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
@@ -376,6 +377,7 @@ jobs:
           python --version
           python -m pip install -U wheel setuptools
           python setup.py --data bazel-bin -q bdist_wheel
+          rm -rf build
           python setup.py --project tensorflow-io-gcs-filesystem --data bazel-bin -q bdist_wheel
           ls -la dist
       - uses: actions/upload-artifact@v2
@@ -578,6 +580,7 @@ jobs:
           python -m pip install -U wheel setuptools
           python --version
           python setup.py --data bazel-bin -q bdist_wheel --plat-name macosx_10_14_x86_64 --nightly $BUILD_NUMBER
+          rm -rf build
           python setup.py --project tensorflow-io-gcs-filesystem --data bazel-bin -q bdist_wheel --plat-name macosx_10_14_x86_64 --nightly $BUILD_NUMBER
       - name: Auditwheel ${{ matrix.python }} macOS
         run: |
@@ -618,6 +621,7 @@ jobs:
           set -x -e
           mv bazel-bin/tensorflow_io/.bazelrc .
           docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
+          rm -rf build
           docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --project tensorflow-io-gcs-filesystem --data bazel-bin -q bdist_wheel --nightly $BUILD_NUMBER
       - name: Auditwheel ${{ matrix.python }} Linux
         run: |
@@ -662,6 +666,7 @@ jobs:
           python --version
           python -m pip install -U wheel setuptools
           python setup.py --data bazel-bin -q bdist_wheel --nightly %BUILD_NUMBER%
+          rm -rf build
           python setup.py --project tensorflow-io-gcs-filesystem --data bazel-bin -q bdist_wheel --nightly %BUILD_NUMBER%
           ls -la dist
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Same as https://github.com/tensorflow/io/pull/1476 but backported to release 0.19 to release 0.19.1