### PR TITLE
Fix an issue when pushing docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -547,7 +547,6 @@ jobs:
         with:
           context: .
           push: true
-          load: true
           tags: tfsigio/candidate:${{ steps.info.outputs.version }}
 
   docker-release:


### PR DESCRIPTION
This PR fixes an issue when pushing docker image with the following error:
```
buildx failed with: error: push and load may not be set together at the moment
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>