### PR TITLE
Cherry pick clean wheels for 0.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,6 +258,7 @@ jobs:
           set -x -e
           mv bazel-bin/tensorflow_io/.bazelrc .
           docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --data bazel-bin -q bdist_wheel
+          rm -rf build
           docker run -i --rm --user $(id -u):$(id -g) -v /etc/password:/etc/password -v $PWD:/v -w /v --net=host python:${{ matrix.python }}-slim python setup.py --project tensorflow-io-gcs-filesystem --data bazel-bin -q bdist_wheel
       - name: Auditwheel ${{ matrix.python }} Linux
         run: |


### PR DESCRIPTION
Hey folks it's me again, was wondering if we can get a patch release for 0.19 (latest TF 2.5 release) w https://github.com/tensorflow/io/commit/d485e4ae87dae33b3880db6e92ef0dc46a3c860c applied?

We are finding issues internally with this.