### PR TITLE
Update Kafka to 2.7.2

### DIFF
--- a/docs/tutorials/kafka.ipynb
+++ b/docs/tutorials/kafka.ipynb
@@ -182,8 +182,8 @@
       },
       "outputs": [],
       "source": [
-        "!curl -sSOL https://downloads.apache.org/kafka/2.7.0/kafka_2.13-2.7.0.tgz\n",
-        "!tar -xzf kafka_2.13-2.7.0.tgz"
+        "!curl -sSOL https://downloads.apache.org/kafka/2.7.2/kafka_2.13-2.7.2.tgz\n",
+        "!tar -xzf kafka_2.13-2.7.2.tgz"
       ]
     },
     {
@@ -203,8 +203,8 @@
       },
       "outputs": [],
       "source": [
-        "!./kafka_2.13-2.7.0/bin/zookeeper-server-start.sh -daemon ./kafka_2.13-2.7.0/config/zookeeper.properties\n",
-        "!./kafka_2.13-2.7.0/bin/kafka-server-start.sh -daemon ./kafka_2.13-2.7.0/config/server.properties\n",
+        "!./kafka_2.13-2.7.2/bin/zookeeper-server-start.sh -daemon ./kafka_2.13-2.7.2/config/zookeeper.properties\n",
+        "!./kafka_2.13-2.7.2/bin/kafka-server-start.sh -daemon ./kafka_2.13-2.7.2/config/server.properties\n",
         "!echo \"Waiting for 10 secs until kafka and zookeeper services are up and running\"\n",
         "!sleep 10\n"
       ]
@@ -249,8 +249,8 @@
       },
       "outputs": [],
       "source": [
-        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --create --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 1 --topic susy-train\n",
-        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --create --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 2 --topic susy-test\n"
+        "!./kafka_2.13-2.7.2/bin/kafka-topics.sh --create --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 1 --topic susy-train\n",
+        "!./kafka_2.13-2.7.2/bin/kafka-topics.sh --create --bootstrap-server 127.0.0.1:9092 --replication-factor 1 --partitions 2 --topic susy-test\n"
       ]
     },
     {
@@ -270,8 +270,8 @@
       },
       "outputs": [],
       "source": [
-        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --describe --bootstrap-server 127.0.0.1:9092 --topic susy-train\n",
-        "!./kafka_2.13-2.7.0/bin/kafka-topics.sh --describe --bootstrap-server 127.0.0.1:9092 --topic susy-test\n"
+        "!./kafka_2.13-2.7.2/bin/kafka-topics.sh --describe --bootstrap-server 127.0.0.1:9092 --topic susy-train\n",
+        "!./kafka_2.13-2.7.2/bin/kafka-topics.sh --describe --bootstrap-server 127.0.0.1:9092 --topic susy-test\n"
       ]
     },
     {
@@ -722,7 +722,7 @@
       },
       "outputs": [],
       "source": [
-        "!./kafka_2.13-2.7.0/bin/kafka-consumer-groups.sh --bootstrap-server 127.0.0.1:9092 --describe --group testcg\n"
+        "!./kafka_2.13-2.7.2/bin/kafka-consumer-groups.sh --bootstrap-server 127.0.0.1:9092 --describe --group testcg\n"
       ]
     },
     {


### PR DESCRIPTION
The [previous archive](https://downloads.apache.org/kafka/2.7.0/kafka_2.13-2.7.0.tgz) has been removed, so the notebook isn't starting the kafka brokers.

This will expose the error causing failures in #1569.