### PR TITLE
Update filter_ops.py

### DIFF
--- a/tensorflow_io/python/experimental/filter_ops.py
+++ b/tensorflow_io/python/experimental/filter_ops.py
@@ -22,7 +22,7 @@ import tensorflow as tf
 def pad(input, ksize, mode, constant_values):
     input = tf.convert_to_tensor(input)
     ksize = tf.convert_to_tensor(ksize)
-    mode = "CONSTANT" if mode is None else upper(mode)
+    mode = "CONSTANT" if mode is None else str.upper(mode)
     constant_values = (
         tf.zeros([], dtype=input.dtype)
         if constant_values is None


### PR DESCRIPTION
currently for every value of the 'mode' parameter other than 'None' a NameError exception is thrown (NameError: name 'upper' is not defined)
This is due to misuse of the upper() method