### PR TITLE
docs: document Backblaze B2 and S3-compatible storage for the s3:// filesystem

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -19,6 +19,29 @@ Integrations with many systems and cloud vendors include (but not limited to):
 - Microsoft Azure Storage
 - Alibaba Cloud OSS etc.
 
+## S3 and S3-compatible object storage
+
+The `s3://` file system, registered on `import tensorflow_io`, supports Amazon S3
+and S3-compatible object stores such as Backblaze B2, Cloudflare R2, and MinIO. It
+reads the standard AWS credential and region variables (`AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_REGION`); for a non-AWS provider, set `S3_ENDPOINT`
+to the provider endpoint. The same `s3://` paths are used for reading and writing
+through `tf.data`, `tf.io.gfile`, `tf.train.Checkpoint`, and `tf.saved_model`.
+
+```python
+import tensorflow as tf
+import tensorflow_io as tfio  # registers the s3:// file system
+
+dataset = tf.data.TFRecordDataset("s3://my-bucket/train/shard-00000.tfrecord")
+```
+
+```bash
+export AWS_ACCESS_KEY_ID=<access_key_id>
+export AWS_SECRET_ACCESS_KEY=<secret_access_key>
+export AWS_REGION=us-west-004
+export S3_ENDPOINT=https://s3.us-west-004.backblazeb2.com
+```
+
 ## Community
 
 * SIG IO [Google Group](https://groups.google.com/a/tensorflow.org/forum/#!forum/io) and mailing list: [io@tensorflow.org](io@tensorflow.org)


### PR DESCRIPTION
The `s3://` file system supports Amazon S3 and any S3-compatible object store, but `docs/overview.md` did not document it. This adds an "S3 and S3-compatible object storage" section to the overview.

1. Credentials and region: documents the standard AWS environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) that the `s3://` file system reads.

2. Non-AWS providers: documents pointing the client at a provider endpoint with `S3_ENDPOINT` (for example Backblaze B2, Cloudflare R2, MinIO).

3. Usage: notes that the same `s3://` paths work for reading and writing through `tf.data`, `tf.io.gfile`, `tf.train.Checkpoint`, and `tf.saved_model`.

The variables and path-style addressing match the current `tensorflow_io/core/filesystems/s3/s3_filesystem.cc` implementation. Docs only; no code changes.
