### PR TITLE
Implement `InputDatasets` for AvroRecordDatasetOp

### DIFF
--- a/tensorflow_io/core/kernels/avro/avro_record_dataset_kernels.cc
+++ b/tensorflow_io/core/kernels/avro/avro_record_dataset_kernels.cc
@@ -56,6 +56,10 @@ class AvroRecordDatasetOp::Dataset : public DatasetBase {
     VLOG(7) << "Buffer size " << buffer_size / 1024 << "kBy";
   }
 
+  Status InputDatasets(std::vector<const DatasetBase*>* inputs) const {
+    return Status::OK();
+  }
+
   std::unique_ptr<IteratorBase> MakeIteratorInternal(
       const string& prefix) const override {
     return absl::make_unique<Iterator>(Iterator::Params{


### PR DESCRIPTION
Same change as in #1614, fixes the following warnings:

```
E tensorflow/core/framework/dataset.cc:580] UNIMPLEMENTED: Cannot compute input sources for dataset of type IO>AvroRecordDataset, because the dataset does not implement `InputDatasets`.
E tensorflow/core/framework/dataset.cc:584] UNIMPLEMENTED: Cannot merge options for dataset of type IO>AvroRecordDataset, because the dataset does not implement `InputDatasets`.
```