### PR TITLE
Allow installing for Python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
@@ -166,7 +167,7 @@ setuptools.setup(
     ],
     keywords="tensorflow io machine learning",
     packages=setuptools.find_packages(where=".", exclude=exclude),
-    python_requires=">=3.7, <3.11",
+    python_requires=">=3.7, <3.12",
     install_requires=install_requires,
     extras_require={
         "tensorflow": [require],


### PR DESCRIPTION
This fixes issue #1736. Since Python 3.11 wheels are already available, this PR just makes `setup.py` consistent with that.