### PR TITLE
Allow to work with AARCH64 build of TensorFlow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,6 +173,7 @@ setuptools.setup(
         "tensorflow-gpu": [require.replace("tensorflow", "tensorflow-gpu")],
         "tensorflow-cpu": [require.replace("tensorflow", "tensorflow-cpu")],
         "tensorflow-rocm": [require.replace("tensorflow", "tensorflow-rocm")],
+        "tensorflow-aarch64": [require.replace("tensorflow", "tensorflow-aarch64")],
     },
     package_data={
         ".": ["*.so"],


### PR DESCRIPTION
The AARCH64 build of TensorFlow should have its package name included