### PR TITLE
fix the parquet dataset creation with list_files and map.

### DIFF
--- a/tensorflow_io/core/kernels/parquet_kernels.cc
+++ b/tensorflow_io/core/kernels/parquet_kernels.cc
@@ -31,6 +31,12 @@ class ParquetReadableResource : public ResourceBase {
 
   Status Init(const string& input) {
     mutex_lock l(mu_);
+    Status status = env_->IsDirectory(input);
+    if (status.ok()) {
+      return errors::InvalidArgument(
+          "passing a directory path to 'filename' is not supported. ",
+          "Use 'tf.data.Dataset.list_files()' with a map() operation instead.");
+    }
 
     file_.reset(new SizedRandomAccessFile(env_, input, nullptr, 0));
     TF_RETURN_IF_ERROR(file_->GetFileSize(&file_size_));

--- a/tensorflow_io/python/ops/parquet_dataset_ops.py
+++ b/tensorflow_io/python/ops/parquet_dataset_ops.py
@@ -27,11 +27,6 @@ class ParquetIODataset(tf.data.Dataset):
         """ParquetIODataset."""
         assert internal
         with tf.name_scope("ParquetIODataset"):
-            if tf.io.gfile.isdir(filename):
-                raise ValueError(
-                    "passing a directory path to 'filename' is not supported. "
-                    "Use 'tf.data.Dataset.list_files()' with a map() operation instead."
-                )
             components, shapes, dtypes = core_ops.io_parquet_readable_info(
                 filename, shared=filename, container="ParquetIODataset"
             )


### PR DESCRIPTION
This PR addresses the issue: https://github.com/tensorflow/io/issues/1504 along with https://github.com/tensorflow/io/issues/1468. The change moves the `filename` IsDirectory check to the cc layer from python layer. This allows the users to use `tf.data.Dataset.list_files(...)` and `map()` to load multiple parquet files into a dataset.
Tests have been added to assert this behaviour.