### PR TITLE
retrieve previous version from the tags list and avoid recalculation

### DIFF
--- a/tools/release/note_create.py
+++ b/tools/release/note_create.py
@@ -1,6 +1,19 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 import re
 import pathlib
-
 
 note = pathlib.Path("RELEASE.md").read_text()
 
@@ -8,6 +21,7 @@ release = re.findall(r"^# Release [\d\.]+", note)[0][len("# Release ") :].rstrip
 
 exec(pathlib.Path("tensorflow_io/python/ops/version_ops.py").read_text())
 
+# the `version` variable is loaded from the `exec`` above
 if tuple(map(int, (release.split(".")))) < tuple(map(int, (version.split(".")))):
     print(f"[Create {release}]\n")
     pathlib.Path("RELEASE.md").write_text(

--- a/tools/release/note_update.py
+++ b/tools/release/note_update.py
@@ -1,3 +1,17 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 import re
 import pathlib
 import subprocess
@@ -13,10 +27,7 @@ for index, line in enumerate(note.split("\n")):
 # Find current version
 curr = tuple(map(int, (entries[0][0].split("."))))
 # Find last version, padded to patch version of 0
-if curr[2] == 0:
-    last = tuple([curr[0], curr[1] - 1, 0])
-else:
-    last = tuple([curr[0], curr[1], curr[2] - 1])
+last = tuple(map(int, (entries[1][0].split("."))))
 
 print(
     "[Authors {} => {}]:\n".format(".".join(map(str, last)), ".".join(map(str, curr)))


### PR DESCRIPTION
This PR modifies the logic to retrieve the previous version of the package by using the tags list instead of explicit calculations.

cc: @yongtang I think with this change, we don't need to go down the `semver` path as this current logic achieves the purpose. However, we can use it in the future based on requirements now that we have it noted in our discussions.