### PR TITLE
Pinning urllib to <2 in CI

### DIFF
--- a/.github/workflows/build.bazel.sh
+++ b/.github/workflows/build.bazel.sh
@@ -41,6 +41,7 @@ $PYTHON -m pip install --upgrade setuptools
 $PYTHON -m pip --version
 
 $PYTHON -m pip install -q ${TENSORFLOW_INSTALL}
+$PYTHON -m pip install -q "urllib3 <2"
 
 $PYTHON tools/build/configure.py
 


### PR DESCRIPTION
Currently Linux CI is failing with this error:

```log
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2g  1 Mar 2016. See: https://github.com/urllib3/urllib3/issues/2168
```
It's mainly an issue with the `requests` library: https://github.com/psf/requests/issues/6432

For now this can be bypassed for now by installing an urllib version <2.

