### PR TITLE
Update log level from fetal to error when loading the libhdfs.so failed

### DIFF
--- a/tensorflow_io/core/filesystems/hdfs/hadoop_filesystem.cc
+++ b/tensorflow_io/core/filesystems/hdfs/hadoop_filesystem.cc
@@ -241,7 +241,7 @@ class LibHDFS {
       if (TF_GetCode(status) == TF_OK) {
         return;
       } else {
-        TF_Log(TF_FATAL, "HadoopFileSystem load error: %s", TF_Message(status));
+        TF_Log(TF_ERROR, "HadoopFileSystem load error: %s", TF_Message(status));
       }
     }
 


### PR DESCRIPTION
Sorry i'm not familiar with the codebase of tensorflow/io. But i found that when no libhdfs.so in the path of HADOOP_HDFS_HOME environment var, it will directly absort when using tensorflo2.8

Howerver, in our linux machine, it exist in /usr/lib64/libhdfs.so. And it should fall back to load /usr/lib64 path.

Besides everything is OK in tensorflow2.4
