### PR TITLE
Store release candidate packages to dockerhub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -509,6 +509,47 @@ jobs:
           name: tensorflow-io-release
           path: wheelhouse
 
+  release-candidate:
+    name: Release Candidate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [lint, release]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v1
+        with:
+          name: tensorflow-io-release
+          path: wheelhouse
+      - run: |
+          set -x -e
+          sha256sum wheelhouse/*.whl | sort -u > wheelhouse.sha256
+          git rev-parse --verify HEAD > wheelhouse.commit
+          grep 'version = ' tensorflow_io/python/ops/version_ops.py  | sed -E 's@^.*version = "@@g' | sed -E 's@".*$@@g' > wheelhouse.version
+          cat wheelhouse.sha256
+          cat wheelhouse.commit
+          cat wheelhouse.version
+          echo "::set-output name=version::$(cat wheelhouse.version)"
+        id: info
+      - run: |-
+          cat <<EOF > Dockerfile
+          FROM gcr.io/distroless/base-debian11
+          COPY wheelhouse /wheelhouse
+          COPY wheelhouse.sha256 /wheelhouse.sha256
+          COPY wheelhouse.commit /wheelhouse.commit
+          COPY wheelhouse.version /wheelhouse.version
+          EOF
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: tfsigio
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          load: true
+          tags: tfsigio/candidate:${{ steps.info.outputs.version }}
+
   docker-release:
     name: Docker Release
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
While we try to automate the release process, one issue we are facing
is: where to store the release candidate python packages?
In GitHub Actions, the python packages are stored as artifact in our workflow.
However, GitHub workflow does not allow downloading the artifact through
API, it only allows downloading the artifact through UI.
For that we need to have a place to save the wheel files (before we automatically
release a version).

This PR utilize the dockerhub to save the wheel files:
1. We package wheel files and information (commit id, sha256 of packages, and version)
   into a minimal docker container image `tfsigio/candidate:{version}` and push to dockerhub.
2. The next step is to write a release workflow so that when a tag is triggered,
   the workflow will automatically pull the docker image `tfsigio/candidate:{version}`,
   and use the saved wheel files to push to PyPI.org (and create release from GitHub API).

Will have a follow up PR once this PR is merged (as the docker image will have to be available
to test).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>