### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.note.yml
+++ b/.github/workflows/release.note.yml
@@ -1,0 +1,28 @@
+name: Release Note
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-note:
+    name: README.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git tag
+      - run: python3 tools/release/note_create.py
+      - run: git diff
+      - run: python3 tools/release/note_update.py
+      - run: git diff
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Update RELEASE.md [bot]
+          branch: bot-RELEASE.md
+          delete-branch: true
+          title: 'Update RELEASE.md [bot]'
+          body: |
+            README.md: auto-updated by .github/workflows/release.note.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,72 @@
-name: Release Bot
+name: Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (e.g., v0.24.0)"
+        required: true
+      commit:
+        description: "Commit (e.g., 92b44e1)"
+        required: true
 
 jobs:
   release:
-    name: README.md
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: git tag
-      - run: python3 tools/release/note_create.py
-      - run: git diff
-      - run: python3 tools/release/note_update.py
-      - run: git diff
-      - uses: peter-evans/create-pull-request@v3
+      - run: |
+          set -x -e
+          COMMIT=$(git rev-parse --quiet --verify ${{ github.event.inputs.commit }})
+          if [[ "$(git tag -l ${{ github.event.inputs.version }})" == "${{ github.event.inputs.version }}" ]]; then
+            echo "${{ github.event.inputs.version }} already released"
+            exit 1
+          fi
+          VERSION=${{ github.event.inputs.version }}
+
+          docker pull tfsigio/candidate:${VERSION:1}
+          docker create -it --name storage tfsigio/candidate:${VERSION:1} bash
+          docker cp storage:/wheelhouse .
+          docker cp storage:/wheelhouse.sha256 .
+          docker cp storage:/wheelhouse.commit .
+          docker cp storage:/wheelhouse.version .
+
+          sha256sum wheelhouse/*.whl | sort -u | diff wheelhouse.sha256 -
+          mv wheelhouse dist
+
+          if [[ "${COMMIT}" != "$(cat wheelhouse.commit)" ]]; then
+            echo "${COMMIT} != $(cat wheelhouse.commit)"
+            exit 1
+          fi
+          if [[ "${VERSION}" != "v$(cat wheelhouse.version)" ]]; then
+            echo "${VERSION} != v$(cat wheelhouse.version)"
+            exit 1
+          fi
+
+          python3 tools/release/note_take.py ${VERSION}
+
+          echo "::set-output name=tag::${VERSION}"
+          echo "::set-output name=name::TensorFlow I/O ${VERSION:1}"
+          echo "::set-output name=commit::${COMMIT}"
+        id: info
+      - run: |
+          set -x -e
+          echo ${{ steps.info.outputs.tag }}
+          echo ${{ steps.info.outputs.name }}
+          echo ${{ steps.info.outputs.commit }}
+          cat CURRENT.md
+      - uses: softprops/action-gh-release@v1
         with:
-          commit-message: Update RELEASE.md [bot]
-          branch: bot-RELEASE.md
-          delete-branch: true
-          title: 'Update RELEASE.md [bot]'
-          body: |
-            README.md: auto-updated by .github/workflows/release.yml
+          body_path: CURRENT.md
+          name: ${{ steps.info.outputs.name }}
+          tag_name: ${{ steps.info.outputs.tag }}
+          target_commitish: ${{ steps.info.outputs.commit }}
+          draft: true
+      #- uses: pypa/gh-action-pypi-publish@master
+      #  with:
+      #    user: __token__
+      #    password: ${{ secrets.github_tensorflow_io_nightly }}
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,13 @@ jobs:
           tag_name: ${{ steps.info.outputs.tag }}
           target_commitish: ${{ steps.info.outputs.commit }}
           draft: true
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
       #- uses: pypa/gh-action-pypi-publish@master
       #  with:
       #    user: __token__
-      #    password: ${{ secrets.github_tensorflow_io_nightly }}
+      #    password: ${{ secrets.PYPI_TOKEN }}
           

--- a/tools/release/note_take.py
+++ b/tools/release/note_take.py
@@ -1,0 +1,64 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import re
+import sys
+import pathlib
+import subprocess
+import textwrap
+
+exec(pathlib.Path("tensorflow_io/python/ops/version_ops.py").read_text())
+
+# the `version` variable is loaded from the `exec`` above
+if f"v{version}" != sys.argv[1]:
+    print(f"[Version {version} in version_ops.py does not match {sys.argv[1]}]")
+    sys.exit(1)
+version = sys.argv[1]
+
+note = pathlib.Path("RELEASE.md").read_text()
+
+entries = []
+for index, line in enumerate(note.split("\n")):
+    if re.match(r"^# Release [\d\.]+", line):
+        entries.append((line[len("# Release ") :].rstrip(), index))
+
+tag = (
+    subprocess.run(
+        ["git", "tag", "-l", f"v{entries[0][0]}"],
+        capture_output=True,
+        check=True,
+    )
+    .stdout.decode("utf-8")
+    .strip()
+)
+if tag == f"v{entries[0][0]}":
+    print(
+        "[The latest version in RELEASE.md {} has already been released]".format(
+            entries[0][0]
+        )
+    )
+    sys.exit(0)
+
+
+if version != f"v{entries[0][0]}":
+    print(
+        "[The latest version in RELEASE.md {} has does not match {}]".format(
+            entries[0][0], version
+        )
+    )
+    sys.exit(0)
+
+# Cut note
+current = "\n".join(note.split("\n")[: entries[1][1]])
+pathlib.Path("CURRENT.md").write_text(current)


### PR DESCRIPTION
This PR adds a release workflow that can be triggered through Actions => All Workflows => Release => Run Workflow. A tag and a commit has to be provided.

The action will fetch the candidate binary from dockerhub, cut the head of the RELEADE.md, and create a release.

Follow up steps:
1. The release is a draft (draft: true) now. Once we are feeling confident, we can switch to draft: false
2. The publishing to pypi is comment out for now. Once we are feeling confident, we can uncomment.

Note: The old release.yml has been renamed to release.note.yml to better represent the content.

A try run is available in another repo: https://github.com/yongtang/io/runs/5134338413?check_suite_focus=true

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>