### PR TITLE
fix(filesystem): Fix crash when using S3

### DIFF
--- a/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
@@ -215,13 +215,13 @@ static int GetExecutorPoolSize() {
   return temp_value;
 }
 
-static void GetExecutor(tf_s3_filesystem::S3File* s3_file) {
+static void GetExecutor(tf_s3_filesystem::S3File* s3_file, int executor_pool_size) {
   absl::MutexLock l(&s3_file->initialization_lock);
 
   if (s3_file->executor.get() == nullptr) {
     s3_file->executor =
         Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(
-            kExecutorTag, kExecutorPoolSize);
+            kExecutorTag, executor_pool_size);
   }
 }
 

--- a/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
+++ b/tensorflow_io/core/filesystems/s3/s3_filesystem.cc
@@ -228,7 +228,7 @@ static void GetExecutor(tf_s3_filesystem::S3File* s3_file) {
 static void GetTransferManager(
     const Aws::Transfer::TransferDirection& direction,
     tf_s3_filesystem::S3File* s3_file) {
-  executor_pool_size = GetExecutorPoolSize();
+  int executor_pool_size = GetExecutorPoolSize();
   // These functions should be called before holding `initialization_lock`.
   GetS3Client(s3_file);
   GetExecutor(s3_file, executor_pool_size);


### PR DESCRIPTION
- Related: #1912 
- Just splitted `GetExecutor` function.
  - `executor_pool_size` is retrieved from `GetExecutorPoolSize`(new implemented)
  - And `GetExecutor` receives new argument named `executor_pool_size`
- Checked exception by pure virtual method call does not happend anymore.