### PR TITLE
Add retry when downloading pulsar through apache in CI

### DIFF
--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -22,7 +22,7 @@ TAR_FILE="apache-pulsar-${VERSION}-bin.tar.gz"
 
 echo "Downloading pulsar ${VERSION}"
 if [[ ! -f ${TAR_FILE} ]]; then
-  curl -sSOL "https://archive.apache.org/dist/pulsar/pulsar-${VERSION}/${TAR_FILE}"
+  curl --retry 10 -sSOL "https://archive.apache.org/dist/pulsar/pulsar-${VERSION}/${TAR_FILE}"
 fi
 
 tar -xzf ${TAR_FILE}


### PR DESCRIPTION
We have had lots of failures downloading pulsar recently.

This PR adds --retry 10 to reduce the failure.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>