### PR TITLE
Fix parquet in graph execution

### DIFF
--- a/tensorflow_io/python/ops/parquet_dataset_ops.py
+++ b/tensorflow_io/python/ops/parquet_dataset_ops.py
@@ -81,7 +81,8 @@ class ParquetIODataset(tf.data.Dataset):
                 indices_start = tf.data.Dataset.range(0, shape[0], step)
                 indices_stop = indices_start.skip(1).concatenate(
                     tf.data.Dataset.from_tensor_slices(
-                        tf.convert_to_tensor([shape[0]], tf.int64))
+                        tf.convert_to_tensor([shape[0]], tf.int64)
+                    )
                 )
                 dataset = tf.data.Dataset.zip((indices_start, indices_stop))
 

--- a/tensorflow_io/python/ops/parquet_dataset_ops.py
+++ b/tensorflow_io/python/ops/parquet_dataset_ops.py
@@ -48,8 +48,12 @@ class ParquetIODataset(tf.data.Dataset):
                 return dtype
 
             if not tf.executing_eagerly():
-                assert columns is not None
-                assert isinstance(columns, dict)
+                if columns is None or not isinstance(columns, dict):
+                    raise ValueError(
+                        "The `columns` parameter can only be "
+                        "a dictionary in graph execution, mapping "
+                        "feature names to `tf.TensorSpec`."
+                    )
                 shapes = [shape_f(shapes, components, column) for column in columns]
                 dtypes = [
                     spec if isinstance(spec, tf.dtypes.DType) else spec.dtype

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -43,7 +43,7 @@ filename = "file://" + filename
 # Column 2 (int64): Equal to row_index * 1000 * 1000 * 1000 * 1000.
 # Column 4 (float): Equal to row_index * 1.1.
 # Column 5 (double): Equal to row_index * 1.1111111.
-def test_parquet():
+def test_parquet_sample():
     """Test case for read_parquet."""
     parquet = tfio.IOTensor.from_parquet(filename)
     columns = [

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -141,6 +141,41 @@ def test_parquet_dataset_ordered_dict():
     )
 
 
+def test_parquet_dataset_columns_cannot_be_none_in_graph_execution():
+    """Test case to ensure columns cannot be None in graph mode"""
+
+    @tf.function(autograph=False)
+    def read_parquet():
+        return tfio.IODataset.from_parquet(filename, columns=None)
+
+    try:
+        parquet = read_parquet()
+    except ValueError as e:
+        assert "can only be a dictionary in graph execution" in str(e)
+
+
+def test_parquet_dataset_columns_cannot_be_list_in_graph_execution():
+    """Test case to ensure columns cannot be a list in graph mode"""
+
+    @tf.function(autograph=False)
+    def read_parquet():
+        columns = [
+            "boolean_field",
+            "int32_field",
+            "int64_field",
+            "float_field",
+            "double_field",
+            "ba_field",
+            "flba_field",
+        ]
+        return tfio.IODataset.from_parquet(filename, columns)
+
+    try:
+        parquet = read_parquet()
+    except ValueError as e:
+        assert "can only be a dictionary in graph execution" in str(e)
+
+
 def test_parquet_dataset_ordered_dict_in_graph_execution():
     """Test case for order and dict of parquet dataset"""
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -141,6 +141,36 @@ def test_parquet_dataset_ordered_dict():
     )
 
 
+def test_parquet_dataset_ordered_dict_in_graph_execution():
+    """Test case for order and dict of parquet dataset"""
+
+    @tf.function(autograph=False)
+    def read_parquet():
+        columns = {
+            "boolean_field": tf.TensorSpec(shape=(), dtype=tf.bool),
+            "int32_field": tf.TensorSpec(shape=(), dtype=tf.int32),
+            "int64_field": tf.TensorSpec(shape=(), dtype=tf.int64),
+            "float_field": tf.TensorSpec(shape=(), dtype=tf.float32),
+            "double_field": tf.TensorSpec(shape=(), dtype=tf.float64),
+            "ba_field": tf.TensorSpec(shape=(), dtype=tf.string),
+            "flba_field": tf.TensorSpec(shape=(), dtype=tf.string),
+        }
+        return tfio.IODataset.from_parquet(filename, columns)
+
+    parquet = read_parquet()
+    assert parquet.element_spec == collections.OrderedDict(
+        [
+            ("boolean_field", tf.TensorSpec(shape=(), dtype=tf.bool)),
+            ("int32_field", tf.TensorSpec(shape=(), dtype=tf.int32)),
+            ("int64_field", tf.TensorSpec(shape=(), dtype=tf.int64)),
+            ("float_field", tf.TensorSpec(shape=(), dtype=tf.float32)),
+            ("double_field", tf.TensorSpec(shape=(), dtype=tf.float64)),
+            ("ba_field", tf.TensorSpec(shape=(), dtype=tf.string)),
+            ("flba_field", tf.TensorSpec(shape=(), dtype=tf.string)),
+        ]
+    )
+
+
 def test_parquet_graph():
     """Test case for parquet in graph mode."""
 


### PR DESCRIPTION
My first commit adds a failing test `test_parquet_dataset_ordered_dict_in_graph_execution` to demonstrate the issue to resolve. In a nutshell the shape is set to `<unknown>` in graph execution, which is undesirable and not consistent with the eager execution.

Here is an extract of the failing test output:

```
E         + OrderedDict([('boolean_field',
E         -               TensorSpec(shape=(), dtype=tf.bool, name=None)),
E         ?                                ^^
E         +               TensorSpec(shape=<unknown>, dtype=tf.bool, name=None)),
E         ?                                ^^^^^^^^^
E         -              (b'int32_field',
E         ?               -
E         +              ('int32_field',
E         -               TensorSpec(shape=(), dtype=tf.int32, name=None)),
E         ?                                ^^
E         +               TensorSpec(shape=<unknown>, dtype=tf.int32, name=None)),
E         ?                                ^^^^^^^^^

...
```

My second commit is fixing this test with a workaround.
Let me know if you have a better fix in mind.

Cheers