### PR TITLE
Fix protobuf compilation error and CI error

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
-          sudo python3 -m pip install -U numpy pip black pyupgrade
+          sudo python3 -m pip install -U numpy black pyupgrade
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:lint -- bazel
       - uses: reviewdog/action-suggester@a3026c6020837c23b61a79d12db223a00df19e6a # v1.19.0
   black:
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
-          sudo python3 -m pip install -U numpy pip black pyupgrade
+          sudo python3 -m pip install -U numpy black pyupgrade
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:lint -- black
       - uses: reviewdog/action-suggester@a3026c6020837c23b61a79d12db223a00df19e6a # v1.19.0
   clang:
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
-          sudo python3 -m pip install -U numpy pip black pyupgrade
+          sudo python3 -m pip install -U numpy black pyupgrade
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:lint -- clang
       - uses: reviewdog/action-suggester@a3026c6020837c23b61a79d12db223a00df19e6a # v1.19.0
   pyupgrade:
@@ -54,6 +54,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
-          sudo python3 -m pip install -U numpy pip black pyupgrade
+          sudo python3 -m pip install -U numpy black pyupgrade
           bazel run -s --verbose_failures --experimental_repo_remote_exec //tools/lint:lint -- pyupgrade
       - uses: reviewdog/action-suggester@a3026c6020837c23b61a79d12db223a00df19e6a # v1.19.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,9 +71,7 @@ http_archive(
     name = "com_google_googleapis",
     build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
     patch_cmds = [
-        """sed -i.bak 's/OPTIONAL/OPIONAL/g' google/api/field_behavior.proto""",
-        """sed -i.bak 's/OPTIONAL/OPIONAL/g' google/pubsub/v1beta2/pubsub.proto""",
-        """sed -i.bak 's/OPTIONAL/OPIONAL/g' google/pubsub/v1/pubsub.proto""",
+        """find google/ -name "*.proto" -exec sed -i.bak 's/\\bOPTIONAL\\b/OPIONAL/g' {} +""",
     ],
     sha256 = "249d83abc5d50bf372c35c49d77f900bff022b2c21eb73aa8da1458b6ac401fc",
     strip_prefix = "googleapis-6b3fdcea8bc5398be4e7e9930c693f0ea09316a0",

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -26,11 +26,8 @@ genrule(
     name = "pyupgrade",
     srcs = [],
     outs = ["pyupgrade"],
-    cmd = "echo '$(location :pyupgrade_py) \"$$@\"' > $@",
+    cmd = "echo 'pyupgrade \"$$@\"' > $@",
     executable = True,
-    tools = [
-        ":pyupgrade_py",
-    ],
 )
 
 py_binary(
@@ -45,11 +42,8 @@ genrule(
     name = "black",
     srcs = [],
     outs = ["black"],
-    cmd = "echo '$(location :black_py) \"$$@\"' > $@",
+    cmd = "echo 'black \"$$@\"' > $@",
     executable = True,
-    tools = [
-        ":black_py",
-    ],
 )
 
 genrule(


### PR DESCRIPTION
## Fix protobuf compilation error

The build error was caused by a conflict between a workaround for Windows compilation and the `googleapis` dependency. To prevent compilation failures on Windows (where `OPTIONAL` can be defined as an empty string by the preprocessor), tensorflow_io had a patch in  WORKSPACE  that renamed `OPTIONAL` to `OPIONAL` in  google/api/field_behavior.proto  and a couple of other proto files in the `com_google_googleapis`  repository.

However, #2168  brought in google/cloud/bigquery/storage/v1/table.proto which also uses `OPTIONAL`. Since the rename patch was only applied to a few hardcoded files, table.proto still used `OPTIONAL` but field_behavior.proto define it as  `OPIONAL`, leading to the compilation error:

Enum type "google.api.FieldBehavior" has no value named "OPTIONAL" for option "google.api.field_behavior".

## Fix CI build error

The error occurred because the workflow was running on `ubuntu-24.04` using Python, and attempting to upgrade `pip` itself via `sudo python3 -m pip install -U ... pip ...`.

On Ubuntu/Debian, the system-installed pip is managed by apt and does not contain the `RECORD` file that  pip  expects when uninstalling/upgrading. This caused pip to fail with:

ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.