### PR TITLE
Set Token Permissions on GitHub workflows

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 12 * * *"
 
+permissions:
+  contents: read
+
 jobs:
 
   macos:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   macos:
     if: github.repository == 'tensorflow/io' # Don't do this in forks
@@ -47,6 +50,8 @@ jobs:
     if: github.repository == 'tensorflow/io' # Don't do this in forks
     name: Linux ${{ matrix.python }} + ${{ matrix.version }}
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # to allow sending a commit comment for the benchmark action
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 env:
   REPO_NAME: ${{ github.repository }}
   EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/release.note.yml
+++ b/.github/workflows/release.note.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   release-note:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: README.md
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,13 @@ on:
         description: "Commit (e.g., 92b44e1)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   bazel:
+    permissions:
+      checks: write  # for reviewdog/action-suggester to report issues using checks
+      contents: read  # for actions/checkout to fetch code
     name: Bazel Buildifier
     runs-on: ubuntu-20.04
     steps:
@@ -16,6 +22,9 @@ jobs:
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:lint -- bazel
       - uses: reviewdog/action-suggester@v1
   black:
+    permissions:
+      checks: write  # for reviewdog/action-suggester to report issues using checks
+      contents: read  # for actions/checkout to fetch code
     name: Python Black
     runs-on: ubuntu-20.04
     steps:
@@ -25,6 +34,9 @@ jobs:
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:lint -- black
       - uses: reviewdog/action-suggester@v1
   clang:
+    permissions:
+      checks: write  # for reviewdog/action-suggester to report issues using checks
+      contents: read  # for actions/checkout to fetch code
     name: Clang Format
     runs-on: ubuntu-20.04
     steps:
@@ -34,6 +46,9 @@ jobs:
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:lint -- clang
       - uses: reviewdog/action-suggester@v1
   pyupgrade:
+    permissions:
+      checks: write  # for reviewdog/action-suggester to report issues using checks
+      contents: read  # for actions/checkout to fetch code
     name: Python Pyupgrade
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Hi, I'm Joyce from GOSST (Google Open Source Security Team) and I'd like to suggest to use minimal permissions to the GitHub workflows. 

The default permissions granted for GITHUB_TOKEN (used on GitHub workflows) are write-all as can be seen in the "set up job"

<img width="326" alt="image" src="https://github.com/tensorflow/io/assets/22223372/331bae70-c928-49b9-bf36-8cd2365558ee">

That's why the [OpenSSF Scorecard](https://github.com/ossf/scorecard) and the [GitHub itself](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets) recommends that all permissions be minimally scoped.

I've used Step Security tool to get the needed permissions for many workflows. The bechmarks, api and build workflow I manually analyzed them to understand the needed permissions, so let me know if I missed anything.
