### PR TITLE
Fix decode_json empty lists segmentation issue

### DIFF
--- a/tensorflow_io/core/kernels/serialization_kernels.cc
+++ b/tensorflow_io/core/kernels/serialization_kernels.cc
@@ -107,7 +107,9 @@ class DecodeJSONOp : public OpKernel {
                              std::vector<int64>& tensor_shape_vector) {
     if (entry->IsArray()) {
       tensor_shape_vector.push_back(entry->Size());
-      getTensorShape(&(*entry)[0], tensor_shape_vector);
+      if (entry->Size() != 0) {
+        getTensorShape(&(*entry)[0], tensor_shape_vector);
+      }
     }
   }
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -213,5 +213,16 @@ def test_json_keras():
     model.fit(dataset, epochs=5)
 
 
+def test_json_empty():
+    """Test case for GitHub issue 1605."""
+    spec = {
+        "user_id": tf.TensorSpec(shape=(), dtype=tf.string),
+        "actions": tf.TensorSpec(shape=(None,), dtype=tf.string),
+    }
+    tfio.experimental.serialization.decode_json(
+        b'{"user_id":"0000asdasdasdasdas dasdasdasdasdasd","actions":[]}\n', spec
+    )
+
+
 if __name__ == "__main__":
     test.main()


### PR DESCRIPTION
This PR fixes decode_json empty lists segmentation issue raised in #1605.

This PR fixes #1605.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>