### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,7 +14,7 @@ jobs:
       checks: write  # for reviewdog/action-suggester to report issues using checks
       contents: read  # for actions/checkout to fetch code
     name: Bazel Buildifier
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: |
@@ -26,7 +26,7 @@ jobs:
       checks: write  # for reviewdog/action-suggester to report issues using checks
       contents: read  # for actions/checkout to fetch code
     name: Python Black
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: |
@@ -38,7 +38,7 @@ jobs:
       checks: write  # for reviewdog/action-suggester to report issues using checks
       contents: read  # for actions/checkout to fetch code
     name: Clang Format
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: |
@@ -50,7 +50,7 @@ jobs:
       checks: write  # for reviewdog/action-suggester to report issues using checks
       contents: read  # for actions/checkout to fetch code
     name: Python Pyupgrade
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: |


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
