### PR TITLE
Modified dtype error info in ArrowDataset

### DIFF
--- a/tensorflow_io/core/kernels/arrow/arrow_util.cc
+++ b/tensorflow_io/core/kernels/arrow/arrow_util.cc
@@ -40,7 +40,7 @@ Status GetTensorFlowType(std::shared_ptr<::arrow::DataType> dtype,
   ::arrow::Status status =
       ::arrow::adapters::tensorflow::GetTensorFlowType(dtype, out);
   if (!status.ok()) {
-    return errors::InvalidArgument("arrow data type ", dtype,
+    return errors::InvalidArgument("arrow data type ", dtype->name(),
                                    " is not supported: ", status);
   }
   return Status::OK();


### PR DESCRIPTION
the dtype is a shared_ptr, print a address is no useful error info

[arrow::DataType::name()](https://github.com/apache/arrow/blob/master/cpp/src/arrow/type.h#L166)