### PR TITLE
switch to stable tensorflow-io package in mongodb tutorial

### DIFF
--- a/docs/tutorials/mongodb.ipynb
+++ b/docs/tutorials/mongodb.ipynb
@@ -103,7 +103,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install tensorflow-io-nightly\n",
+        "!pip install tensorflow-io\n",
         "!pip install pymongo"
       ]
     },


### PR DESCRIPTION
This PR switches to stable `tensorflow-io` package in mongodb tutorial as v0.20.0 has been released.

This is a post-release action item of https://github.com/tensorflow/io/issues/1474

cc: @MarkDaoust