### PR TITLE
upgrading docker devel image to use python3.7 and updating documentation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -217,35 +217,6 @@ TFIO_DATAPATH=bazel-bin \
     'python3 -m pytest -s -v tests/test_serialization.py'
 ```
 
-#### Python Wheels
-
-It is possible to build python wheels after bazel build is complete with the following command:
-```
-$ python3 setup.py bdist_wheel --data bazel-bin
-```
-The .whl file will be available in dist directory. Note the bazel binary directory `bazel-bin`
-has to be passed with `--data` args in order for setup.py to locate the necessary share objects,
-as `bazel-bin` is outside of the `tensorflow_io` package directory.
-
-Alternatively, source install could be done with:
-```
-$ TFIO_DATAPATH=bazel-bin python3 -m pip install .
-```
-with `TFIO_DATAPATH=bazel-bin` passed for the same reason.
-
-Note installing with `-e` is different from the above. The
-```
-$ TFIO_DATAPATH=bazel-bin python3 -m pip install -e .
-```
-will not install shared object automatically even with `TFIO_DATAPATH=bazel-bin`. Instead,
-`TFIO_DATAPATH=bazel-bin` has to be passed everytime the program is run after the install:
-```
-$ TFIO_DATAPATH=bazel-bin python3
-
->>> import tensorflow_io as tfio
->>> ...
-```
-
 #### Docker
 
 For Python development, a reference Dockerfile [here](tools/docker/devel.Dockerfile) can be
@@ -268,7 +239,7 @@ $ docker run -it --rm --name tfio-dev --net=host -v ${PWD}:/v -w /v tfsigio/tfio
 # NOTE: Based on the available resources, please change the number of job workers to:
 # -j 4/8/16 to prevent bazel server terminations and resource oriented build errors.
 
-(tfio-dev) root@docker-desktop:/v$ bazel build -j 8 --copt=-msse4.2 --copt=-mavx --compilation_mode=opt --verbose_failures --test_output=errors --crosstool_top=//third_party/toolchains/gcc7_manylinux2010:toolchain //tensorflow_io/...
+(tfio-dev) root@docker-desktop:/v$ bazel build -j 8 --copt=-msse4.2 --copt=-mavx --compilation_mode=opt --verbose_failures --test_output=errors --crosstool_top=//third_party/toolchains/gcc7_manylinux2010:toolchain //tensorflow_io/... //tensorflow_io_gcs_filesystem/...
 
 
 # Run tests with PyTest, note: some tests require launching additional containers to run (see below)
@@ -289,6 +260,35 @@ NOTE: While the tfio-dev container gives developers an easy to work with
 environment, the released whl packages are built differently due to manylinux2010
 requirements. Please check [Build Status and CI] section for more details
 on how the released whl packages are generated.
+
+#### Python Wheels
+
+It is possible to build python wheels after bazel build is complete with the following command:
+```
+$ python setup.py bdist_wheel --data bazel-bin
+```
+The .whl file will be available in dist directory. Note the bazel binary directory `bazel-bin`
+has to be passed with `--data` args in order for setup.py to locate the necessary share objects,
+as `bazel-bin` is outside of the `tensorflow_io` package directory.
+
+Alternatively, source install could be done with:
+```
+$ TFIO_DATAPATH=bazel-bin python -m pip install .
+```
+with `TFIO_DATAPATH=bazel-bin` passed for the same reason.
+
+Note installing with `-e` is different from the above. The
+```
+$ TFIO_DATAPATH=bazel-bin python -m pip install -e .
+```
+will not install shared object automatically even with `TFIO_DATAPATH=bazel-bin`. Instead,
+`TFIO_DATAPATH=bazel-bin` has to be passed everytime the program is run after the install:
+```
+$ TFIO_DATAPATH=bazel-bin python
+
+>>> import tensorflow_io as tfio
+>>> ...
+```
 
 #### Testing
 

--- a/tools/docker/devel.Dockerfile
+++ b/tools/docker/devel.Dockerfile
@@ -1,6 +1,6 @@
 FROM tensorflow/tensorflow:custom-op-ubuntu16
 
-RUN rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list && apt-get update && \
+RUN rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_7-xenial.list && apt-get update && \
     apt-get install -y \
     git \
     gcc \
@@ -23,7 +23,7 @@ RUN curl -sL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSI
 
 ARG CONDA_OS=Linux
 
-# Miniconda - Python 3.6, 64-bit, x86, latest
+# Miniconda - Python 3.7, 64-bit, x86, latest
 RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o mconda-install.sh && \
     bash -x mconda-install.sh -b -p miniconda && \
     rm mconda-install.sh
@@ -32,7 +32,7 @@ ENV PATH="/miniconda/bin:$PATH"
 
 ARG CONDA_ADD_PACKAGES=""
 
-RUN conda create -y -q -n tfio-dev python=3.6 ${CONDA_ADD_PACKAGES}
+RUN conda create -y -q -n tfio-dev python=3.7 ${CONDA_ADD_PACKAGES}
 
 ARG ARROW_VERSION=0.16.0
 
@@ -48,6 +48,7 @@ RUN /bin/bash -c "source activate tfio-dev && python -m pip install \
     pylint \
     boto3 \
     google-cloud-pubsub==0.39.1 \
+    google-cloud-bigquery-storage==1.1.0 \
     pyarrow==${ARROW_VERSION} \
     pandas \
     fastavro \


### PR DESCRIPTION
Devel docker image is not longer usable because latest release doesn't have whls for Python 3.6, therefore updating  Python to 3.7.
Also updated documentation, references to python3 probably should be replaced by python since support for python2 was dropped.