### PR TITLE
Bump tensorflow to 2.6.0rc2

### DIFF
--- a/tensorflow_io/python/ops/version_ops.py
+++ b/tensorflow_io/python/ops/version_ops.py
@@ -15,4 +15,4 @@
 """version_ops"""
 
 version = "0.20.0"
-require = "tensorflow>=2.6.0rc1,<2.7.0"
+require = "tensorflow>=2.6.0rc2,<2.7.0"


### PR DESCRIPTION
This PR bumps tensorflow to 2.6.0rc2

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>