### PR TITLE
Update README.md and RELEASE.md with 0.19.1 information

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - R0.19
   pull_request:
     branches:
       - master
+      - R0.19
 
 env:
   REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - master
-      - R0.19
   pull_request:
     branches:
       - master
-      - R0.19
 
 env:
   REPO_NAME: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ of releases [here](https://github.com/tensorflow/io/releases).
 
 | TensorFlow I/O Version | TensorFlow Compatibility | Release Date |
 | --- | --- | --- |
+| 0.19.1 | 2.5.x | Jul 23, 2021 |
 | 0.19.0 | 2.5.x | Jun 25, 2021 |
 | 0.18.0 | 2.5.x | May 13, 2021 |
 | 0.17.1 | 2.4.x | Apr 16, 2021 |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ of releases [here](https://github.com/tensorflow/io/releases).
 
 | TensorFlow I/O Version | TensorFlow Compatibility | Release Date |
 | --- | --- | --- |
-| 0.19.1 | 2.5.x | Jul 23, 2021 |
+| 0.19.1 | 2.5.x | Jul 25, 2021 |
 | 0.19.0 | 2.5.x | Jun 25, 2021 |
 | 0.18.0 | 2.5.x | May 13, 2021 |
 | 0.17.1 | 2.4.x | Apr 16, 2021 |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,17 @@
+# Release 0.19.1
+
+## Bug Fixes
+* Fixed wheel issue with tensorflow-io-gcs-filesystem by removing temporary build folder.
+
+## Thanks to our Contributors
+
+This release contains contributions from many people:
+
+Gerard Casas Saez, Kota Yamaguchi, Vignesh Kothapalli, Vo Van Nghia, Yong Tang, emkornfield
+
+We are also grateful to all who filed issues or helped resolve them, asked and
+answered questions, and were part of inspiring discussions.
+
 # Release 0.19.0
 
 ## Major Features


### PR DESCRIPTION
This PR adds README.md and RELEASE.md with 0.19.1 information to master branch (already in v0.19.1 release).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>