### PR TITLE
Add bazelisk-linux-amd64, and use github actions' preinstalled bazelisk whenever possible

### DIFF
--- a/.github/workflows/build.bazel.sh
+++ b/.github/workflows/build.bazel.sh
@@ -24,11 +24,14 @@ $PYTHON --version
 
 export TENSORFLOW_INSTALL="$($PYTHON setup.py --install-require)"
 
-export BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-export BAZEL_VERSION=$(cat .bazelversion)
 export PYTHON_BIN_PATH=`which $PYTHON`
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
+
+if [[ $(uname) == "Linux" ]]; then
+  curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+  mv bazelisk-linux-amd64 /usr/local/bin/bazel
+  chmod +x /usr/local/bin/bazel
+fi
+
 bazel version
 
 $PYTHON -m pip --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,6 @@ jobs:
         run: |
           set -x -e
           git log --pretty -1
-          BAZEL_OS=$(uname | tr '[:upper:]' '[:lower:]')
-          BAZEL_VERSION=$(cat .bazelversion)
-          curl -sSOL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
-          sudo bash -e bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh
           sudo python3 -m pip install -U numpy
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:check -- bazel pyupgrade black clang
       - name: Run Lint Script for Docs
@@ -324,17 +320,13 @@ jobs:
       - name: Bazel on Windows
         env:
           BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/"
-        shell: cmd
+        shell: bash
         run: |
-          @echo on
-          set "BAZEL_OPTIMIZATION="
-          if "%EVENT_NAME%" == "push" (
-            if "%REPO_NAME%" == "tensorflow/io" (
-              set "BAZEL_OPTIMIZATION=%BAZEL_OPTIMIZATION% --remote_upload_local_results=true --google_credentials=service_account_creds.json"
-            )
-          )
-          set /P BAZEL_VERSION=< .bazelversion
-          curl -sSL -o bazel.exe https://github.com/bazelbuild/bazel/releases/download/%BAZEL_VERSION%/bazel-%BAZEL_VERSION%-windows-x86_64.exe
+          set -x -e
+          export BAZEL_OPTIMIZATION="--config=cache"
+          if [[ "${EVENT_NAME}" == "push" && "${REPO_NAME}" == "tensorflow/io" ]]; then
+            export BAZEL_OPTIMIZATION="$BAZEL_OPTIMIZATION --remote_upload_local_results=true --google_credentials=service_account_creds.json"
+          fi
           bazel version
           python3 --version
           python3 -m pip install wheel setuptools
@@ -342,8 +334,7 @@ jobs:
           python3 setup.py --install-require | xargs python3 -m pip install
           python3 tools/build/configure.py
           cat .bazelrc
-          bazel build -s %BAZEL_OPTIMIZATION% //tensorflow_io:python/ops/libtensorflow_io.so //tensorflow_io:python/ops/libtensorflow_io_plugins.so  //tensorflow_io_gcs_filesystem/...
-          if %errorlevel% neq 0 exit /b %errorlevel%
+          bazel build -s ${BAZEL_OPTIMIZATION} //tensorflow_io:python/ops/libtensorflow_io.so //tensorflow_io:python/ops/libtensorflow_io_plugins.so  //tensorflow_io_gcs_filesystem/...
           mkdir -p build
           cp -r bazel-bin/tensorflow_io build
           cp -r bazel-bin/tensorflow_io_gcs_filesystem build

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,9 +14,10 @@ TensorFlow I/O's code conforms to Bazel Buildifier, Clang Format, Black, and Pyu
 Please use the following command to check the source code and identify lint issues:
 
 ```
-# Install Bazel version specified in .bazelversion
-$ curl -OL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-darwin-x86_64.sh
-$ sudo bash -x -e bazel-$(cat .bazelversion)-installer-darwin-x86_64.sh
+# Install Bazelisk (manage bazel version implicitly)
+$ curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+$ sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
+$ sudo chmod +x /usr/local/bin/bazel
 $ bazel run //tools/lint:check
 ```
 
@@ -74,9 +75,8 @@ xcodebuild -version
 # Show macOS's default python3
 python3 --version
 
-# Install Bazel version specified in .bazelversion
-curl -OL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-darwin-x86_64.sh
-sudo bash -x -e bazel-$(cat .bazelversion)-installer-darwin-x86_64.sh
+# Install Bazelisk (manage bazel version implicitly)
+brew install bazelisk
 
 # Install tensorflow and configure bazel
 sudo ./configure.sh
@@ -130,9 +130,10 @@ the shared libraries on Ubuntu 20.04:
 sudo apt-get -y -qq update
 sudo apt-get -y -qq install gcc g++ git unzip curl python3-pip
 
-# Install Bazel version specified in .bazelversion
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
-sudo bash -x -e bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
+# Install Bazelisk (manage bazel version implicitly)
+$ curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+$ sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
+$ sudo chmod +x /usr/local/bin/bazel
 
 # Upgrade pip
 sudo python3 -m pip install -U pip
@@ -185,9 +186,10 @@ The following will install bazel, devtoolset-9, rh-python36, and build the share
 sudo yum install -y centos-release-scl
 sudo yum install -y devtoolset-9 git rh-python36 make
 
-# Install Bazel version specified in .bazelversion
-curl -sSOL https://github.com/bazelbuild/bazel/releases/download/$(cat .bazelversion)/bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
-sudo bash -x -e bazel-$(cat .bazelversion)-installer-linux-x86_64.sh
+# Install Bazelisk (manage bazel version implicitly)
+$ curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+$ sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
+$ sudo chmod +x /usr/local/bin/bazel
 
 # Upgrade pip
 scl enable rh-python36 devtoolset-9 \

--- a/docs/development.md
+++ b/docs/development.md
@@ -131,9 +131,9 @@ sudo apt-get -y -qq update
 sudo apt-get -y -qq install gcc g++ git unzip curl python3-pip
 
 # Install Bazelisk (manage bazel version implicitly)
-$ curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
-$ sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
-$ sudo chmod +x /usr/local/bin/bazel
+curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
+sudo chmod +x /usr/local/bin/bazel
 
 # Upgrade pip
 sudo python3 -m pip install -U pip
@@ -187,9 +187,9 @@ sudo yum install -y centos-release-scl
 sudo yum install -y devtoolset-9 git rh-python36 make
 
 # Install Bazelisk (manage bazel version implicitly)
-$ curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
-$ sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
-$ sudo chmod +x /usr/local/bin/bazel
+curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
+sudo chmod +x /usr/local/bin/bazel
 
 # Upgrade pip
 scl enable rh-python36 devtoolset-9 \

--- a/tools/docker/devel.Dockerfile
+++ b/tools/docker/devel.Dockerfile
@@ -14,12 +14,9 @@ RUN rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_7-xenial.list && apt
     ffmpeg \
     dnsutils
 
-ARG BAZEL_VERSION=3.7.2
-ARG BAZEL_OS=linux
-
-RUN curl -sL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh -o bazel-install.sh && \
-    bash -x bazel-install.sh && \
-    rm bazel-install.sh
+RUN curl -sSOL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64 && \
+    mv bazelisk-linux-amd64 /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel
 
 ARG CONDA_OS=Linux
 


### PR DESCRIPTION
We used to install bazel manually by find out the version through `.bazelversion`. However, since bazelisk automatically manages bazel version, and GitHub Actions already have bazelisk pre-installed, it is not necessarily to install bazel anymore. 

This PR removes the need of bazel install when possible (only inside docker we still need to install a bazelisk-linux-amd64).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>