### PR TITLE
Remove python 3.6 from setup.py description.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,10 +324,10 @@ jobs:
         shell: cmd
         run: |
           @echo on
-          set "BAZEL_OPTIMIZATION="
+          set "BAZEL_OPTIMIZATION=--config=cache"
           if "%EVENT_NAME%" == "push" (
             if "%REPO_NAME%" == "tensorflow/io" (
-              set "BAZEL_OPTIMIZATION=--remote_upload_local_results=true --google_credentials=service_account_creds.json"
+              set "BAZEL_OPTIMIZATION=%BAZEL_OPTIMIZATION% --remote_upload_local_results=true --google_credentials=service_account_creds.json"
             )
           )
           set /P BAZEL_VERSION=< .bazelversion

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,8 @@ with open(os.path.join(here, "tensorflow_io/python/ops/version_ops.py")) as f:
     entries = [e.strip() for e in f.readlines() if not e.startswith("#")]
     assert sum(e.startswith("version = ") for e in entries) == 1
     assert sum(e.startswith("require = ") for e in entries) == 1
-    version = list([e[10:] for e in entries if e.startswith("version = ")])[0].strip(
-        '"'
-    )
-    require = list([e[10:] for e in entries if e.startswith("require = ")])[0].strip(
-        '"'
-    )
+    version = list(e[10:] for e in entries if e.startswith("version = "))[0].strip('"')
+    require = list(e[10:] for e in entries if e.startswith("require = "))[0].strip('"')
     assert version != ""
     assert require != ""
 
@@ -77,16 +73,14 @@ if "--nightly" in sys.argv:
 
 install_requires = []
 if project == "tensorflow-io":
-    install_requires = ["{}=={}".format(e, version) for e in subpackages]
+    install_requires = [f"{e}=={version}" for e in subpackages]
 elif project == "tensorflow-io-nightly":
-    install_requires = [
-        "{}-nightly=={}".format(e, version) for e in subpackages
-    ]
+    install_requires = [f"{e}-nightly=={version}" for e in subpackages]
 
-print("Project: {}".format(project))
-print("Exclude: {}".format(exclude))
-print("Install Requires: {}".format(install_requires))
-print("Project Rootpath: {}".format(project_rootpath))
+print(f"Project: {project}")
+print(f"Exclude: {exclude}")
+print(f"Install Requires: {install_requires}")
+print(f"Project Rootpath: {project_rootpath}")
 
 datapath = None
 if "--data" in sys.argv:
@@ -99,9 +93,7 @@ else:
 
 if (datapath is not None) and ("bdist_wheel" in sys.argv):
     rootpath = tempfile.mkdtemp()
-    print(
-        "setup.py - create {} and copy {} data files".format(rootpath, project_rootpath)
-    )
+    print(f"setup.py - create {rootpath} and copy {project_rootpath} data files")
     for rootname, _, filenames in os.walk(os.path.join(datapath, project_rootpath)):
         if not fnmatch.fnmatch(rootname, "*test*") and not fnmatch.fnmatch(
             rootname, "*runfiles*"
@@ -127,7 +119,7 @@ if (datapath is not None) and ("bdist_wheel" in sys.argv):
                     rootpath,
                     os.path.relpath(os.path.join(rootname, filename), datapath),
                 )
-                print("setup.py - copy {} to {}".format(src, dst))
+                print(f"setup.py - copy {src} to {dst}")
                 os.makedirs(os.path.dirname(dst), exist_ok=True)
                 shutil.copyfile(src, dst)
     sys.argv.append("--bdist-dir")
@@ -160,7 +152,6 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -178,11 +169,13 @@ setuptools.setup(
     install_requires=install_requires,
     extras_require={
         "tensorflow": [require],
-        "tensorflow-gpu": [require.replace('tensorflow', 'tensorflow-gpu')],
-        "tensorflow-cpu": [require.replace('tensorflow', 'tensorflow-cpu')],
-        "tensorflow-rocm": [require.replace('tensorflow', 'tensorflow-rocm')],
+        "tensorflow-gpu": [require.replace("tensorflow", "tensorflow-gpu")],
+        "tensorflow-cpu": [require.replace("tensorflow", "tensorflow-cpu")],
+        "tensorflow-rocm": [require.replace("tensorflow", "tensorflow-rocm")],
     },
-    package_data={".": ["*.so"],},
+    package_data={
+        ".": ["*.so"],
+    },
     project_urls={
         "Source": "https://github.com/tensorflow/io",
         "Bug Reports": "https://github.com/tensorflow/io/issues",


### PR DESCRIPTION
This PR removes python 3.6 from setup.py description
as support has been dropped.

In addition, this PR also:
1. Reformat setup.py with black and pyupgrade (py3.7+).
2. Re-introduce bacel cache for Windows build, as our build has been stablized with TF 2.7.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>