### PR TITLE
Bring back S3_VERIFY_SSL environment variable

### DIFF
--- a/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
@@ -134,6 +134,13 @@ static Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
   absl::MutexLock l(&cfg_lock);
 
   if (!init) {
+    const char* verify_ssl = getenv("S3_VERIFY_SSL");
+    if (verify_ssl) {
+      if (verify_ssl[0] == '0')
+        cfg.verifySSL = false;
+      else
+        cfg.verifySSL = true;
+    }
     // if these timeouts are low, you may see an error when
     // uploading/downloading large files: Unable to connect to endpoint
     int64_t timeout;

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -51,6 +51,7 @@ def test_read_file():
     response = client.get_object(Bucket=bucket_name, Key=key_name)
     assert response["Body"].read() == body
 
+    os.environ["S3_VERIFY_SSL"] = "0"
     os.environ["S3_ENDPOINT"] = "http://localhost:4566"
 
     content = tf.io.read_file(f"s3://{bucket_name}/{key_name}")


### PR DESCRIPTION
#1343 removed the environment variable `S3_VERIFY_SSL`.

Even though it's discouraged to disable SSL verification, it is still useful to do so in development environments. So it would be great to bring this back.