### PR TITLE
Remove CRFL characters in variables.

### DIFF
--- a/docs/tutorials/kafka.ipynb
+++ b/docs/tutorials/kafka.ipynb
@@ -449,6 +449,10 @@
         "\n",
         "x_test = list(filter(None, x_test_df.to_csv(index=False).split(\"\\n\")[1:]))\n",
         "y_test = list(filter(None, y_test_df.to_csv(index=False).split(\"\\n\")[1:]))\n"
+        "for i in range(len(x_train)): x_train[i] = x_train[i].rstrip()\n"
+        "for i in range(len(y_train)): y_train[i] = y_train[i].rstrip()\n"
+        "for i in range(len(x_test)): x_test[i] = x_test[i].rstrip()\n"
+        "for i in range(len(y_test)): y_test[i] = y_test[i].rstrip()\n"
       ]
     },
     {


### PR DESCRIPTION
There is "\r" in the list of string variables (x_train, y_train, x_test, y_test). Therefore when consumed from the Kafka topic, a graph execution error showed up. After removing the CRFL character it worked and the training began.