### PR TITLE
Create GitHub Actions to automate Release Note author update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release Bot
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: README.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git tag
+      - run: python3 tools/release/note_create.py
+      - run: git diff
+      - run: python3 tools/release/note_update.py
+      - run: git diff
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Update RELEASE.md [bot]
+          branch: bot-RELEASE.md
+          delete-branch: true
+          title: 'Update RELEASE.md [bot]'
+          body: |
+            README.md: auto-updated by .github/workflows/release.yml

--- a/tools/release/note_create.py
+++ b/tools/release/note_create.py
@@ -1,0 +1,32 @@
+import re
+import pathlib
+
+
+note = pathlib.Path("RELEASE.md").read_text()
+
+release = re.findall(r"^# Release [\d\.]+", note)[0][len("# Release ") :].rstrip()
+
+exec(pathlib.Path("tensorflow_io/python/ops/version_ops.py").read_text())
+
+if tuple(map(int, (release.split(".")))) < tuple(map(int, (version.split(".")))):
+    print(f"[Create {release}]\n")
+    pathlib.Path("RELEASE.md").write_text(
+        f"""# Release {version}
+
+## Major Features and Bug Fixes
+* <TODO>
+
+## Thanks to our Contributors
+
+This release contains contributions from many people:
+
+<TODO>
+
+We are also grateful to all who filed issues or helped resolve them, asked and
+answered questions, and were part of inspiring discussions.
+
+{note}"""
+    )
+print("\n")
+print("[README.md]:\n")
+print(pathlib.Path("RELEASE.md").read_text())

--- a/tools/release/note_update.py
+++ b/tools/release/note_update.py
@@ -1,0 +1,52 @@
+import re
+import pathlib
+import subprocess
+import textwrap
+
+note = pathlib.Path("RELEASE.md").read_text()
+
+entries = []
+for index, line in enumerate(note.split("\n")):
+    if re.match(r"^# Release [\d\.]+", line):
+        entries.append((line[len("# Release ") :].rstrip(), index))
+
+# Find current version and last version
+curr = tuple(map(int, (entries[0][0].split("."))))
+# Find last minor version
+last = tuple([curr[0], curr[1] - 1, curr[2]])
+
+print(
+    "[Authors {} => {}]:\n".format(".".join(map(str, last)), ".".join(map(str, curr)))
+)
+logs = subprocess.run(
+    ["git", "shortlog", "v{}..HEAD".format(".".join(map(str, last))), "-s"],
+    capture_output=True,
+    check=False,
+).stdout.decode("utf-8")
+
+authors = [e.split("\t")[1].strip() for e in logs.rstrip().split("\n")]
+# Replace " " with "@" to allow text wrap without break names, then replace back
+authors = textwrap.fill(", ".join([e.replace(" ", "@") for e in authors]), 80).replace(
+    "@", " "
+)
+
+print(authors)
+
+print("\n")
+
+current_note = note.split("\n")[: entries[1][1]]
+for index, line in enumerate(current_note):
+    if re.match(r"^This release contains contributions from many people:", line):
+        current_author_index_start = index + 2
+    if re.match(r"^We are also grateful to all who ", line):
+        current_author_index_final = index - 1
+
+note = "\n".join(
+    note.split("\n")[:current_author_index_start]
+    + [authors]
+    + note.split("\n")[current_author_index_final:]
+)
+print("[RELEASE.md]:\n")
+print(note)
+
+pathlib.Path("RELEASE.md").write_text(note)

--- a/tools/release/note_update.py
+++ b/tools/release/note_update.py
@@ -10,10 +10,13 @@ for index, line in enumerate(note.split("\n")):
     if re.match(r"^# Release [\d\.]+", line):
         entries.append((line[len("# Release ") :].rstrip(), index))
 
-# Find current version and last version
+# Find current version
 curr = tuple(map(int, (entries[0][0].split("."))))
-# Find last minor version
-last = tuple([curr[0], curr[1] - 1, curr[2]])
+# Find last version, padded to patch version of 0
+if curr[2] == 0:
+    last = tuple([curr[0], curr[1] - 1, 0])
+else:
+    last = tuple([curr[0], curr[1], 0])
 
 print(
     "[Authors {} => {}]:\n".format(".".join(map(str, last)), ".".join(map(str, curr)))

--- a/tools/release/note_update.py
+++ b/tools/release/note_update.py
@@ -16,7 +16,7 @@ curr = tuple(map(int, (entries[0][0].split("."))))
 if curr[2] == 0:
     last = tuple([curr[0], curr[1] - 1, 0])
 else:
-    last = tuple([curr[0], curr[1], 0])
+    last = tuple([curr[0], curr[1], curr[2] - 1])
 
 print(
     "[Authors {} => {}]:\n".format(".".join(map(str, last)), ".".join(map(str, curr)))


### PR DESCRIPTION
This PR create GitHub Actions to automate Release Note author update. Anytime a commit is made, the bot will automatically update the PR to make sure the Release note captures the author (if new author is available).

Note the bot will compare the version in tensorflow_io/python/ops/version_ops.py and the RELEASE.md's head version, and will create a placeholder section if version_ops.py is later than RELEASE.md's latest version.

Example PR is available: https://github.com/yongtang/io/pull/12

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>