### PR TITLE
Fix decode_video returning only the first frame

### DIFF
--- a/tensorflow_io/core/kernels/ffmpeg_kernels.cc
+++ b/tensorflow_io/core/kernels/ffmpeg_kernels.cc
@@ -669,7 +669,7 @@ class FFmpegVideoStream : public FFmpegStream {
     char* base = ((char*)(value->flat<uint8>().data()));
     int64 datasize = height_ * width_ * channels_;
     for (size_t i = 0; i < frames_.size(); i++) {
-      memcpy(base, reinterpret_cast<char*>(frames_buffer_.front().get()),
+      memcpy(base, reinterpret_cast<char*>(frames_buffer_[i].get()),
              datasize);
       base += datasize;
     }

--- a/tensorflow_io/core/kernels/ffmpeg_kernels.cc
+++ b/tensorflow_io/core/kernels/ffmpeg_kernels.cc
@@ -669,8 +669,7 @@ class FFmpegVideoStream : public FFmpegStream {
     char* base = ((char*)(value->flat<uint8>().data()));
     int64 datasize = height_ * width_ * channels_;
     for (size_t i = 0; i < frames_.size(); i++) {
-      memcpy(base, reinterpret_cast<char*>(frames_buffer_[i].get()),
-             datasize);
+      memcpy(base, reinterpret_cast<char*>(frames_buffer_[i].get()), datasize);
       base += datasize;
     }
     frames_.clear();

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -84,6 +84,7 @@ def test_ffmpeg_decode_video(video_path):
     video = tfio.experimental.ffmpeg.decode_video(content, 0)
     assert video.shape == [166, 320, 560, 3]
     assert video.dtype == tf.uint8
+    assert np.abs(video[0] - video[-1]).sum() > 0
 
 
 def test_ffmpeg_decode_video_invalid_content():


### PR DESCRIPTION
This PR fixes the bug in `tfio.experimental.ffmpeg.decode_video` returning the repeated first frame.

Fix #1471 