### PR TITLE
Hash pin pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -921,7 +921,7 @@ jobs:
           cp Windows-3.11-nightly/tensorflow_io_nightly*.whl dist/
           ls -la dist/
           sha256sum dist/*.whl
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e # v1.8.10
         with:
           user: __token__
           password: ${{ secrets.github_tensorflow_io_nightly }}
@@ -946,7 +946,7 @@ jobs:
           cp Windows-3.11-nightly/tensorflow_io_gcs_filesystem_nightly*.whl dist/
           ls -la dist/
           sha256sum dist/*.whl
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e # v1.8.10
         with:
           user: __token__
           password: ${{ secrets.tensorflow_io_gcs_filesystem_nightly }}


### PR DESCRIPTION
Regarding #1862 I've forgotten to hash pin the pypa/gh-action-pypi-publish which was pinned to master. I've changed it to the specific version instead of `# master` as recommended by the actions's README (see [master branch sunset](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-)).

Thanks!

