### PR TITLE
Bump TF to 2.7.0

### DIFF
--- a/.github/workflows/build.bazel.sh
+++ b/.github/workflows/build.bazel.sh
@@ -15,23 +15,31 @@
 # ==============================================================================
 set -e -x
 
-export TENSORFLOW_INSTALL="$(python3 setup.py --install-require)"
+
+PYTHON=python3
+if [[ $# == 1 ]]; then
+    PYTHON=$1
+fi
+$PYTHON --version
+
+export TENSORFLOW_INSTALL="$($PYTHON setup.py --install-require)"
 
 export BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
 export BAZEL_VERSION=$(cat .bazelversion)
+export PYTHON_BIN_PATH=`which $PYTHON`
 curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
 bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
 bazel version
 
-python3 -m pip --version
+$PYTHON -m pip --version
 
-python3 -m pip install --upgrade pip
-python3 -m pip install --upgrade setuptools
-python3 -m pip --version
+$PYTHON -m pip install --upgrade pip
+$PYTHON -m pip install --upgrade setuptools
+$PYTHON -m pip --version
 
-python3 -m pip install -q ${TENSORFLOW_INSTALL}
+$PYTHON -m pip install -q ${TENSORFLOW_INSTALL}
 
-python3 tools/build/configure.py
+$PYTHON tools/build/configure.py
 
 cat .bazelrc
 

--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -2,6 +2,7 @@ set -e
 
 export TF_AZURE_USE_DEV_STORAGE=1
 export TF_USE_MODULAR_FILESYSTEM=1
+export PYTHONPATH=${PYTHONPATH}:${CWD}/tests
 
 run_test() {
   entry=$1

--- a/.github/workflows/build.wheel.sh
+++ b/.github/workflows/build.wheel.sh
@@ -2,7 +2,6 @@ set -e
 
 export TF_AZURE_USE_DEV_STORAGE=1
 export TF_USE_MODULAR_FILESYSTEM=1
-export PYTHONPATH=${PYTHONPATH}:${CWD}/tests
 
 run_test() {
   entry=$1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,6 @@ jobs:
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
-          echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
-          export PATH=/usr/bin:$PATH
           echo $PATH
           python3 --version
           python3 -c 'import site; print(site.getsitepackages())'
@@ -117,9 +115,7 @@ jobs:
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
-          echo "Bring /usr/bin to front as GitHub does not use system python3 by default"
-          export PATH=/usr/bin:$PATH
-          sudo -E bash -e .github/workflows/build.bazel.sh
+          sudo -E -H bash -e .github/workflows/build.bazel.sh
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-bazel-bin
@@ -133,7 +129,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -210,7 +206,7 @@ jobs:
     name: Bazel Linux
     runs-on: ubuntu-latest
     container:
-      image: gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@sha256:3a9b4820021801b1fa7d0592c1738483ac7abc209fc6ee8c9ef06cf2eab2d170
+      image: gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010
       env:
         REPO_NAME: ${{ env.REPO_NAME }}
         EVENT_NAME: ${{ env.EVENT_NAME }}
@@ -229,7 +225,7 @@ jobs:
           if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
             export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
           fi
-          bash -x -e .github/workflows/build.bazel.sh
+          bash -x -e .github/workflows/build.bazel.sh python3.8
           sudo cp .bazelrc build/tensorflow_io/
       - uses: actions/upload-artifact@v2
         with:
@@ -244,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -328,10 +324,10 @@ jobs:
         shell: cmd
         run: |
           @echo on
-          set "BAZEL_OPTIMIZATION=--config=cache"
+          set "BAZEL_OPTIMIZATION="
           if "%EVENT_NAME%" == "push" (
             if "%REPO_NAME%" == "tensorflow/io" (
-              set "BAZEL_OPTIMIZATION=%BAZEL_OPTIMIZATION% --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+              set "BAZEL_OPTIMIZATION=--remote_upload_local_results=true --google_credentials=service_account_creds.json"
             )
           )
           set /P BAZEL_VERSION=< .bazelversion
@@ -361,7 +357,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -449,10 +445,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: macOS-3.6-wheel
-          path: macOS-3.6-wheel
-      - uses: actions/download-artifact@v1
-        with:
           name: macOS-3.7-wheel
           path: macOS-3.7-wheel
       - uses: actions/download-artifact@v1
@@ -465,10 +457,6 @@ jobs:
           path: macOS-3.9-wheel
       - uses: actions/download-artifact@v1
         with:
-          name: Linux-3.6-wheel
-          path: Linux-3.6-wheel
-      - uses: actions/download-artifact@v1
-        with:
           name: Linux-3.7-wheel
           path: Linux-3.7-wheel
       - uses: actions/download-artifact@v1
@@ -479,10 +467,6 @@ jobs:
         with:
           name: Linux-3.9-wheel
           path: Linux-3.9-wheel
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.6-wheel
-          path: Windows-3.6-wheel
       - uses: actions/download-artifact@v1
         with:
           name: Windows-3.7-wheel
@@ -498,15 +482,12 @@ jobs:
       - run: |
           set -e -x
           mkdir -p wheelhouse
-          cp macOS-3.6-wheel/*.whl wheelhouse/
           cp macOS-3.7-wheel/*.whl wheelhouse/
           cp macOS-3.8-wheel/*.whl wheelhouse/
           cp macOS-3.9-wheel/*.whl wheelhouse/
-          cp Linux-3.6-wheel/*.whl wheelhouse/
           cp Linux-3.7-wheel/*.whl wheelhouse/
           cp Linux-3.8-wheel/*.whl wheelhouse/
           cp Linux-3.9-wheel/*.whl wheelhouse/
-          cp Windows-3.6-wheel/*.whl wheelhouse/
           cp Windows-3.7-wheel/*.whl wheelhouse/
           cp Windows-3.8-wheel/*.whl wheelhouse/
           cp Windows-3.9-wheel/*.whl wheelhouse/
@@ -560,7 +541,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -605,7 +586,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -645,7 +626,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -683,10 +664,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: macOS-3.6-nightly
-          path: macOS-3.6-nightly
-      - uses: actions/download-artifact@v1
-        with:
           name: macOS-3.7-nightly
           path: macOS-3.7-nightly
       - uses: actions/download-artifact@v1
@@ -699,10 +676,6 @@ jobs:
           path: macOS-3.9-nightly
       - uses: actions/download-artifact@v1
         with:
-          name: Linux-3.6-nightly
-          path: Linux-3.6-nightly
-      - uses: actions/download-artifact@v1
-        with:
           name: Linux-3.7-nightly
           path: Linux-3.7-nightly
       - uses: actions/download-artifact@v1
@@ -713,10 +686,6 @@ jobs:
         with:
           name: Linux-3.9-nightly
           path: Linux-3.9-nightly
-      - uses: actions/download-artifact@v1
-        with:
-          name: Windows-3.6-nightly
-          path: Windows-3.6-nightly
       - uses: actions/download-artifact@v1
         with:
           name: Windows-3.7-nightly
@@ -732,15 +701,12 @@ jobs:
       - run: |
           set -e -x
           mkdir -p dist
-          cp macOS-3.6-nightly/tensorflow_io_nightly*.whl dist/
           cp macOS-3.7-nightly/tensorflow_io_nightly*.whl dist/
           cp macOS-3.8-nightly/tensorflow_io_nightly*.whl dist/
           cp macOS-3.9-nightly/tensorflow_io_nightly*.whl dist/
-          cp Linux-3.6-nightly/tensorflow_io_nightly*.whl dist/
           cp Linux-3.7-nightly/tensorflow_io_nightly*.whl dist/
           cp Linux-3.8-nightly/tensorflow_io_nightly*.whl dist/
           cp Linux-3.9-nightly/tensorflow_io_nightly*.whl dist/
-          cp Windows-3.6-nightly/tensorflow_io_nightly*.whl dist/
           cp Windows-3.7-nightly/tensorflow_io_nightly*.whl dist/
           cp Windows-3.8-nightly/tensorflow_io_nightly*.whl dist/
           cp Windows-3.9-nightly/tensorflow_io_nightly*.whl dist/
@@ -754,15 +720,12 @@ jobs:
           set -e -x
           rm -rf dist
           mkdir -p dist
-          cp macOS-3.6-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp macOS-3.7-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp macOS-3.8-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp macOS-3.9-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
-          cp Linux-3.6-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Linux-3.7-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Linux-3.8-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Linux-3.9-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
-          cp Windows-3.6-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Windows-3.7-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Windows-3.8-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Windows-3.9-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,17 +132,16 @@ switched_rules_by_language(
 # Note rules_python is placed earlier as tensorflow's version is older
 http_archive(
     name = "rules_python",
-    sha256 = "c911dc70f62f507f3a361cbc21d6e0d502b91254382255309bc60b7a0f48de28",
-    strip_prefix = "rules_python-38f86fb55b698c51e8510c807489c9f4e047480e",
+    sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/rules_python/archive/38f86fb55b698c51e8510c807489c9f4e047480e.tar.gz",
-        "https://github.com/bazelbuild/rules_python/archive/38f86fb55b698c51e8510c807489c9f4e047480e.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
+        "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
     ],
 )
 
-load("@rules_python//python:pip.bzl", "pip3_import")
+load("@rules_python//python:pip.bzl", "pip_import")
 
-pip3_import(
+pip_import(
     name = "lint_dependencies",
     requirements = "//tools/lint:requirements.txt",
 )
@@ -153,10 +152,10 @@ pip_install()
 
 http_archive(
     name = "org_tensorflow",
-    sha256 = "41b32eeaddcbc02b0583660bcf508469550e4cd0f86b22d2abe72dfebeacde0f",
-    strip_prefix = "tensorflow-2.6.0",
+    sha256 = "bb124905c7fdacd81e7c842b287c169bbf377d29c74c9dacc04f96c9793747bb",
+    strip_prefix = "tensorflow-2.7.0",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.6.0.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.7.0.tar.gz",
     ],
 )
 

--- a/tensorflow_io/python/ops/version_ops.py
+++ b/tensorflow_io/python/ops/version_ops.py
@@ -15,4 +15,4 @@
 """version_ops"""
 
 version = "0.21.0"
-require = "tensorflow>=2.6.0,<2.7.0"
+require = "tensorflow>=2.7.0,<2.8.0"

--- a/third_party/toolchains/tf/BUILD.tpl
+++ b/third_party/toolchains/tf/BUILD.tpl
@@ -7,6 +7,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:cord",


### PR DESCRIPTION
This PR bumps the TensorFlow (dependency) version to 2.7.0