### PR TITLE
Add `ref` and `amin` argument in `dbscale`

### DIFF
--- a/tests/test_audio_ops.py
+++ b/tests/test_audio_ops.py
@@ -876,6 +876,19 @@ def test_spectrogram():
     assert dbscale_mel_spectrogram.shape == [29, mels]
     assert dbscale_mel_spectrogram.dtype == tf.float32
 
+    # Inf check for zero input
+    dbscale_mel_spectrogram = tfio.audio.dbscale(tf.zeros_like(mel_spectrogram), top_db=80, amin=1e-10)
+
+    # Check if any inf in output
+    assert not tf.math.reduce_any(tf.math.is_inf(dbscale_mel_spectrogram))
+
+    # Custom ref check
+    dbscale_mel_spectrogram = tfio.audio.dbscale(mel_spectrogram, top_db=80, ref=tf.math.reduce_max)
+
+    # Check content after ref is different
+    assert dbscale_mel_spectrogram.shape == [29, mels]
+    assert dbscale_mel_spectrogram.dtype == tf.float32
+
     spec = dbscale_mel_spectrogram
 
     # Freq masking

--- a/tests/test_audio_ops.py
+++ b/tests/test_audio_ops.py
@@ -877,13 +877,17 @@ def test_spectrogram():
     assert dbscale_mel_spectrogram.dtype == tf.float32
 
     # Inf check for zero input
-    dbscale_mel_spectrogram = tfio.audio.dbscale(tf.zeros_like(mel_spectrogram), top_db=80, amin=1e-10)
+    dbscale_mel_spectrogram = tfio.audio.dbscale(
+        tf.zeros_like(mel_spectrogram), top_db=80, amin=1e-10
+    )
 
     # Check if any inf in output
     assert not tf.math.reduce_any(tf.math.is_inf(dbscale_mel_spectrogram))
 
     # Custom ref check
-    dbscale_mel_spectrogram = tfio.audio.dbscale(mel_spectrogram, top_db=80, ref=tf.math.reduce_max)
+    dbscale_mel_spectrogram = tfio.audio.dbscale(
+        mel_spectrogram, top_db=80, ref=tf.math.reduce_max
+    )
 
     # Check content after ref is different
     assert dbscale_mel_spectrogram.shape == [29, mels]


### PR DESCRIPTION
This PR will add two parameters `ref` and `amin` in `tfio.audio.dbscale()`, similar to **librosa** `power_to_db` function.
* `amin` will avoid $-inf$ for zero inputs
* `ref` will provide more flexibility as many user use `np.max` as ref.