### PR TITLE
Enable python 3.10 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -388,7 +388,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -168,7 +168,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -357,7 +357,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -388,7 +388,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v1
@@ -458,6 +458,10 @@ jobs:
           path: macOS-3.9-wheel
       - uses: actions/download-artifact@v1
         with:
+          name: macOS-3.10-wheel
+          path: macOS-3.10-wheel
+      - uses: actions/download-artifact@v1
+        with:
           name: Linux-3.7-wheel
           path: Linux-3.7-wheel
       - uses: actions/download-artifact@v1
@@ -470,6 +474,10 @@ jobs:
           path: Linux-3.9-wheel
       - uses: actions/download-artifact@v1
         with:
+          name: Linux-3.10-wheel
+          path: Linux-3.10-wheel
+      - uses: actions/download-artifact@v1
+        with:
           name: Windows-3.7-wheel
           path: Windows-3.7-wheel
       - uses: actions/download-artifact@v1
@@ -480,18 +488,25 @@ jobs:
         with:
           name: Windows-3.9-wheel
           path: Windows-3.9-wheel
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.10-wheel
+          path: Windows-3.10-wheel
       - run: |
           set -e -x
           mkdir -p wheelhouse
           cp macOS-3.7-wheel/*.whl wheelhouse/
           cp macOS-3.8-wheel/*.whl wheelhouse/
           cp macOS-3.9-wheel/*.whl wheelhouse/
+          cp macOS-3.10-wheel/*.whl wheelhouse/
           cp Linux-3.7-wheel/*.whl wheelhouse/
           cp Linux-3.8-wheel/*.whl wheelhouse/
           cp Linux-3.9-wheel/*.whl wheelhouse/
+          cp Linux-3.10-wheel/*.whl wheelhouse/
           cp Windows-3.7-wheel/*.whl wheelhouse/
           cp Windows-3.8-wheel/*.whl wheelhouse/
           cp Windows-3.9-wheel/*.whl wheelhouse/
+          cp Windows-3.10-wheel/*.whl wheelhouse/
           ls -la wheelhouse/
           sha256sum wheelhouse/*.whl
       - uses: actions/upload-artifact@v2
@@ -542,7 +557,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -587,7 +602,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -627,7 +642,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/download-artifact@v1
         with:
@@ -677,6 +692,10 @@ jobs:
           path: macOS-3.9-nightly
       - uses: actions/download-artifact@v1
         with:
+          name: macOS-3.10-nightly
+          path: macOS-3.10-nightly
+      - uses: actions/download-artifact@v1
+        with:
           name: Linux-3.7-nightly
           path: Linux-3.7-nightly
       - uses: actions/download-artifact@v1
@@ -689,6 +708,10 @@ jobs:
           path: Linux-3.9-nightly
       - uses: actions/download-artifact@v1
         with:
+          name: Linux-3.10-nightly
+          path: Linux-3.10-nightly
+      - uses: actions/download-artifact@v1
+        with:
           name: Windows-3.7-nightly
           path: Windows-3.7-nightly
       - uses: actions/download-artifact@v1
@@ -699,18 +722,25 @@ jobs:
         with:
           name: Windows-3.9-nightly
           path: Windows-3.9-nightly
+      - uses: actions/download-artifact@v1
+        with:
+          name: Windows-3.10-nightly
+          path: Windows-3.10-nightly
       - run: |
           set -e -x
           mkdir -p dist
           cp macOS-3.7-nightly/tensorflow_io_nightly*.whl dist/
           cp macOS-3.8-nightly/tensorflow_io_nightly*.whl dist/
           cp macOS-3.9-nightly/tensorflow_io_nightly*.whl dist/
+          cp macOS-3.10-nightly/tensorflow_io_nightly*.whl dist/
           cp Linux-3.7-nightly/tensorflow_io_nightly*.whl dist/
           cp Linux-3.8-nightly/tensorflow_io_nightly*.whl dist/
           cp Linux-3.9-nightly/tensorflow_io_nightly*.whl dist/
+          cp Linux-3.10-nightly/tensorflow_io_nightly*.whl dist/
           cp Windows-3.7-nightly/tensorflow_io_nightly*.whl dist/
           cp Windows-3.8-nightly/tensorflow_io_nightly*.whl dist/
           cp Windows-3.9-nightly/tensorflow_io_nightly*.whl dist/
+          cp Windows-3.10-nightly/tensorflow_io_nightly*.whl dist/
           ls -la dist/
           sha256sum dist/*.whl
       - uses: pypa/gh-action-pypi-publish@master
@@ -724,12 +754,15 @@ jobs:
           cp macOS-3.7-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp macOS-3.8-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp macOS-3.9-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
+          cp macOS-3.10-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Linux-3.7-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Linux-3.8-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Linux-3.9-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
+          cp Linux-3.10-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Windows-3.7-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Windows-3.8-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           cp Windows-3.9-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
+          cp Windows-3.10-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           ls -la dist/
           sha256sum dist/*.whl
       - uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
This PR enables python 3.10 build as the next tensorflow (TF 2.8) release will support 3.10. Since tensorflow depends on tensorflow-io-gcs-filesystem, we will need to release a 3.10 version before 2.8.

This PR disables 3.10 test for now, as we cannot run test until TF 2.8 is released.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
