### PR TITLE
Add cpu=darwin flag to get around grpc/cares build issue

### DIFF
--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -124,6 +124,8 @@ def write_config():
             bazel_rc.write('build:macos --linkopt="-mmacosx-version-min=10.14"\n')
             # Warns for unguarded uses of Objective-C APIs
             bazel_rc.write("build:macos --copt=-Wunguarded-availability\n")
+            bazel_rc.write("build:macos --copt=-Wno-error=unused-but-set-variable\n")
+            bazel_rc.write("build:macos --cpu=darwin\n")
             # MSVC (Windows): Standards-conformant preprocessor mode
             bazel_rc.write('build:windows --copt="/Zc:preprocessor"\n')
             bazel_rc.write('build:windows --copt="/std:c++17"\n')

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -125,6 +125,7 @@ def write_config():
             # Warns for unguarded uses of Objective-C APIs
             bazel_rc.write("build:macos --copt=-Wunguarded-availability\n")
             bazel_rc.write("build:macos --copt=-Wno-error=unused-but-set-variable\n")
+            bazel_rc.write("build:macos --copt=-Wno-error=unknown-warning-option\n")
             bazel_rc.write("build:macos --cpu=darwin\n")
             # MSVC (Windows): Standards-conformant preprocessor mode
             bazel_rc.write('build:windows --copt="/Zc:preprocessor"\n')


### PR DESCRIPTION
Add cpu=darwin flag to get around grpc/cares build issue on mac