### PR TITLE
Proposed fix of #1766 (isdir() returning True for HttpFileSystem)

### DIFF
--- a/tensorflow_io/core/filesystems/http/http_filesystem.cc
+++ b/tensorflow_io/core/filesystems/http/http_filesystem.cc
@@ -782,8 +782,13 @@ static bool IsDirectory(const TF_Filesystem* filesystem, const char* path,
     return false;
   }
 
-  TF_SetStatus(status, TF_OK, "");
-  return stats.is_directory;
+  if (stats.is_directory) {
+    TF_SetStatus(status, TF_OK, "");
+    return true;
+  }
+
+  TF_SetStatus(status, TF_FAILED_PRECONDITION, "not a directory");
+  return false;
 }
 
 static int GetChildren(const TF_Filesystem* filesystem, const char* path,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -106,5 +106,18 @@ def test_gfile_tell(local_content, remote_filename):
     assert remote_gfile.tell() == 100
 
 
+@pytest.mark.skipif(
+    sys.platform in ("darwin", "win32"), reason="macOS/Windows fails now"
+)
+def test_gfile_isdir(remote_filename):
+    """Test case for isdir()"""
+
+    # A valid http link is not a dir.
+    assert not tf.io.gfile.isdir(remote_filename)
+    # An invalid http link is not a dir either.
+    assert not tf.io.gfile.isdir("https://not-a-valid-domain/tfio-test")
+
+
+
 if __name__ == "__main__":
     tf.test.main()


### PR DESCRIPTION
See #1766 for context. I tested this change locally as I wanted to use the Parquet Dataset to read off of S3 presigned URLs. Without this PR, tfio errored at this line: https://github.com/tensorflow/io/blob/e196400d874f6dbe7b12625c7debb44da44c3dc4/tensorflow_io/core/kernels/parquet_kernels.cc#L37

With this PR everything works fine.