### PR TITLE
Change hadoop's download source to github

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -428,11 +428,11 @@ http_archive(
 http_archive(
     name = "hadoop",
     build_file = "//third_party:hadoop.BUILD",
-    sha256 = "5fd5831b12b1e0999bd352d6cca11ef80f883c81ffa898e53c68d8fe8d170e9f",
-    strip_prefix = "hadoop-3.3.0-src",
+    sha256 = "fa9d0587d06c36838e778081bcf8271a9c63060af00b3bf456423c1777a62043",
+    strip_prefix = "hadoop-rel-release-3.3.0",
     urls = [
-        "https://storage.googleapis.com/mirror.tensorflow.org/downloads.apache.org/hadoop/common/hadoop-3.3.0/hadoop-3.3.0-src.tar.gz",
-        "https://downloads.apache.org/hadoop/common/hadoop-3.3.0/hadoop-3.3.0-src.tar.gz",
+        "https://storage.googleapis.com/mirror.tensorflow.org/apache/hadoop/archive/refs/tags/rel/release-3.3.0.tar.gz",
+        "https://github.com/apache/hadoop/archive/refs/tags/rel/release-3.3.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
We used to download hadoop source from apache's download site
and that has caused quite a few build failures.

This PR changes hadoop's download source to GitHub instead.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>