### PR TITLE
Hide the python subpackage from generated docs.

### DIFF
--- a/tensorflow_io/python/api/__init__.py
+++ b/tensorflow_io/python/api/__init__.py
@@ -25,10 +25,10 @@ from tensorflow_io.python.api import audio
 from tensorflow_io.python.api import version
 from tensorflow_io.python.api import experimental
 
-if os.environ.get('GENERATING_TF_DOCS', ''):
-  # Mark these as public api for /tools/docs/build_docs.py
-  from tensorflow_io import arrow
-  from tensorflow_io import bigquery
-  from tensorflow_io import ignite
+if os.environ.get("GENERATING_TF_DOCS", ""):
+    # Mark these as public api for /tools/docs/build_docs.py
+    from tensorflow_io import arrow
+    from tensorflow_io import bigquery
+    from tensorflow_io import ignite
 
 del os

--- a/tensorflow_io/python/api/__init__.py
+++ b/tensorflow_io/python/api/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """tensorflow_io"""
+import os
 
 # tensorflow_io.core.python.ops is implicitly imported (along with file system)
 from tensorflow_io.python.ops.io_dataset import IODataset
@@ -23,3 +24,11 @@ from tensorflow_io.python.api import image
 from tensorflow_io.python.api import audio
 from tensorflow_io.python.api import version
 from tensorflow_io.python.api import experimental
+
+if os.environ.get('GENERATING_TF_DOCS', ''):
+  # Mark these as public api for /tools/docs/build_docs.py
+  from tensorflow_io import arrow
+  from tensorflow_io import bigquery
+  from tensorflow_io import ignite
+
+del os

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -38,10 +38,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import pathlib
+
 from absl import app
 from absl import flags
 
-import tensorflow_io as tfio
+import tensorflow_io.python.api as tfio
 
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import parser
@@ -93,10 +95,10 @@ def main(argv):
         root_title=PROJECT_FULL_NAME,
         # Replace `tensorflow_docs` with your module, here.
         py_modules=[(PROJECT_SHORT_NAME, tfio)],
+        base_dir=pathlib.Path(tfio.__file__).parents[2],
         code_url_prefix=code_url_prefix,
-        private_map={'tfio': ['__version__', 'utils', 'version', 'core']},
         # This callback cleans up a lot of aliases caused by internal imports.
-        callbacks=[],
+        callbacks=[public_api.explicit_package_contents_filter],
         search_hints=FLAGS.search_hints,
         site_path=FLAGS.site_path)
 

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -50,9 +50,6 @@ from tensorflow_docs.api_generator import parser
 from tensorflow_docs.api_generator import public_api
 from tensorflow_docs.api_generator import utils
 
-# tfio doesn't eagerly import submodules.
-utils.recursive_import(tfio)
-
 PROJECT_SHORT_NAME = 'tfio'
 PROJECT_FULL_NAME = 'TensorFlow I/O'
 

--- a/tools/docs/build_docs.py
+++ b/tools/docs/build_docs.py
@@ -38,11 +38,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
 import pathlib
 
 from absl import app
 from absl import flags
 
+os.environ["GENERATING_TF_DOCS"] = "True"
 import tensorflow_io.python.api as tfio
 
 from tensorflow_docs.api_generator import generate_lib


### PR DESCRIPTION
Something about the package structure changed since the last time the api_docs were generated.

Running the script as it was was outputting ~200 symbols under `tfio.python`.

This change to the doc generator switches the project to use the "explicit_package_contents_filter". This mode documents anything imported in an __init__ file, recursively.

Running this on the `tfio.python.api` file gives the following change in output, relative to last time:

```
+/tmp/io_after
 ├── tfio
 │   ├── all_symbols.md
-│   ├── arrow
-│   │   ├── ArrowDataset.md
-│   │   ├── ArrowFeatherDataset.md
-│   │   ├── ArrowStreamDataset.md
-│   │   └── list_feather_columns.md
-│   ├── arrow.md
+│   ├── _api_cache.json
 │   ├── audio
 │   │   ├── AudioIODataset.md
 │   │   ├── AudioIOTensor.md
@@ -31,14 +26,6 @@ third_party/devsite/tensorflow/en/io/api_docs/python/
 │   │   ├── time_mask.md
 │   │   └── trim.md
 │   ├── audio.md
-│   ├── bigquery
-│   │   ├── BigQueryClient
-│   │   │   ├── DataFormat.md
-│   │   │   └── FieldMode.md
-│   │   ├── BigQueryClient.md
-│   │   ├── BigQueryReadSession.md
-│   │   └── BigQueryTestClient.md
-│   ├── bigquery.md
 │   ├── experimental
 │   │   ├── color
 │   │   │   ├── bgr_to_rgb.md
@@ -75,6 +62,9 @@ third_party/devsite/tensorflow/en/io/api_docs/python/
 │   │   ├── ffmpeg
 │   │   │   └── decode_video.md
 │   │   ├── ffmpeg.md
+│   │   ├── filesystem
+│   │   │   └── set_configuration.md
+│   │   ├── filesystem.md
 │   │   ├── filter
 │   │   │   ├── gabor.md
 │   │   │   ├── gaussian.md
@@ -130,9 +120,6 @@ third_party/devsite/tensorflow/en/io/api_docs/python/
 │   │   ├── read_fastq.md
 │   │   └── sequences_to_onehot.md
 │   ├── genome.md
-│   ├── ignite
-│   │   └── IgniteDataset.md
-│   ├── ignite.md
 │   ├── image
 │   │   ├── decode_dicom_data.md
 │   │   ├── decode_dicom_image.md
@@ -143,8 +130,8 @@ third_party/devsite/tensorflow/en/io/api_docs/python/
 │   ├── image.md
 │   ├── IODataset.md
 │   ├── IOTensor.md
-│   ├── _redirects.yaml
-│   └── _toc.yaml
+│   ├── _toc.yaml
+│   └── version.md
 └── tfio.md
```


This looks better, except we've lost `Arrow` , `Bigquery` and `Ignite`. 
Is that intentional or should these be included?