### PR TITLE
set --max-time for curl to retrieve pulsar package

### DIFF
--- a/tests/test_pulsar/pulsar_test.sh
+++ b/tests/test_pulsar/pulsar_test.sh
@@ -22,7 +22,7 @@ TAR_FILE="apache-pulsar-${VERSION}-bin.tar.gz"
 
 echo "Downloading pulsar ${VERSION}"
 if [[ ! -f ${TAR_FILE} ]]; then
-  curl --retry 10 -sSOL "https://archive.apache.org/dist/pulsar/pulsar-${VERSION}/${TAR_FILE}"
+  curl --retry 10 --max-time 120 -sSOL "https://archive.apache.org/dist/pulsar/pulsar-${VERSION}/${TAR_FILE}"
 fi
 
 tar -xzf ${TAR_FILE}


### PR DESCRIPTION
This PR sets the `--max-time` curl option to 120 while downloading the `pulsar` package. 

Failure reference even after retries: https://github.com/tensorflow/io/runs/5163199512?check_suite_focus=true