### PR TITLE
Remove pdb and other unneeded files from Windows build directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,9 +341,10 @@ jobs:
           cat .bazelrc
           bazel build -s %BAZEL_OPTIMIZATION% //tensorflow_io:python/ops/libtensorflow_io.so //tensorflow_io:python/ops/libtensorflow_io_plugins.so  //tensorflow_io_gcs_filesystem/...
           if %errorlevel% neq 0 exit /b %errorlevel%
-          mkdir build
+          mkdir -p build
           cp -r bazel-bin/tensorflow_io build
           cp -r bazel-bin/tensorflow_io_gcs_filesystem build
+          bash -c "find build -not -name '*.so' -type f | xargs rm -rf"
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-bazel-bin


### PR DESCRIPTION
This PR remove pdb and other unneeded files from Windows build directory,
so that it is possible to upload the artifact to GitHub Actions
(seems the previous failure was caused by artifact too large).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>