### PR TITLE
setup.py: Fix metadata to indicate currently supported Python >= 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,8 +152,6 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -168,7 +166,7 @@ setuptools.setup(
     ],
     keywords="tensorflow io machine learning",
     packages=setuptools.find_packages(where=".", exclude=exclude),
-    python_requires=">=3.7, <3.13",
+    python_requires=">=3.9, <3.13",
     install_requires=install_requires,
     extras_require={
         "tensorflow": [require],


### PR DESCRIPTION
This synchronized metadata with actual published binary releases.

fixes #2036