### PR TITLE
[docs] handle empty mini_ds from kafka during online training

### DIFF
--- a/docs/tutorials/kafka.ipynb
+++ b/docs/tutorials/kafka.ipynb
@@ -805,7 +805,8 @@
         "  mini_ds = mini_ds.shuffle(buffer_size=32)\n",
         "  mini_ds = mini_ds.map(decode_kafka_online_item)\n",
         "  mini_ds = mini_ds.batch(32)\n",
-        "  model.fit(mini_ds, epochs=3)\n"
+        "  if len(mini_ds) > 0:\n",
+        "    model.fit(mini_ds, epochs=3)"
       ]
     },
     {


### PR DESCRIPTION
This PR fixes the issue https://github.com/tensorflow/io/issues/1569 by handling empty mini datasets in the online training section of the tutorial. The reason why the online dataset is returning the empty mini_ds might need some further investigation later.

cc: @markmcd @MarkDaoust 