### PR TITLE
Added Power support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,17 +27,6 @@ http_archive(
     ],
 )
 
-http_archive(
-    name = "rules_python",
-    sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
-    strip_prefix = "rules_python-0.31.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
-)
-
-load("@rules_python//python:repositories.bzl", "py_repositories")
-
-py_repositories()
-
 # Note: boringssl is placed earlier as boringssl needs to be patched for mongodb
 http_archive(
     name = "boringssl",
@@ -118,10 +107,14 @@ http_archive(
 
 http_archive(
     name = "rules_python",
-    sha256 = "84aec9e21cc56fbc7f1335035a71c850d1b9b5cc6ff497306f84cced9a769841",
-    strip_prefix = "rules_python-0.23.1",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.23.1/rules_python-0.23.1.tar.gz",
+    sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
+    strip_prefix = "rules_python-0.31.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
 )
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
 
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,6 +27,17 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "rules_python",
+    sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
+    strip_prefix = "rules_python-0.31.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 # Note: boringssl is placed earlier as boringssl needs to be patched for mongodb
 http_archive(
     name = "boringssl",

--- a/third_party/pulsar.BUILD
+++ b/third_party/pulsar.BUILD
@@ -39,6 +39,9 @@ cc_library(
         "@platforms//cpu:x86_64": [
             "lib/checksum/crc32c_sse42.cc",
         ],
+        "@platforms//cpu:ppc": [
+            "lib/checksum/crc32c_sse42.cc",
+        ],
         "//conditions:default": [],
     }),
     hdrs = [


### PR DESCRIPTION
Hello Team, 
we have raised this PR to add power support. We have built tf-io using the following steps:

```
export BAZEL_OPTIMIZATION="--copt=-mcpu=power9 --copt=-mvsx --copt=-maltivec"
bazel build -s --verbose_failures $BAZEL_OPTIMIZATION --copt="-Wno-error=array-parameter=" --copt="-I/usr/include/tirpc" //tensorflow_io/... //tensorflow_io_gcs_filesystem/... --cpu=ppc
```
We have also updated the version of rules_python from 0.23.1 to 0.31.0 as it has a bug fix for ppc64le as mentioned in the issue below:
[Issue Link](https://github.com.mcas.ms/bazelbuild/rules_python/issues/1472)

Please let us know, your thoughts about this.
Thank you!
