### PR TITLE
Add release notes for 0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ of releases [here](https://github.com/tensorflow/io/releases).
 
 | TensorFlow I/O Version | TensorFlow Compatibility | Release Date |
 | --- | --- | --- |
+| 0.20.0 | 2.6.x | Aug 11, 2021 |
 | 0.19.1 | 2.5.x | Jul 25, 2021 |
 | 0.19.0 | 2.5.x | Jun 25, 2021 |
 | 0.18.0 | 2.5.x | May 13, 2021 |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,25 @@
+# Release 0.20.0
+
+## Major Features
+* S3 and HDFS file system supports fully migrated from tensorflow to tensorflow-io package.
+* Add tutorial of MongoDB support with tensorflow-io.
+* Add tutorial of ORC support with tensorflow-io
+* Add batched string support for Apache Arrow.
+
+## Bug Fixes
+* Fix decode_video returning only the first frame.
+* Reset mongo cursor after reaching end of collection.
+
+## Thanks to our Contributors
+
+This release contains contributions from many people:
+
+Aleksey Vlasenko, Gerard Casas Saez, Keqiu Hu, Kota Yamaguchi,
+Mark Daoust, Vignesh Kothapalli, Yong Tang, austinzh
+
+We are also grateful to all who filed issues or helped resolve them, asked and
+answered questions, and were part of inspiring discussions.
+
 # Release 0.19.1
 
 ## Bug Fixes


### PR DESCRIPTION
Given TF 2.6's version string has been updated in r2.6 branch:
https://github.com/tensorflow/tensorflow/commits/r2.6

The release of TF 2.6 is imminent I think.

This PR updates release notes for 0.20.0.

We still need to update the dependency package to `tensorflow>=2.6.0`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>