### PR TITLE
Fix HDFS append to non-existent file error

### DIFF
--- a/tests/test_hdfs/hdfs_test.sh
+++ b/tests/test_hdfs/hdfs_test.sh
@@ -21,6 +21,16 @@ HADOOP_RELEASE_TAG="3.2.1"
 curl -OL https://github.com/big-data-europe/docker-hadoop/archive/refs/tags/$HADOOP_RELEASE_TAG.tar.gz
 tar -xzf $HADOOP_RELEASE_TAG.tar.gz -C /tmp/
 cd /tmp/docker-hadoop-$HADOOP_RELEASE_TAG
+# Add following properties
+# to prevent following error when closing the hdfs client:
+#
+# java.io.IOException: Failed to replace a bad datanode on the existing pipeline due to no more good datanodes
+# being available to try.
+
+echo "
+HDFS_CONF_dfs_client_block_write_replace___datanode___on___failure_enable=true
+HDFS_CONF_dfs_client_block_write_replace___datanode___on___failure_policy=NEVER" >> hadoop.env
+
 docker-compose up -d
 echo "Hadoop up"
 exit 0


### PR DESCRIPTION
This PR fixes the error below:
Writing to HDFS from the snapshot writer generates the following exception
```
Caused by: org.apache.hadoop.ipc.RemoteException(java.io.FileNotFoundException): Failed to append to non-existent file 
```

This is because HDFS expects files opened for "append" to already exist. This change checks the existence of files, and if it does not exist, then opens them for "write" instead of "append".
