### PR TITLE
Remove aws-cpp-sdk-core empty glob

### DIFF
--- a/third_party/aws-sdk-cpp.BUILD
+++ b/third_party/aws-sdk-cpp.BUILD
@@ -16,7 +16,6 @@ cc_library(
         "aws-cpp-sdk-core/source/auth/*.cpp",  # AWS_AUTH_SOURCE
         "aws-cpp-sdk-core/source/client/*.cpp",  # AWS_CLIENT_SOURCE
         "aws-cpp-sdk-core/source/internal/*.cpp",  # AWS_INTERNAL_SOURCE
-        "aws-cpp-sdk-core/source/aws/model/*.cpp",  # AWS_MODEL_SOURCE
         "aws-cpp-sdk-core/source/http/*.cpp",  # HTTP_SOURCE
         "aws-cpp-sdk-core/source/http/standard/*.cpp",  # HTTP_STANDARD_SOURCE
         "aws-cpp-sdk-core/source/config/*.cpp",  # CONFIG_SOURCE


### PR DESCRIPTION
- Remove because this doesn't exist, `aws-cpp-sdk-core` doesn't have api models: https://github.com/aws/aws-sdk-cpp/tree/1.8.187/aws-cpp-sdk-core/source
- Fixes error for later bazel versions since empty globs are not allowed by default starting in bazel 8
```
ERROR: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_patrickpei/3e18eec45bfacda742ed17ecb758929d/external/aws-sdk-cpp/BUILD.bazel", line 12, column 16, in <toplevel>
		srcs = glob([
Error in glob: glob pattern 'aws-cpp-sdk-core/source/aws/model/*.cpp' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
```